### PR TITLE
Authentifier.py : message d'erreur plus clair

### DIFF
--- a/ignf_gpf_sdk/auth/Authentifier.py
+++ b/ignf_gpf_sdk/auth/Authentifier.py
@@ -99,10 +99,18 @@ class Authentifier(metaclass=Singleton):
             if o_response.status_code == HTTPStatus.OK:
                 self.__last_token = Token(o_response.json())
             else:
-                raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code}")
+                # On tente de récupérer le message
+                try:
+                    s_message = o_response.json()["error_description"]
+                except Exception:
+                    s_message = "pas de raison indiqué"
+                raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code} ({s_message})")
 
         except Exception as e_error:
-            Config().om.warning("La récupération du jeton d'authentification a échoué...")
+            if isinstance(e_error, requests.exceptions.HTTPError):
+                Config().om.warning(e_error.args[0])
+            else:
+                Config().om.warning("La récupération du jeton d'authentification a échoué...")
             # Affiche la pile d'exécution
             Config().om.debug(traceback.format_exc())
             # Une erreur s'est produite : attend un peu et relance une nouvelle fois la fonction


### PR DESCRIPTION
Exemple de message d'erreur :

```
(env) user@machine:~/local/ignf-gpf-sdk$ python -m ignf_gpf_sdk --ini config.ini me
ALERTE - Code retour authentification KeyCloak = 401 (Invalid client or Invalid client credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid client or Invalid client credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid client or Invalid client credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid client or Invalid client credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid client or Invalid client credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid client or Invalid client credentials)
ERREUR - La récupération du jeton d'authentification a échoué après 5 tentatives
ERREUR - La récupération du jeton d'authentification a échoué après 5 tentatives
ERREUR FATALE - La récupération du jeton d'authentification a échoué après 5 tentatives
(env) user@machine:~/local/ignf-gpf-sdk$ python -m ignf_gpf_sdk --ini config.ini me
ALERTE - Code retour authentification KeyCloak = 401 (Invalid user credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid user credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid user credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid user credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid user credentials)
ALERTE - Code retour authentification KeyCloak = 401 (Invalid user credentials)
ERREUR - La récupération du jeton d'authentification a échoué après 5 tentatives
ERREUR - La récupération du jeton d'authentification a échoué après 5 tentatives
ERREUR FATALE - La récupération du jeton d'authentification a échoué après 5 tentatives
```

Au lieu de :

```
(env) user@machine:~/local/ignf-gpf-sdk$ python -m ignf_gpf_sdk --ini config.ini me
ALERTE - La récupération du jeton d'authentification a échoué...
ALERTE - La récupération du jeton d'authentification a échoué...
ALERTE - La récupération du jeton d'authentification a échoué...
ALERTE - La récupération du jeton d'authentification a échoué...
ALERTE - La récupération du jeton d'authentification a échoué...
ALERTE - La récupération du jeton d'authentification a échoué...
ERREUR - La récupération du jeton d'authentification a échoué après 5 tentatives
ERREUR - La récupération du jeton d'authentification a échoué après 5 tentatives
ERREUR FATALE - La récupération du jeton d'authentification a échoué après 5 tentatives
```