### PR TITLE
Sp18 commentaire tag

### DIFF
--- a/ignf_gpf_sdk/__main__.py
+++ b/ignf_gpf_sdk/__main__.py
@@ -134,12 +134,12 @@ class Main:
         o_sub_parser.add_argument("--name", "-n", type=str, default=None, help="Nom du workflow à extraire")
         o_sub_parser.add_argument("--step", "-s", type=str, default=None, help="Étape du workflow à lancer")
         o_sub_parser.add_argument("--behavior", "-b", type=str, default=None, help="Action à effectuer si l'exécution de traitement existe déjà")
-        o_sub_parser.add_argument("--tag", "-t", type=str, nargs=2, action="append", metavar=("Clef", "Valeur"), default=None, help="tag à ajouter aux actions (plusieurs tags possible)")
+        o_sub_parser.add_argument("--tag", "-t", type=str, nargs=2, action="append", metavar=("Clef", "Valeur"), default=[], help="tag à ajouter aux actions (plusieurs tags possible)")
         o_sub_parser.add_argument(
             "--commentaire",
             "-c",
             type=str,
-            default=None,
+            default=[],
             action="append",
             metavar='"Le commentaire"',
             help="Commentaire à ajouter aux actions (plusieurs commentaires possible, mettre le commentaire entre guillemets)",
@@ -425,9 +425,7 @@ class Main:
                     except Exception:
                         PrintLogHelper.print("Logs indisponibles pour le moment...")
 
-                d_tags = {}
-                if self.o_args.tag:
-                    d_tags = {l_el[0]: l_el[1] for l_el in self.o_args.tag}
+                d_tags = {l_el[0]: l_el[1] for l_el in self.o_args.tag}
                 o_workflow.run_step(self.o_args.step, callback_run_step, behavior=s_behavior, datastore=self.datastore, comments=self.o_args.commentaire, tags=d_tags)
         else:
             l_children: List[str] = []

--- a/ignf_gpf_sdk/__main__.py
+++ b/ignf_gpf_sdk/__main__.py
@@ -134,9 +134,9 @@ class Main:
         o_sub_parser.add_argument("--name", "-n", type=str, default=None, help="Nom du workflow à extraire")
         o_sub_parser.add_argument("--step", "-s", type=str, default=None, help="Étape du workflow à lancer")
         o_sub_parser.add_argument("--behavior", "-b", type=str, default=None, help="Action à effectuer si l'exécution de traitement existe déjà")
-        o_sub_parser.add_argument("--tag", "-t", type=str, nargs=2, action="append", metavar=("Clef", "Valeur"), default=[], help="tag à ajouter aux actions (plusieurs tags possible)")
+        o_sub_parser.add_argument("--tag", "-t", type=str, nargs=2, action="append", metavar=("Clef", "Valeur"), default=[], help="Tag à ajouter aux actions (plusieurs tags possible)")
         o_sub_parser.add_argument(
-            "--commentaire",
+            "--comment",
             "-c",
             type=str,
             default=[],
@@ -426,7 +426,7 @@ class Main:
                         PrintLogHelper.print("Logs indisponibles pour le moment...")
 
                 d_tags = {l_el[0]: l_el[1] for l_el in self.o_args.tag}
-                o_workflow.run_step(self.o_args.step, callback_run_step, behavior=s_behavior, datastore=self.datastore, comments=self.o_args.commentaire, tags=d_tags)
+                o_workflow.run_step(self.o_args.step, callback_run_step, behavior=s_behavior, datastore=self.datastore, comments=self.o_args.comment, tags=d_tags)
         else:
             l_children: List[str] = []
             for p_child in p_root.iterdir():

--- a/ignf_gpf_sdk/__main__.py
+++ b/ignf_gpf_sdk/__main__.py
@@ -134,6 +134,16 @@ class Main:
         o_sub_parser.add_argument("--name", "-n", type=str, default=None, help="Nom du workflow à extraire")
         o_sub_parser.add_argument("--step", "-s", type=str, default=None, help="Étape du workflow à lancer")
         o_sub_parser.add_argument("--behavior", "-b", type=str, default=None, help="Action à effectuer si l'exécution de traitement existe déjà")
+        o_sub_parser.add_argument("--tag", "-t", type=str, nargs=2, action="append", metavar=("Clef", "Valeur"), default=None, help="tag à ajouter aux actions (plusieurs tags possible)")
+        o_sub_parser.add_argument(
+            "--commentaire",
+            "-c",
+            type=str,
+            default=None,
+            action="append",
+            metavar='"Le commentaire"',
+            help="Commentaire à ajouter aux actions (plusieurs commentaires possible, mettre le commentaire entre guillemets)",
+        )
 
         # Parser pour delete
         o_sub_parser = o_sub_parsers.add_parser("delete", help="Delete")
@@ -415,7 +425,10 @@ class Main:
                     except Exception:
                         PrintLogHelper.print("Logs indisponibles pour le moment...")
 
-                o_workflow.run_step(self.o_args.step, callback_run_step, behavior=s_behavior, datastore=self.datastore)
+                d_tags = {}
+                if self.o_args.tag:
+                    d_tags = {l_el[0]: l_el[1] for l_el in self.o_args.tag}
+                o_workflow.run_step(self.o_args.step, callback_run_step, behavior=s_behavior, datastore=self.datastore, comments=self.o_args.commentaire, tags=d_tags)
         else:
             l_children: List[str] = []
             for p_child in p_root.iterdir():

--- a/ignf_gpf_sdk/_conf/json_schemas/workflow.json
+++ b/ignf_gpf_sdk/_conf/json_schemas/workflow.json
@@ -68,6 +68,15 @@
                                 "items": {
                                     "type": "string"
                                 }
+                            },
+                            "comments": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "tags": {
+                                "type": "object"
                             }
                         }
                     }
@@ -76,6 +85,15 @@
         },
         "datastore": {
             "type" : "string"
+        },
+        "comments": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "tags": {
+            "type": "object"
         }
     },
     "required": [ "workflow" ],

--- a/ignf_gpf_sdk/helper/JsonHelper.py
+++ b/ignf_gpf_sdk/helper/JsonHelper.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import Any
-import jsonschema  # type: ignore
+import jsonschema
 from jsonc_parser.parser import JsoncParser  # type: ignore
 from jsonc_parser.errors import ParserError  # type: ignore
 

--- a/ignf_gpf_sdk/io/OutputManager.py
+++ b/ignf_gpf_sdk/io/OutputManager.py
@@ -41,7 +41,7 @@ class OutputManager(metaclass=Singleton):
         Args:
             message (str): message de type debug à journaliser
         """
-        self.__logger.debug("DEBUG - %s", message)
+        self.__logger.debug("%sDEBUG - %s%s", Color.GREY, message, Color.END)
 
     def info(self, message: str, green_colored: bool = False) -> None:
         """Ajout d'un message de type info

--- a/ignf_gpf_sdk/workflow/Workflow.py
+++ b/ignf_gpf_sdk/workflow/Workflow.py
@@ -130,7 +130,35 @@ class Workflow:
         """
         # Recherche de l'étape correspondante
         if step_name in self.__raw_definition_dict["workflow"]["steps"]:
-            return dict(self.__raw_definition_dict["workflow"]["steps"][step_name])
+            # récupération e l'étape :
+            d_step = dict(self.__raw_definition_dict["workflow"]["steps"][step_name])
+
+            # on récupère les commentaires commun au workflow et à l'étape
+            l_comments = []
+            if "comments" in self.__raw_definition_dict:
+                l_comments.extend(self.__raw_definition_dict["comments"])
+            if "comments" in d_step:
+                l_comments.extend(d_step["comments"])
+
+            d_tags = {}
+            # on récupère les tags commun au workflow et à l'étape
+            if "tags" in self.__raw_definition_dict:
+                d_tags.update(self.__raw_definition_dict["tags"])
+            if "tags" in d_step:
+                d_tags.update(d_step["tags"])
+
+            # Ajout des commentaire et des tags à chaque actions
+            for d_action in d_step["actions"]:
+                if "comments" in d_action:
+                    d_action["comments"] = [*l_comments, *d_action["comments"]]
+                else:
+                    d_action["comments"] = l_comments
+                if "tags" in d_action:
+                    d_action["tags"] = {**d_tags, **d_action["tags"]}
+                else:
+                    d_action["tags"] = d_tags
+
+            return d_step
 
         # Si on passe le if, c'est que l'étape n'existe pas dans la définition du workflow
         s_error_message = f"L'étape {step_name} n'est pas définie dans le workflow {self.__name}"

--- a/ignf_gpf_sdk/workflow/Workflow.py
+++ b/ignf_gpf_sdk/workflow/Workflow.py
@@ -50,7 +50,15 @@ class Workflow:
         """
         return self.__raw_definition_dict
 
-    def run_step(self, step_name: str, callback: Optional[Callable[[ProcessingExecution], None]] = None, behavior: Optional[str] = None, datastore: Optional[str] = None) -> List[StoreEntity]:
+    def run_step(
+        self,
+        step_name: str,
+        callback: Optional[Callable[[ProcessingExecution], None]] = None,
+        behavior: Optional[str] = None,
+        datastore: Optional[str] = None,
+        comments: List[str] = [],
+        tags: Dict[str, str] = {},
+    ) -> List[StoreEntity]:
         """Lance une étape du workflow à partir de son nom. Liste les entités créées par chaque action et le retourne.
 
         Args:
@@ -58,18 +66,20 @@ class Workflow:
             callback (Optional[Callable[[ProcessingExecution], None]], optional): callback de suivi si création d'une exécution de traitement.
             behavior (Optional[str]): comportement à adopter si une entité existe déjà sur l'entrepôt.
             datastore (Optional[str]): id du datastore à utiliser. Si None, le datastore sera le premier trouvé dans l'action puis dans workflow puis dans configuration.
+            comments (Optional[List[str]]): liste des commentaire à rajouté à toute les actions de l'étape (les cas de doublons sont géré).
+            tags (Optional[Dict[str, str]]): dictionnaire des tag à rajouté pour toutes les action de l'étape. Écrasé par ceux du workflow, de l'étape et de l'action si les clef sont les même.
 
         Raises:
             WorkflowError: levée si un problème apparaît pendant l'exécution du workflow
 
         Returns:
-            liste des entités créées
+            List[StoreEntity]: liste des entités créées
         """
         Config().om.info(f"Lancement de l'étape {step_name}...")
         # Création d'une liste pour stocker les entités créées
         l_store_entity: List[StoreEntity] = []
         # Récupération de l'étape dans la définition de workflow
-        d_step_definition = self.__get_step_definition(step_name)
+        d_step_definition = self.__get_step_definition(step_name, comments, tags)
         # initialisation des actions parentes
         o_parent_action: Optional[ActionAbstract] = None
         # Pour chaque action définie dans le workflow, instanciation de l'objet Action puis création sur l'entrepôt
@@ -118,15 +128,20 @@ class Workflow:
         # Retour de la liste
         return l_store_entity
 
-    def __get_step_definition(self, step_name: str) -> Dict[str, Any]:
+    def __get_step_definition(self, step_name: str, comments: List[str] = [], tags: Dict[str, str] = {}) -> Dict[str, Any]:
         """Renvoie le dictionnaire correspondant à une étape du workflow à partir de son nom.
         Lève une WorkflowError avec un message clair si l'étape n'est pas trouvée.
 
         Args:
-            step_name (string): nom de l'étape
+            step_name (str): nom de l'étape
+            comments (Optional[List[str]]): liste des commentaire à rajouté à toute les actions de l'étape (les cas de doublons sont géré).
+            tags (Optional[Dict[str, str]]): dictionnaire des tag à rajouté pour toutes les action de l'étape. Écrasé par ceux du workflow, de l'étape et de l'action si les clef sont les même.
 
         Raises:
             WorkflowExecutionError: est levée si l'étape n'existe pas dans le workflow
+
+        Returns:
+            Dict[str, Any]: dictionnaire de l'étape
         """
         # Recherche de l'étape correspondante
         if step_name in self.__raw_definition_dict["workflow"]["steps"]:
@@ -134,29 +149,27 @@ class Workflow:
             d_step = dict(self.__raw_definition_dict["workflow"]["steps"][step_name])
 
             # on récupère les commentaires commun au workflow et à l'étape
-            l_comments = []
             if "comments" in self.__raw_definition_dict:
-                l_comments.extend(self.__raw_definition_dict["comments"])
+                comments.extend(self.__raw_definition_dict["comments"])
             if "comments" in d_step:
-                l_comments.extend(d_step["comments"])
+                comments.extend(d_step["comments"])
 
-            d_tags = {}
             # on récupère les tags commun au workflow et à l'étape
             if "tags" in self.__raw_definition_dict:
-                d_tags.update(self.__raw_definition_dict["tags"])
+                tags.update(self.__raw_definition_dict["tags"])
             if "tags" in d_step:
-                d_tags.update(d_step["tags"])
+                tags.update(d_step["tags"])
 
             # Ajout des commentaire et des tags à chaque actions
             for d_action in d_step["actions"]:
                 if "comments" in d_action:
-                    d_action["comments"] = [*l_comments, *d_action["comments"]]
+                    d_action["comments"] = [*comments, *d_action["comments"]]
                 else:
-                    d_action["comments"] = l_comments
+                    d_action["comments"] = comments
                 if "tags" in d_action:
-                    d_action["tags"] = {**d_tags, **d_action["tags"]}
+                    d_action["tags"] = {**tags, **d_action["tags"]}
                 else:
-                    d_action["tags"] = d_tags
+                    d_action["tags"] = tags
 
             return d_step
 

--- a/ignf_gpf_sdk/workflow/Workflow.py
+++ b/ignf_gpf_sdk/workflow/Workflow.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-import jsonschema  # type: ignore
+import jsonschema
 from ignf_gpf_sdk.Errors import GpfSdkError
 from ignf_gpf_sdk.helper.JsonHelper import JsonHelper
 
@@ -305,25 +305,18 @@ class Workflow:
 
         # Maintenant que l'on a fait ça, on peut faire des vérifications pratiques
 
-        # 1. Est-ce que les parents de chaque étape existent ?
         # Pour chaque étape
         for s_step_name in self.steps:
+            # 1. Est-ce que les parents de chaque étape existent ?
             # Pour chaque parent de l'étape
             for s_parent_name in self.__get_step_definition(s_step_name)["parents"]:
                 # S'il n'est pas dans la liste
                 if not s_parent_name in self.steps:
                     l_errors.append(f"Le parent « {s_parent_name} » de l'étape « {s_step_name} » n'est pas défini dans le workflow.")
-
-        # 2. Est-ce que chaque action a au moins une étape ?
-        # Pour chaque étape
-        for s_step_name in self.steps:
-            # est-ce qu'il y a au moins une action ?
+            # 2. Est-ce que chaque action a au moins une étape ?
             if not self.__get_step_definition(s_step_name)["actions"]:
                 l_errors.append(f"L'étape « {s_step_name} » n'a aucune action de défini.")
-
-        # 3. Est-ce que chaque action de chaque étape est instantiable ?
-        # Pour chaque étape
-        for s_step_name in self.steps:
+            # 3. Est-ce que chaque action de chaque étape est instantiable ?
             # Pour chaque action de l'étape
             for i, d_action in enumerate(self.__get_step_definition(s_step_name)["actions"], 1):
                 # On tente de l'instancier

--- a/ignf_gpf_sdk/workflow/action/ProcessingExecutionAction.py
+++ b/ignf_gpf_sdk/workflow/action/ProcessingExecutionAction.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 from ignf_gpf_sdk.Errors import GpfSdkError
 from ignf_gpf_sdk.io.Config import Config
@@ -154,19 +154,24 @@ class ProcessingExecutionAction(ActionAbstract):
             # cas on a pas de commentaires : on ne fait rien
             return
         # on ajoute les commentaires
+        i_nb_ajout = 0
         if self.upload is not None:
-            Config().om.info(f"Livraison {self.upload['name']} : ajout des {len(self.definition_dict['comments'])} commentaires...")
-            for s_comment in self.definition_dict["comments"]:
-                self.upload.api_add_comment({"text": s_comment})
-            Config().om.info(f"Livraison {self.upload['name']} : les {len(self.definition_dict['comments'])} commentaires ont été ajoutés avec succès.")
+            o_data: Union[StoredData, Upload] = self.upload
+            s_type = "Livraison"
         elif self.stored_data is not None:
-            Config().om.info(f"Donnée stockée {self.stored_data['name']} : ajout des {len(self.definition_dict['comments'])} commentaires...")
-            for s_comment in self.definition_dict["comments"]:
-                self.stored_data.api_add_comment({"text": s_comment})
-            Config().om.info(f"Donnée stockée {self.stored_data['name']} : les {len(self.definition_dict['comments'])} commentaires ont été ajoutés avec succès.")
+            o_data = self.stored_data
+            s_type = "Donnée stockée"
         else:
             # on a pas de stored_data ni de upload
             raise StepActionError("aucune upload ou stored-data trouvé. Impossible d'ajouter les commentaires")
+
+        Config().om.info(f"{s_type} {o_data['name']} : ajout des {len(self.definition_dict['comments'])} commentaires...")
+        l_actual_comments = [d_comment["text"] for d_comment in o_data.api_list_comments() if d_comment]
+        for s_comment in self.definition_dict["comments"]:
+            if s_comment not in l_actual_comments:
+                o_data.api_add_comment({"text": s_comment})
+                i_nb_ajout += 1
+        Config().om.info(f"{s_type} {o_data['name']} : {i_nb_ajout} commentaires ont été ajoutés.")
 
     def __launch(self) -> None:
         """Lancement de la ProcessingExecution."""

--- a/ignf_gpf_sdk/workflow/action/ProcessingExecutionAction.py
+++ b/ignf_gpf_sdk/workflow/action/ProcessingExecutionAction.py
@@ -87,6 +87,7 @@ class ProcessingExecutionAction(ActionAbstract):
                     self.__processing_execution = None
                 # Comportement "on continue l'exécution"
                 elif self.__behavior == self.BEHAVIOR_CONTINUE:
+                    o_stored_data.api_update()
                     # on regarde si le résultat du traitement précédent est en échec
                     if o_stored_data["status"] == StoredData.STATUS_UNSTABLE:
                         raise GpfSdkError(f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_stored_data}. Impossible de lancer le traitement demandé.")

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,5 @@
 [mypy]
 [mypy-requests_toolbelt.*]
 ignore_missing_imports = True
+[mypy-jsonschema.*]
+ignore_missing_imports = True

--- a/tests/workflow/WorkflowTestCase.py
+++ b/tests/workflow/WorkflowTestCase.py
@@ -436,3 +436,24 @@ class WorkflowTestCase(GpfTestCase):
                 # Vérifications
                 self.assertEqual(o_action, o_action_get)
                 o_mock_get_actions.assert_called_once_with("stem_name")
+
+    def test_get_all_steps(self) -> None:
+        """test de get_all_steps"""
+        o_workflow = Workflow(
+            "workflow_name",
+            {
+                "workflow": {
+                    "steps": {
+                        "etape1": {"parents": [], "actions": []},
+                        "etape2A": {"parents": ["etape1"], "actions": []},
+                        "etape2B": {"parents": ["etape1"], "actions": []},
+                        "etape3": {"parents": ["etape2A", "etape2B"], "actions": []},
+                    },
+                },
+            },
+        )
+        l_steps = o_workflow.get_all_steps()
+        self.assertEqual(l_steps[0], "Etape « etape1 » [parent(s) : ]")
+        self.assertEqual(l_steps[1], "Etape « etape2A » [parent(s) : etape1]")
+        self.assertEqual(l_steps[2], "Etape « etape2B » [parent(s) : etape1]")
+        self.assertEqual(l_steps[3], "Etape « etape3 » [parent(s) : etape2A, etape2B]")

--- a/tests/workflow/WorkflowTestCase.py
+++ b/tests/workflow/WorkflowTestCase.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Optional, Type, List, Callable
+from typing import Any, Dict, Optional, Type, List
 from unittest.mock import PropertyMock, patch, MagicMock
 
 from ignf_gpf_sdk.Errors import GpfSdkError
@@ -33,57 +33,99 @@ class WorkflowTestCase(GpfTestCase):
         o_workflow = Workflow("nom", d_workflow)
         self.assertDictEqual(d_workflow, o_workflow.get_raw_dict())
 
+    def __list_action_run_step(self, s_etape: str, d_args_run_step: Dict[str, Any], d_workflow: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """création de la liste des actions pour run_run_step()
+
+        Args:
+            s_etape (str): non de l'étape
+            d_args_run_step (Dict[str, Any]): dictionnaire donné à run step
+            d_workflow (Dict[str, Any]): dictionnaire du workflow
+
+        Returns:
+            List[Dict[str, Any]]: liste des actions avec les commentaire et les tags de gérer
+        """
+        if s_etape not in d_workflow["workflow"]["steps"]:
+            return []
+        l_comments: List[str] = d_args_run_step["comments"]
+        d_tags: Dict[str, str] = d_args_run_step["tags"]
+        l_actions = []
+
+        # général workflow
+        if "comments" in d_workflow:
+            l_comments = [*l_comments, *d_workflow["comments"]]
+        if "tags" in d_workflow:
+            d_tags = {**d_tags, **d_workflow["tags"]}
+        # dans l'étape
+        if "comments" in d_workflow["workflow"]["steps"][s_etape]:
+            l_comments = [*l_comments, *d_workflow["workflow"]["steps"][s_etape]["comments"]]
+        if "tags" in d_workflow["workflow"]["steps"][s_etape]:
+            d_tags = {**d_tags, **d_workflow["workflow"]["steps"][s_etape]["tags"]}
+        for d_action in d_workflow["workflow"]["steps"][s_etape]["actions"]:
+            d_action = d_action.copy()
+            if "comments" in d_action:
+                d_action["comments"] = [*l_comments, *d_action["comments"]]
+            else:
+                d_action["comments"] = l_comments
+            if "tags" in d_action:
+                d_action["tags"] = {**d_tags, **d_action["tags"]}
+            else:
+                d_action["tags"] = d_tags
+            l_actions.append(d_action)
+        return l_actions
+
     def run_run_step(
         self,
-        s_etape: str,
-        s_datastore: Optional[str],
+        d_args_run_step: Dict[str, Any],
         d_workflow: Dict[str, Any],
         l_run_args: List[Any],
-        callback: Optional[Callable[[ProcessingExecution], None]] = None,
-        behavior: Optional[str] = None,
         monitoring_until_end: Optional[List[str]] = None,
         error_message: Optional[str] = None,
+        output_type: str = "configuration",
     ) -> None:
         """Fonction de lancement des tests pour run_step()
 
         Args:
-            s_etape (str): nom de l'étape du workflow à lancé
-            s_datastore (Optional[str]): nom du datastore à utiliser, si None datastore trouvé dans l'étape, le workflow ou None.
+            d_args_run_step Dict[str, Any]: dictionnaire donné à run step
             d_workflow (Dict[str, Any]): dictionnaire du workflow
             l_run_args (List[Any]): liste des argument passé en appel de action.run(). Un élément = un appel
-            callback (Optional[Callable[[ProcessingExecution], None]], optional): possible callback utilisé. Defaults to None.
-            behavior (Optional[str], optional): Action en cas de doublon, None action par défaut. Defaults to None.
             monitoring_until_end (Optional[List[str]], optional): si None, action sans monitoring, si défini : définition du side effect du mock de action.monitoring_until_end(). Defaults to None.
             error_message (Optional[str], optional): Message d'erreur compléter avec "action", si None : pas d'erreur attendu. Defaults to None.
+            output_type (str): type de l'entité de sortie : stored_data, configuration, offering ou upload
         """
+        s_etape = str(d_args_run_step["step_name"])
+
         # récupération de la liste d'action
-        l_actions = []
-        if s_etape in d_workflow["workflow"]["steps"]:
-            l_actions = d_workflow["workflow"]["steps"][s_etape]["actions"]
+        l_actions = self.__list_action_run_step(s_etape, d_args_run_step, d_workflow)
 
         # création du o_mock_action
+        if output_type == "upload":
+            o_mock_action = MagicMock(spec=ProcessingExecutionAction)
+            o_mock_action.stored_data = None
+            o_mock_action.upload = f"Entity_{output_type}"
+        elif output_type == "stored_data":
+            o_mock_action = MagicMock(spec=ProcessingExecutionAction)
+            o_mock_action.stored_data = f"Entity_{output_type}"
+            o_mock_action.upload = None
+        elif output_type == "offering":
+            o_mock_action = MagicMock(spec=OfferingAction)
+            o_mock_action.offering = f"Entity_{output_type}"
+        else:
+            o_mock_action = MagicMock(spec=ConfigurationAction)
+            o_mock_action.configuration = f"Entity_{output_type}"
+
         if monitoring_until_end:
             # cas avec monitoring
-            o_mock_action = MagicMock(spec=ProcessingExecutionAction)
             o_mock_action.monitoring_until_end.side_effect = monitoring_until_end
-            o_mock_action.stored_data = "entite"
-            o_mock_action.upload = None
 
-        else:
-            # cas sans monitoring
-            o_mock_action = MagicMock(spec=ConfigurationAction)
-            o_mock_action.configuration = "entite"
         ## config mock générale
         o_mock_action.resolve.return_value = None
         o_mock_action.run.return_value = None
+
         ## mock de la property definition_dict
-        if len(l_actions) == 1:
-            type(o_mock_action).definition_dict = PropertyMock(return_value=l_actions[0])
-        else:
-            d_effect = []
-            for d_el in l_actions:
-                d_effect += [d_el] * 2
-            type(o_mock_action).definition_dict = PropertyMock(side_effect=d_effect)
+        d_effect = []
+        for d_el in l_actions:
+            d_effect += [d_el] * 2
+        type(o_mock_action).definition_dict = PropertyMock(side_effect=d_effect)
 
         # initialisation de Workflow
         o_workflow = Workflow("nom", d_workflow)
@@ -93,18 +135,18 @@ class WorkflowTestCase(GpfTestCase):
             if error_message is not None:
                 # si on attend une erreur
                 with self.assertRaises(WorkflowError) as o_arc:
-                    o_workflow.run_step(s_etape, callback, behavior, s_datastore)
+                    o_workflow.run_step(**d_args_run_step)
                 self.assertEqual(o_arc.exception.message, error_message.format(action=o_mock_action))
             else:
                 # pas d'erreur attendu
-                l_entities = o_workflow.run_step(s_etape, callback, behavior, s_datastore)
-                self.assertListEqual(l_entities, ["entite"] * len(l_run_args))
+                l_entities = o_workflow.run_step(**d_args_run_step)
+                self.assertListEqual(l_entities, [f"Entity_{output_type}"] * len(l_run_args))
 
             # vérification des appels à generate
             self.assertEqual(o_mock_action_generate.call_count, len(l_run_args))
             o_parent = None
-            for i in range(len(l_run_args)):
-                o_mock_action_generate.assert_any_call(s_etape, l_actions[i], o_parent, behavior)
+            for d_action in l_actions:
+                o_mock_action_generate.assert_any_call(s_etape, d_action, o_parent, d_args_run_step["behavior"])
                 o_parent = o_mock_action
 
             # vérification des appels à résolve
@@ -118,7 +160,7 @@ class WorkflowTestCase(GpfTestCase):
             # si monitoring : vérification des appels à monitoring
             if monitoring_until_end:
                 self.assertEqual(o_mock_action.resolve.call_count, len(l_run_args))
-                o_mock_action.monitoring_until_end.assert_any_call(callback=callback)
+                o_mock_action.monitoring_until_end.assert_any_call(callback=d_args_run_step["callback"])
 
     def test_run_step(self) -> None:
         """test de run_step"""
@@ -152,48 +194,93 @@ class WorkflowTestCase(GpfTestCase):
                 }
             }
         }
-        d_workflow_2: Dict[str, Any] = {"datastore": "datastore_workflow", **d_workflow}
+        # ajout datastore
+        d_workflow_2: Dict[str, Any] = {"datastore": "datastore_workflow", **d_workflow.copy()}
+        # tag + commentaire au niveau workflow + étape
+        d_workflow_3: Dict[str, Any] = {
+            "workflow": {
+                "steps": {
+                    "mise-en-base": {
+                        "actions": [{"type": "action1"}],
+                        "comments": ["commentaire step 1", "commentaire step 2"],
+                        "tags": {"key_step": "val"},
+                    }
+                },
+            },
+            "comments": ["commentaire workflow 1", "commentaire workflow 2"],
+            "tags": {"key_workflow": "val"},
+        }
         s_datastore = "datastore_force"
 
+        d_args: Dict[str, Any] = {
+            "callback": None,
+            "behavior": None,
+            "datastore": None,
+            "comments": [],
+            "tags": {},
+        }
         # test simple sans s_datastore
-        self.run_run_step("mise-en-base", None, d_workflow, [None])
-        self.run_run_step("mise-en-base2", None, d_workflow, [None, None])
+        self.run_run_step({**d_args, "step_name": "mise-en-base"}, d_workflow, [None])
+        self.run_run_step({**d_args, "step_name": "mise-en-base2"}, d_workflow, [None, None])
 
         # datastore au niveau des étapes
-        self.run_run_step("mise-en-base3", None, d_workflow, ["datastore_3"])
-        self.run_run_step("mise-en-base4", None, d_workflow, ["datastore_4-1", None])
+        self.run_run_step({**d_args, "step_name": "mise-en-base3"}, d_workflow, ["datastore_3"])
+        self.run_run_step({**d_args, "step_name": "mise-en-base4"}, d_workflow, ["datastore_4-1", None])
 
         # datastore au niveau du workflow + étapes
-        self.run_run_step("mise-en-base", None, d_workflow_2, ["datastore_workflow"])
-        self.run_run_step("mise-en-base3", None, d_workflow_2, ["datastore_3"])
-        self.run_run_step("mise-en-base4", None, d_workflow_2, ["datastore_4-1", "datastore_workflow"])
+        self.run_run_step({**d_args, "step_name": "mise-en-base"}, d_workflow_2, ["datastore_workflow"])
+        self.run_run_step({**d_args, "step_name": "mise-en-base3"}, d_workflow_2, ["datastore_3"])
+        self.run_run_step({**d_args, "step_name": "mise-en-base4"}, d_workflow_2, ["datastore_4-1", "datastore_workflow"])
 
         # datastore au niveau du workflow + étape + forcé dans l'appel
-        self.run_run_step("mise-en-base", s_datastore, d_workflow, [s_datastore])
-        self.run_run_step("mise-en-base", s_datastore, d_workflow_2, [s_datastore])
-        self.run_run_step("mise-en-base3", s_datastore, d_workflow_2, [s_datastore])
-        self.run_run_step("mise-en-base4", s_datastore, d_workflow_2, [s_datastore, s_datastore])
+        self.run_run_step({**d_args, "step_name": "mise-en-base", "datastore": s_datastore}, d_workflow, [s_datastore])
+        self.run_run_step({**d_args, "step_name": "mise-en-base", "datastore": s_datastore}, d_workflow_2, [s_datastore])
+        self.run_run_step({**d_args, "step_name": "mise-en-base3", "datastore": s_datastore}, d_workflow_2, [s_datastore])
+        self.run_run_step({**d_args, "step_name": "mise-en-base4", "datastore": s_datastore}, d_workflow_2, [s_datastore, s_datastore])
+        self.run_run_step({**d_args, "step_name": "mise-en-base4", "datastore": s_datastore}, d_workflow_2, [s_datastore, s_datastore], output_type="offering")
+
+        # test pour les commentaires + tags
+        self.run_run_step({**d_args, "step_name": "mise-en-base", "datastore": s_datastore}, d_workflow_3, [s_datastore])
+        self.run_run_step({**d_args, "step_name": "mise-en-base", "datastore": s_datastore, "comments": ["commentaire 1", "commentaire 2"], "tags": {"workflow": "val"}}, d_workflow_3, [s_datastore])
 
         # étape qui n'existe pas
-        self.run_run_step("existe_pas", None, d_workflow, [], error_message="L'étape existe_pas n'est pas définie dans le workflow nom")
+        self.run_run_step({**d_args, "step_name": "existe_pas"}, d_workflow, [], error_message="L'étape existe_pas n'est pas définie dans le workflow nom")
+
         # test avec monitoring
-        self.run_run_step("mise-en-base", None, d_workflow, [None], monitoring_until_end=["SUCCESS"])
-        self.run_run_step("mise-en-base", None, d_workflow, [None], monitoring_until_end=["FAILURE"], error_message="L'exécution de traitement {action} ne s'est pas bien passée. Sortie FAILURE.")
-        self.run_run_step("mise-en-base", None, d_workflow, [None], monitoring_until_end=["ABORTED"], error_message="L'exécution de traitement {action} ne s'est pas bien passée. Sortie ABORTED.")
+        self.run_run_step({**d_args, "step_name": "mise-en-base"}, d_workflow, [None], monitoring_until_end=["SUCCESS"], output_type="upload")
+        self.run_run_step({**d_args, "step_name": "mise-en-base"}, d_workflow, [None], monitoring_until_end=["SUCCESS"], output_type="stored_data")
+        self.run_run_step({**d_args, "step_name": "mise-en-base4"}, d_workflow_2, ["datastore_4-1", "datastore_workflow"], monitoring_until_end=["SUCCESS", "SUCCESS"], output_type="stored_data")
         self.run_run_step(
-            "mise-en-base4",
-            None,
+            {**d_args, "step_name": "mise-en-base"},
+            d_workflow,
+            [None],
+            monitoring_until_end=["FAILURE"],
+            error_message="L'exécution de traitement {action} ne s'est pas bien passée. Sortie FAILURE.",
+            output_type="stored_data",
+        )
+        self.run_run_step(
+            {**d_args, "step_name": "mise-en-base"},
+            d_workflow,
+            [None],
+            monitoring_until_end=["ABORTED"],
+            error_message="L'exécution de traitement {action} ne s'est pas bien passée. Sortie ABORTED.",
+            output_type="stored_data",
+        )
+        self.run_run_step(
+            {**d_args, "step_name": "mise-en-base4"},
             d_workflow_2,
             ["datastore_4-1", "datastore_workflow"],
             monitoring_until_end=["SUCCESS", "ABORTED"],
             error_message="L'exécution de traitement {action} ne s'est pas bien passée. Sortie ABORTED.",
+            output_type="stored_data",
         )
-        self.run_run_step("mise-en-base4", None, d_workflow_2, ["datastore_4-1", "datastore_workflow"], monitoring_until_end=["SUCCESS", "SUCCESS"])
         # callbable
-        self.run_run_step("mise-en-base", None, d_workflow, [None], callback, None, ["SUCCESS"])
+        self.run_run_step({**d_args, "step_name": "mise-en-base", "callback": callback}, d_workflow, [None], monitoring_until_end=["SUCCESS", "SUCCESS"], output_type="stored_data")
         # behavior
-        self.run_run_step("mise-en-base", None, d_workflow, [None], None, "DELETE")
-        self.run_run_step("mise-en-base", None, d_workflow, [None], callback, "DELETE", ["SUCCESS"])
+        self.run_run_step({**d_args, "step_name": "mise-en-base", "behavior": "DELETE"}, d_workflow, [None])
+        self.run_run_step(
+            {**d_args, "step_name": "mise-en-base", "callback": callback, "behavior": "DELETE"}, d_workflow, [None], monitoring_until_end=["SUCCESS", "SUCCESS"], output_type="stored_data"
+        )
 
     def run_generation(self, expected_type: Type[ActionAbstract], name: str, dico_def: Dict[str, Any], parent: Optional[ActionAbstract] = None, behavior: Optional[str] = None) -> None:
         """lancement de la commande de génération


### PR DESCRIPTION
Développement suite à la demande #13 

Possibilité de définir des commentaires et des tags dans la ligne de commande, dans le workflow pour pour toutes les étapes et dans le workflow pour toute l'étape.
Et tests de Workflow pour une couverture à 100%

help commande :
```txt
usage: ignf_gpf_sdk workflow [-h] [--file FILE] [--name NAME] [--step STEP] [--behavior BEHAVIOR] [--tag Clef Valeur] [--commentaire "Le commentaire"]

optional arguments:
  -h, --help            show this help message and exit
  --file FILE, -f FILE  Chemin du fichier à utiliser OU chemin où extraire le dataset
  --name NAME, -n NAME  Nom du workflow à extraire
  --step STEP, -s STEP  Étape du workflow à lancer
  --behavior BEHAVIOR, -b BEHAVIOR
                        Action à effectuer si l'exécution de traitement existe déjà
  --tag Clef Valeur, -t Clef Valeur
                        tag à ajouter aux actions (plusieurs tags possible)
  --commentaire "Le commentaire", -c "Le commentaire"
                        Commentaire à ajouter aux actions (plusieurs commentaires possible, mettre le commentaire entre guillemets)

Quatre types de lancement :
        * liste des exemples de workflow disponibles : `` (aucun arguments)
        * Récupération d'un workflow exemple : `--name NAME`
        * Vérification de la structure du ficher workflow et affichage des étapes : `--file FILE`
        * Lancement l'une étape d'un workflow: `--file FILE --step STEP [--behavior BEHAVIOR]`
```