### PR TITLE
offering status check

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -20,7 +20,7 @@ echo
 # Lancement des tests et vérification de la couverture
 coverage run -m unittest discover -b -p *TestCase.py
 code+=$?
-coverage report --fail-under=75
+coverage report -m --fail-under=75
 code+=$?
 coverage html
 

--- a/ignf_gpf_sdk/auth/Authentifier.py
+++ b/ignf_gpf_sdk/auth/Authentifier.py
@@ -99,7 +99,7 @@ class Authentifier(metaclass=Singleton):
             if o_response.status_code == HTTPStatus.OK:
                 self.__last_token = Token(o_response.json())
             else:
-                raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code}")
+                raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code}", response=o_response, request=None)
 
         except Exception as e_error:
             Config().om.warning("La récupération du jeton d'authentification a échoué...")

--- a/ignf_gpf_sdk/auth/Authentifier.py
+++ b/ignf_gpf_sdk/auth/Authentifier.py
@@ -99,7 +99,7 @@ class Authentifier(metaclass=Singleton):
             if o_response.status_code == HTTPStatus.OK:
                 self.__last_token = Token(o_response.json())
             else:
-                raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code}", response=o_response, request=None)
+                raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code}", response=o_response, request=o_response.request)
 
         except Exception as e_error:
             Config().om.warning("La récupération du jeton d'authentification a échoué...")

--- a/ignf_gpf_sdk/workflow/action/OfferingAction.py
+++ b/ignf_gpf_sdk/workflow/action/OfferingAction.py
@@ -1,4 +1,4 @@
-from time import sleep
+import time
 from typing import Any, Dict, Optional
 
 from ignf_gpf_sdk.store.Offering import Offering
@@ -48,13 +48,14 @@ class OfferingAction(ActionAbstract):
         Config().om.info("vérification du statut ...")
         while True:
             o_offering.api_update()
-            if o_offering["status"] == Offering.STATUS_PUBLISHED:
+            s_status = o_offering["status"]
+            if s_status == Offering.STATUS_PUBLISHED:
                 Config().om.info("Création d'une offre : terminé")
                 break
-            if o_offering["status"] == Offering.STATUS_UNSTABLE:
-                raise StepActionError("Création d'une offre : terminé en erreur")
+            if s_status == Offering.STATUS_UNSTABLE:
+                raise StepActionError("Création d'une offre : terminé en erreur.")
             # on fixe à 1 seconde, normalement quasiment instantané
-            sleep(1)
+            time.sleep(1)
 
     def __create_offering(self, datastore: Optional[str]) -> None:
         """Création de l'Offering sur l'API à partir des paramètres de définition de l'action.

--- a/ignf_gpf_sdk/workflow/action/OfferingAction.py
+++ b/ignf_gpf_sdk/workflow/action/OfferingAction.py
@@ -1,7 +1,9 @@
+from time import sleep
 from typing import Any, Dict, Optional
 
 from ignf_gpf_sdk.store.Offering import Offering
 from ignf_gpf_sdk.store.Configuration import Configuration
+from ignf_gpf_sdk.workflow.Errors import StepActionError
 from ignf_gpf_sdk.workflow.action.ActionAbstract import ActionAbstract
 from ignf_gpf_sdk.io.Config import Config
 from ignf_gpf_sdk.io.Errors import ConflictError
@@ -28,17 +30,31 @@ class OfferingAction(ActionAbstract):
         self.__create_offering(datastore)
         # Affichage
         o_offering = self.offering
-        if o_offering is not None:
-            # Récupération des liens
+
+        # si on n'a pas réussi a trouvé/créer l'offering on plante
+        if o_offering is None:
+            raise StepActionError("Erreur à la création de la livraison.")
+
+        # Récupération des liens
+        o_offering.api_update()
+        if len(o_offering["urls"]) > 0 and isinstance(o_offering["urls"][0], dict):
+            # si les url sont récupérées sous forme de dict on affiche l'url uniquement
+            s_urls = "\n   - ".join([d_url["url"] for d_url in o_offering["urls"]])
+        else:
+            # si les url sont récupérées sous forme de liste
+            s_urls = "\n   - ".join(o_offering["urls"])
+        Config().om.info(f"Offre créée : {self.__offering}\n   - {s_urls}", green_colored=True)
+        # vérification du status.
+        Config().om.info("vérification du statut ...")
+        while True:
             o_offering.api_update()
-            if len(o_offering["urls"]) > 0 and isinstance(o_offering["urls"][0], dict):
-                # si les url sont récupérées sous forme de dict on affiche l'url uniquement
-                s_urls = "\n   - ".join([d_url["url"] for d_url in o_offering["urls"]])
-            else:
-                # si les url sont récupérées sous forme de liste
-                s_urls = "\n   - ".join(o_offering["urls"])
-            Config().om.info(f"Offre créée : {self.__offering}\n   - {s_urls}", green_colored=True)
-        Config().om.info("Création d'une offre : terminé")
+            if o_offering["status"] == Offering.STATUS_PUBLISHED:
+                Config().om.info("Création d'une offre : terminé")
+                break
+            if o_offering["status"] == Offering.STATUS_UNSTABLE:
+                raise StepActionError("Création d'une offre : terminé en erreur")
+            # on fixe à 1 seconde, normalement quasiment instantané
+            sleep(1)
 
     def __create_offering(self, datastore: Optional[str]) -> None:
         """Création de l'Offering sur l'API à partir des paramètres de définition de l'action.
@@ -55,7 +71,7 @@ class OfferingAction(ActionAbstract):
             try:
                 self.__offering = Offering.api_create(self.definition_dict["body_parameters"], route_params=self.definition_dict["url_parameters"])
             except ConflictError as e:
-                Config().om.warning(f"Impossible de créer l'offre il y a un conflict : \n{e.message}")
+                raise StepActionError(f"Impossible de créer l'offre il y a un conflict : \n{e.message}") from e
 
     def find_configuration(self, datastore: Optional[str] = None) -> Optional[Configuration]:
         """Fonction permettant de récupérer la Configuration associée à l'Offering qui doit être crée par cette Action.

--- a/ignf_gpf_sdk/workflow/action/OfferingAction.py
+++ b/ignf_gpf_sdk/workflow/action/OfferingAction.py
@@ -31,9 +31,9 @@ class OfferingAction(ActionAbstract):
         # Affichage
         o_offering = self.offering
 
-        # si on n'a pas réussi a trouvé/créer l'offering on plante
+        # si on n'a pas réussi a trouver/créer l'offering on plante
         if o_offering is None:
-            raise StepActionError("Erreur à la création de la livraison.")
+            raise StepActionError("Erreur à la création de l'offre.")
 
         # Récupération des liens
         o_offering.api_update()

--- a/tests/workflow/action/OfferingActionTestCase.py
+++ b/tests/workflow/action/OfferingActionTestCase.py
@@ -59,7 +59,7 @@ class OfferingActionTestCase(GpfTestCase):
             with self.assertRaises(StepActionError) as o_err:
                 o_offering_action.run()
                 o_mock_create.assert_called_once()
-            self.assertEqual(o_err.exception.message, "Erreur à la création de la livraison.")
+            self.assertEqual(o_err.exception.message, "Erreur à la création de l'offre.")
 
         # problème lors de la création de l'offre
         o_offering_action = self.__get_offering_action()

--- a/tests/workflow/action/OfferingActionTestCase.py
+++ b/tests/workflow/action/OfferingActionTestCase.py
@@ -1,8 +1,11 @@
+import time
 from unittest.mock import patch, MagicMock
 from typing import Any
+from ignf_gpf_sdk.io.Errors import ConflictError
 
 from ignf_gpf_sdk.store.Offering import Offering
 from ignf_gpf_sdk.store.Configuration import Configuration
+from ignf_gpf_sdk.workflow.Errors import StepActionError
 from ignf_gpf_sdk.workflow.action.OfferingAction import OfferingAction
 
 from tests.GpfTestCase import GpfTestCase
@@ -30,7 +33,7 @@ class OfferingActionTestCase(GpfTestCase):
 
         # mock de offering
         o_mock_offering = MagicMock()
-        o_mock_offering.api_launch.return_value = None
+        o_mock_offering.__getitem__.return_value = Offering.STATUS_PUBLISHED
 
         # On mock find_offering et api_create
         with patch.object(o_offering_action, "find_offering", return_value=None) as o_mock_offering_action_list_offering:
@@ -44,6 +47,74 @@ class OfferingActionTestCase(GpfTestCase):
                 # test de l'appel à Offering.api_create
                 o_mock_offering_api_create.assert_called_once_with(self.d_action["body_parameters"], route_params=self.d_action["url_parameters"])
 
+                # api update appelé 2 fois
+                self.assertEqual(2, o_mock_offering.api_update.call_count)
+
+    def test_run_not_existing_not_create(self) -> None:
+        """test de run quand l'offre à créer n'existe pas et que l'offering n'est pas créer."""
+        # problème lors de la création de l'offre
+        o_offering_action = self.__get_offering_action()
+        with patch.object(OfferingAction, "_OfferingAction__create_offering", return_value=None) as o_mock_create:
+            # on lance l'exécution de run
+            with self.assertRaises(StepActionError) as o_err:
+                o_offering_action.run()
+                o_mock_create.assert_called_once()
+            self.assertEqual(o_err.exception.message, "Erreur à la création de la livraison.")
+
+        # problème lors de la création de l'offre
+        o_offering_action = self.__get_offering_action()
+        s_message = "message conflict"
+        with patch.object(o_offering_action, "find_offering", return_value=None) as o_mock_offering_action_list_offering:
+            e_error = ConflictError("url", "methode", None, None, s_message)
+            with patch.object(Offering, "api_create", side_effect=e_error) as o_mock_api_create:
+                # on lance l'exécution de run
+                with self.assertRaises(StepActionError) as o_err:
+                    o_offering_action.run()
+                o_mock_offering_action_list_offering.assert_called_once()
+                o_mock_api_create.assert_called_once()
+                self.assertEqual(o_err.exception.message, f"Impossible de créer l'offre il y a un conflict : \n{e_error.message}")
+
+    def test_run_not_existing_unstable(self) -> None:
+        """test de run quand l'offre à créer n'existe pas"""
+        # Instanciation de OfferingAction
+        o_offering_action = self.__get_offering_action()
+
+        o_mock_status = MagicMock(side_effect=[Offering.STATUS_PUBLISHING, Offering.STATUS_PUBLISHING, Offering.STATUS_UNSTABLE])
+
+        def offering_getitem(arg: str) -> Any:
+            """fonction pour mocker __getitem__ des offering
+            gestion des url + status
+
+            Args:
+                arg (Any): clef à affiché
+
+            Returns:
+                Any: valeur de retour
+            """
+            if arg == "urls":
+                return ["http://1", "http://2"]
+            if arg == "status":
+                return o_mock_status()
+            return "getitem"
+
+        # mock de offering
+        o_mock_offering = MagicMock()
+        o_mock_offering.__getitem__.side_effect = offering_getitem
+
+        # On mock find_offering et api_create
+        with patch.object(o_offering_action, "find_offering", return_value=None) as o_mock_offering_action_list_offering:
+            with patch.object(Offering, "api_create", return_value=o_mock_offering) as o_mock_offering_api_create:
+                with patch.object(time, "sleep", return_value=None) as o_mock_time:
+                    # on lance l'exécution de run
+                    with self.assertRaises(StepActionError) as o_err:
+                        o_offering_action.run()
+                    self.assertEqual(o_err.exception.message, "Création d'une offre : terminé en erreur.")
+
+                    o_mock_offering_action_list_offering.assert_called_once()
+                    o_mock_offering_api_create.assert_called_once_with(self.d_action["body_parameters"], route_params=self.d_action["url_parameters"])
+                    self.assertEqual(o_mock_offering.api_update.call_count, 4)
+                    o_mock_time.assert_any_call(1)
+
     # On mock find_offering et api_create
     def test_run_existing(self) -> None:
         """test de run quand l'offre à créer existe"""
@@ -52,7 +123,6 @@ class OfferingActionTestCase(GpfTestCase):
 
         # mock de offering
         o_mock_offering = MagicMock()
-        o_mock_offering.api_launch.return_value = None
 
         def side_effect_dict(arg: str) -> Any:
             """side_effect pour récupération des élément de offering, gestion du cas des url qui sont dans un dictionnaire
@@ -65,6 +135,8 @@ class OfferingActionTestCase(GpfTestCase):
             """
             if arg == "urls":
                 return [{"url": "http://1"}, {"url": "http://2"}]
+            if arg == "status":
+                return "PUBLISHED"
             return "getitem"
 
         def side_effect_text(arg: str) -> Any:
@@ -78,6 +150,8 @@ class OfferingActionTestCase(GpfTestCase):
             """
             if arg == "urls":
                 return ["http://1", "http://2"]
+            if arg == "status":
+                return "PUBLISHED"
             return "getitem"
 
         for f_effect in [side_effect_dict, side_effect_text]:


### PR DESCRIPTION
resolve #27 

Test du status de l'offering avant fin de l'action pour éviter une fin de programme sans erreur mais offering instable.
Statut offering :
* PUBLISHING, MODIFYING, UNPUBLISHING : on attend
* UNSTABLE : sortie en erreur : raise
* PUBLISHED : OK !

tests sur offering action pour la vérification du statut et partie oublier