### PR TITLE
Sp18 upload ouvrir fermer

### DIFF
--- a/ignf_gpf_sdk/__main__.py
+++ b/ignf_gpf_sdk/__main__.py
@@ -124,9 +124,9 @@ class Main:
 
         # Parser pour workflow
         s_epilog_workflow = """Quatre types de lancement :
-        * liste des exemple de workflow disponibles : `` (aucun arguments)
+        * liste des exemples de workflow disponibles : `` (aucun arguments)
         * Récupération d'un workflow exemple : `--name NAME`
-        * Vérification de la structure du ficher workflow et affichage des étapes: `--file FILE --step STEP [--behavior BEHAVIOR]`
+        * Vérification de la structure du ficher workflow et affichage des étapes : `--file FILE`
         * Lancement l'une étape d'un workflow: `--file FILE --step STEP [--behavior BEHAVIOR]`
         """
         o_sub_parser = o_sub_parsers.add_parser("workflow", help="Workflow", epilog=s_epilog_workflow, formatter_class=argparse.RawTextHelpFormatter)

--- a/ignf_gpf_sdk/__main__.py
+++ b/ignf_gpf_sdk/__main__.py
@@ -105,7 +105,7 @@ class Main:
         s_epilog_upload = """Trois types de lancement :
         * création / mise à jour de livraison : `--file FILE [--behavior BEHAVIOR]`
         * détail d'une livraison, optionnel ouverture ou fermeture : `--id ID [--open | --close]`
-        * liste des livraison, optionnel filtre sur l'info et tags : `[--infos INFOS] [--tags TAGS]`
+        * liste des livraisons, optionnel filtre sur l'info et tags : `[--infos INFOS] [--tags TAGS]`
         """
         o_sub_parser = o_sub_parsers.add_parser("upload", help="Livraisons", epilog=s_epilog_upload, formatter_class=argparse.RawTextHelpFormatter)
         o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier descriptor dont on veut effectuer la livraison)")

--- a/ignf_gpf_sdk/__main__.py
+++ b/ignf_gpf_sdk/__main__.py
@@ -256,6 +256,17 @@ class Main:
 
     @staticmethod
     def __monitoring_upload(upload: Upload, message_ok: str, message_ko: str, callback: Optional[Callable[[str], None]] = None) -> bool:
+        """monitiring de l'upload et affichage état de sortie
+
+        Args:
+            upload (Upload): upload à monitorer
+            message_ok (str): message si les vérifications sont ok
+            message_ko (str): message si les vérifications sont en erreur
+            callback (Optional[Callable[[str], None]], optional): fonction de callback à exécuter avec le message de suivi.
+
+        Returns:
+            bool: True si toutes les vérifications sont ok, sinon False
+        """
         b_res = UploadAction.monitor_until_end(upload, callback)
         if b_res:
             Config().om.info(message_ok.format(upload=upload), green_colored=True)
@@ -310,13 +321,13 @@ class Main:
                 raise GpfSdkError(f"La livraison {o_upload} n'est pas dans un état permettant de fermer la livraison ({o_upload['status']}).")
 
             # affichage
-            print(o_upload.to_json(indent=3))
+            Config().om.info(o_upload.to_json(indent=3))
         else:
             d_infos_filter = StoreEntity.filter_dict_from_str(self.o_args.infos)
             d_tags_filter = StoreEntity.filter_dict_from_str(self.o_args.tags)
             l_uploads = Upload.api_list(infos_filter=d_infos_filter, tags_filter=d_tags_filter, datastore=self.datastore)
             for o_upload in l_uploads:
-                print(o_upload)
+                Config().om.info(f"{o_upload}")
 
     def dataset(self) -> None:
         """Liste les jeux de données d'exemple proposés et, si demandé par l'utilisateur, en export un."""

--- a/ignf_gpf_sdk/auth/Authentifier.py
+++ b/ignf_gpf_sdk/auth/Authentifier.py
@@ -99,7 +99,7 @@ class Authentifier(metaclass=Singleton):
             if o_response.status_code == HTTPStatus.OK:
                 self.__last_token = Token(o_response.json())
             else:
-                raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code}")
+                raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code}", response=o_response, request=o_response.request)
 
         except Exception as e_error:
             Config().om.warning("La récupération du jeton d'authentification a échoué...")


### PR DESCRIPTION
Ajout des options d'ouverture et de fermeture de l'upload quand on visualise l'upload via les lignes de commandes et amélioration du help

resolve #26

```txt
usage: ignf_gpf_sdk upload [-h] [--file FILE] [--behavior BEHAVIOR] [--id ID] [--open | --close] [--infos INFOS] [--tags TAGS]

optional arguments:
  -h, --help            show this help message and exit
  --file FILE, -f FILE  Chemin vers le fichier descriptor dont on veut effectuer la livraison)
  --behavior BEHAVIOR, -b BEHAVIOR
                        Action à effectuer si la livraison existe déjà (uniquement avec -f)
  --id ID               Affiche la livraison demandée
  --open                Rouvrir une livraison fermée (uniquement avec --id)
  --close               Fermer une livraison ouverte (uniquement avec --id)
  --infos INFOS, -i INFOS
                        Filter les livraisons selon les infos
  --tags TAGS, -t TAGS  Filter les livraisons selon les tags

Trois types de lancement :
        * création / mise à jour de livraison : `--file FILE [--behavior BEHAVIOR]`
        * détail d'une livraison, optionnel ouverture ou fermeture : `--id ID [--open | --close]`
        * liste des livraison, optionnel filtre sur l'info et tags : `[--infos INFOS] [--tags TAGS]`
```