### PR TITLE
Config-offerings utilisation behaviors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
         "rcfile",
         "recupere",
         "requêtage",
+        "requêter",
         "setuptools",
         "sharings",
         "sidc",

--- a/ignf_gpf_sdk/__main__.py
+++ b/ignf_gpf_sdk/__main__.py
@@ -111,13 +111,13 @@ class Main:
         """
         o_sub_parser = o_sub_parsers.add_parser("upload", help="Livraisons", epilog=s_epilog_upload, formatter_class=argparse.RawTextHelpFormatter)
         o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier descriptor dont on veut effectuer la livraison)")
-        o_sub_parser.add_argument("--behavior", "-b", type=str, default=None, help="Action à effectuer si la livraison existe déjà (uniquement avec -f)")
+        o_sub_parser.add_argument("--behavior", "-b", choices=UploadAction.BEHAVIORS, default=None, help="Action à effectuer si la livraison existe déjà (uniquement avec -f)")
         o_sub_parser.add_argument("--id", type=str, default=None, help="Affiche la livraison demandée")
         o_exclusive = o_sub_parser.add_mutually_exclusive_group()
         o_exclusive.add_argument("--open", action="store_true", default=False, help="Rouvrir une livraison fermée (uniquement avec --id)")
         o_exclusive.add_argument("--close", action="store_true", default=False, help="Fermer une livraison ouverte (uniquement avec --id)")
-        o_sub_parser.add_argument("--infos", "-i", type=str, default=None, help="Filter les livraisons selon les infos")
-        o_sub_parser.add_argument("--tags", "-t", type=str, default=None, help="Filter les livraisons selon les tags")
+        o_sub_parser.add_argument("--infos", "-i", type=str, default=None, help="Filtrer les livraisons selon les infos")
+        o_sub_parser.add_argument("--tags", "-t", type=str, default=None, help="Filtrer les livraisons selon les tags")
 
         # Parser pour dataset
         o_sub_parser = o_sub_parsers.add_parser("dataset", help="Jeux de données")

--- a/ignf_gpf_sdk/_conf/default.ini
+++ b/ignf_gpf_sdk/_conf/default.ini
@@ -196,6 +196,10 @@ behavior_if_exists=STOP
 # d'une même ligne sont séparées par un point-virgule
 uniqueness_constraint_infos=name;layer_name
 uniqueness_constraint_tags=
+behavior_if_exists=CONTINUE
+
+[offering]
+behavior_if_exists=CONTINUE
 
 [static]
 create_file_key=file

--- a/ignf_gpf_sdk/store/Configuration.py
+++ b/ignf_gpf_sdk/store/Configuration.py
@@ -48,11 +48,11 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
         return Offering.api_create(data_offering, route_params={self._entity_name: self.id})
 
     def delete_cascade(self, before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
-        """suppression en cascade des offres : uniquement les offres
+        """Fonction de suppression de la Configuration en supprimant en cascade les offres liées (et uniquement les offres, pas les données stockées).
 
         Args:
-            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancé avant la suppression entrée liste des entités à supprimé,
-                sortie liste définitive des entités à supprimer. Defaults to None.
+            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancer avant la suppression (entrée : liste des entités à supprimer,
+                sortie : liste définitive des entités à supprimer). Defaults to None.
         """
         # suppression d'une configuration : offres puis configuration
         l_entities: List[StoreEntity] = []

--- a/ignf_gpf_sdk/store/Configuration.py
+++ b/ignf_gpf_sdk/store/Configuration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from ignf_gpf_sdk.store.Offering import Offering
 from ignf_gpf_sdk.store.StoreEntity import StoreEntity
@@ -46,3 +46,17 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
             Offering: représentation Python de l'Offering créée
         """
         return Offering.api_create(data_offering, route_params={self._entity_name: self.id})
+
+    def delete_cascade(self, before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
+        """suppression en cascade des offres : uniquement les offres
+
+        Args:
+            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancé avant la suppression entrée liste des entités à supprimé,
+                sortie liste définitive des entités à supprimer. Defaults to None.
+        """
+        # suppression d'une configuration : offres puis configuration
+        l_entities: List[StoreEntity] = []
+        l_offering = self.api_list_offerings()
+        l_entities += l_offering
+        l_entities.append(self)
+        self.delete_liste_entities(l_entities, before_delete)

--- a/ignf_gpf_sdk/store/StoreEntity.py
+++ b/ignf_gpf_sdk/store/StoreEntity.py
@@ -244,7 +244,7 @@ class StoreEntity(ABC):
         return d_filter
 
     def delete_cascade(self, before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
-        """suppression en cascade des offres : uniquement les offres
+        """Suppression en cascade d'une stored_data en supprimant en cascade les offering et les configurations liées.
 
         Args:
             before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancé avant la suppression entrée liste des entités à supprimé,

--- a/ignf_gpf_sdk/store/StoreEntity.py
+++ b/ignf_gpf_sdk/store/StoreEntity.py
@@ -255,12 +255,12 @@ class StoreEntity(ABC):
 
     @staticmethod
     def delete_liste_entities(l_entities: List["StoreEntity"], before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
-        """suppression d'une liste d’entités. Exécution de `before_delete(l_entities)` avant la suppression, before_delete return la nouvelle liste des éléments à supprimé.
+        """Suppression d'une liste d’entités. Exécution de `before_delete(l_entities)` avant la suppression, before_delete retourne la nouvelle liste des éléments à supprimer.
 
         Args:
-            l_entities (List[StoreEntity]]): liste des entités à supprimé
-            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancé avant la suppression entrée liste des entités à supprimé,
-                sortie liste définitive des entités à supprimer. Defaults to None.
+            l_entities (List[StoreEntity]]): liste des entités à supprimer
+            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancer avant la suppression (entrée : liste des entités à supprimer,
+                sortie : liste définitive des entités à supprimer). Defaults to None.
         """
         if before_delete is not None:
             # callback avant suppression
@@ -273,7 +273,7 @@ class StoreEntity(ABC):
         for o_entity in l_entities:
             o_entity.api_delete()
             time.sleep(1)
-        Config().om.info("Suppression effectué.", green_colored=True)
+        Config().om.info("Suppression effectuée.", green_colored=True)
 
     ##############################################################
     # Récupération du JSON

--- a/ignf_gpf_sdk/store/StoreEntity.py
+++ b/ignf_gpf_sdk/store/StoreEntity.py
@@ -244,7 +244,7 @@ class StoreEntity(ABC):
         return d_filter
 
     def delete_cascade(self, before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
-        """Suppression en cascade d'une stored_data en supprimant en cascade les offering et les configurations liées.
+        """Suppression en cascade d'une entité en supprimant les entités liées (qui vont dépendre du type de l'entité, donc cf. les classes filles).
 
         Args:
             before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancé avant la suppression entrée liste des entités à supprimé,

--- a/ignf_gpf_sdk/store/StoreEntity.py
+++ b/ignf_gpf_sdk/store/StoreEntity.py
@@ -247,8 +247,8 @@ class StoreEntity(ABC):
         """Suppression en cascade d'une entité en supprimant les entités liées (qui vont dépendre du type de l'entité, donc cf. les classes filles).
 
         Args:
-            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancé avant la suppression entrée liste des entités à supprimé,
-                sortie liste définitive des entités à supprimer. Defaults to None.
+            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancer avant la suppression (entrée : liste des entités à supprimer,
+                sortie : liste définitive des entités à supprimer). Defaults to None.
         """
         # suppression d'une configuration : offres puis configuration
         self.delete_liste_entities([self], before_delete)

--- a/ignf_gpf_sdk/store/StoredData.py
+++ b/ignf_gpf_sdk/store/StoredData.py
@@ -29,7 +29,7 @@ class StoredData(TagInterface, CommentInterface, SharingInterface, EventInterfac
             before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancer avant la suppression (entrée : liste des entités à supprimer,
                 sortie : liste définitive des entités à supprimer). Defaults to None.
         """
-        # suppression d'une stored_data : uniquement l'upload, configuration et stored_data
+        # suppression d'une stored_data : offering et configuration liées puis la stored_data
         l_entities: List[StoreEntity] = []
 
         # liste des configurations

--- a/ignf_gpf_sdk/store/StoredData.py
+++ b/ignf_gpf_sdk/store/StoredData.py
@@ -23,11 +23,11 @@ class StoredData(TagInterface, CommentInterface, SharingInterface, EventInterfac
     STATUS_UNSTABLE = "UNSTABLE"
 
     def delete_cascade(self, before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
-        """suppression en cascade des offres : uniquement les offres
+        """Suppression de la donnée stockée avec suppression en cascade des configuration liées et des offres liées à chaque configuration.
 
         Args:
-            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancé avant la suppression entrée liste des entités à supprimé,
-                sortie liste définitive des entités à supprimer. Defaults to None.
+            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancer avant la suppression (entrée : liste des entités à supprimer,
+                sortie : liste définitive des entités à supprimer). Defaults to None.
         """
         # suppression d'une stored_data : uniquement l'upload, configuration et stored_data
         l_entities: List[StoreEntity] = []

--- a/ignf_gpf_sdk/store/__init__.py
+++ b/ignf_gpf_sdk/store/__init__.py
@@ -1,1 +1,34 @@
 """Classes représentant les entités de l'Entrepôt."""
+
+from ignf_gpf_sdk.store.Annexe import Annexe
+from ignf_gpf_sdk.store.Check import Check
+from ignf_gpf_sdk.store.CheckExecution import CheckExecution
+from ignf_gpf_sdk.store.Configuration import Configuration
+from ignf_gpf_sdk.store.Datastore import Datastore
+from ignf_gpf_sdk.store.Endpoint import Endpoint
+from ignf_gpf_sdk.store.Offering import Offering
+from ignf_gpf_sdk.store.Processing import Processing
+from ignf_gpf_sdk.store.ProcessingExecution import ProcessingExecution
+from ignf_gpf_sdk.store.Static import Static
+from ignf_gpf_sdk.store.StoredData import StoredData
+from ignf_gpf_sdk.store.Tms import Tms
+from ignf_gpf_sdk.store.Upload import Upload
+from ignf_gpf_sdk.store.User import User
+
+# lien entre le nom/type texte et la classe
+TYPE__ENTITY = {
+    Annexe.entity_name(): Annexe,
+    Check.entity_name(): Check,
+    CheckExecution.entity_name(): CheckExecution,
+    Configuration.entity_name(): Configuration,
+    Datastore.entity_name(): Datastore,
+    Endpoint.entity_name(): Endpoint,
+    Offering.entity_name(): Offering,
+    Processing.entity_name(): Processing,
+    ProcessingExecution.entity_name(): ProcessingExecution,
+    Static.entity_name(): Static,
+    StoredData.entity_name(): StoredData,
+    Tms.entity_name(): Tms,
+    Upload.entity_name(): Upload,
+    User.entity_name(): User,
+}

--- a/ignf_gpf_sdk/workflow/action/ActionAbstract.py
+++ b/ignf_gpf_sdk/workflow/action/ActionAbstract.py
@@ -22,6 +22,11 @@ class ActionAbstract(ABC):
         __parent_action (Optional["Action"]): action parente
     """
 
+    # comportements possibles (que peut écrire l'utilisateur)
+    BEHAVIOR_STOP = "STOP"
+    BEHAVIOR_DELETE = "DELETE"
+    BEHAVIOR_CONTINUE = "CONTINUE"
+
     def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None) -> None:
         super().__init__()
         self.__workflow_context: str = workflow_context

--- a/ignf_gpf_sdk/workflow/action/ConfigurationAction.py
+++ b/ignf_gpf_sdk/workflow/action/ConfigurationAction.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Optional
+from ignf_gpf_sdk.Errors import GpfSdkError
 from ignf_gpf_sdk.store.Configuration import Configuration
+from ignf_gpf_sdk.workflow.Errors import StepActionError
 from ignf_gpf_sdk.workflow.action.ActionAbstract import ActionAbstract
 from ignf_gpf_sdk.io.Config import Config
 from ignf_gpf_sdk.io.Errors import ConflictError
@@ -15,10 +17,12 @@ class ConfigurationAction(ActionAbstract):
         __configuration (Optional[Configuration]): représentation Python de la configuration créée
     """
 
-    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None) -> None:
+    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None) -> None:
         super().__init__(workflow_context, definition_dict, parent_action)
         # Autres attributs
         self.__configuration: Optional[Configuration] = None
+        # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut CONTINUE
+        self.__behavior: str = behavior if behavior is not None else Config().get_str("configuration", "behavior_if_exists")
 
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Création et complétion d'une configuration...")
@@ -41,16 +45,30 @@ class ConfigurationAction(ActionAbstract):
         # On regarde si on trouve quelque chose avec la fonction find
         o_configuration = self.find_configuration(datastore)
         if o_configuration is not None:
-            self.__configuration = o_configuration
-            Config().om.info(f"Configuration {self.__configuration['name']} déjà existante, complétion uniquement.")
-        else:
-            # Création en gérant une erreur de type ConflictError (si la Configuration existe déjà selon les critères de l'API)
-            try:
-                Config().om.info("Création de la configuration...")
-                self.__configuration = Configuration.api_create(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
-                Config().om.info(f"Configuration {self.__configuration['name']} créée avec succès.")
-            except ConflictError:
-                Config().om.warning("La configuration que vous tentez de créer existe déjà !")
+            if self.__behavior == self.BEHAVIOR_STOP:
+                raise GpfSdkError(f"Impossible de créer la configuration, une configuration équivalente {o_configuration} existe déjà.")
+            if self.__behavior == self.BEHAVIOR_DELETE:
+                Config().om.warning(f"Une donnée configuration équivalente à {o_configuration} va être supprimée puis recréée.")
+                # Suppression de la donnée stockée
+                o_configuration.api_delete()
+                # on force à None pour que la création soit faite
+                self.__configuration = None
+            # Comportement "on continue l'exécution"
+            elif self.__behavior == self.BEHAVIOR_CONTINUE:
+                Config().om.info(f"Configuration {o_configuration} déjà existante, complétion uniquement.")
+                self.__configuration = o_configuration
+                return
+            else:
+                raise GpfSdkError(
+                    f"Le comportement {self.__behavior} n'est pas reconnu ({self.BEHAVIOR_STOP}|{self.BEHAVIOR_DELETE}|{self.BEHAVIOR_CONTINUE}), l'exécution de traitement n'est pas possible."
+                )
+        # Création en gérant une erreur de type ConflictError (si la Configuration existe déjà selon les critères de l'API)
+        try:
+            Config().om.info("Création de la configuration...")
+            self.__configuration = Configuration.api_create(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
+            Config().om.info(f"Configuration {self.__configuration['name']} créée avec succès.")
+        except ConflictError as e:
+            raise StepActionError(f"Impossible de créer la configuration il y a un conflict : \n{e.message}") from e
 
     def __add_tags(self) -> None:
         """Ajout des tags sur la Configuration."""

--- a/ignf_gpf_sdk/workflow/action/ProcessingExecutionAction.py
+++ b/ignf_gpf_sdk/workflow/action/ProcessingExecutionAction.py
@@ -22,11 +22,6 @@ class ProcessingExecutionAction(ActionAbstract):
         __StoredData (Optional[StoredData]): représentation Python de la données stockée en sortie (null si livraison en sortie)
     """
 
-    # comportements possibles (que peut écrire l'utilisateur)
-    BEHAVIOR_STOP = "STOP"
-    BEHAVIOR_DELETE = "DELETE"
-    BEHAVIOR_CONTINUE = "CONTINUE"
-
     # status possibles d'une ProcessingExecution (status délivrés par l'api)
     # STATUS_CREATED
     # STATUS_ABORTED STATUS_SUCCESS STATUS_FAILURE
@@ -101,6 +96,7 @@ class ProcessingExecutionAction(ActionAbstract):
                         raise GpfSdkError(f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_stored_data}")
                     # arbitrairement, on prend le premier de la liste
                     self.__processing_execution = l_proc_exec[0]
+                    Config().om.info(f"La donnée stocké en sortie {o_stored_data} déjà existante, on reprend le traitement associé : {self.__processing_execution}.")
                     return
                 # Comportement non reconnu
                 else:

--- a/ignf_gpf_sdk/workflow/action/UploadAction.py
+++ b/ignf_gpf_sdk/workflow/action/UploadAction.py
@@ -21,6 +21,7 @@ class UploadAction:
     BEHAVIOR_STOP = "STOP"
     BEHAVIOR_DELETE = "DELETE"
     BEHAVIOR_CONTINUE = "CONTINUE"
+    BEHAVIORS = [BEHAVIOR_STOP, BEHAVIOR_CONTINUE, BEHAVIOR_DELETE]
 
     def __init__(self, dataset: Dataset, behavior: Optional[str] = None) -> None:
         self.__dataset: Dataset = dataset

--- a/tests/store/StoreEntityTestCase.py
+++ b/tests/store/StoreEntityTestCase.py
@@ -453,23 +453,14 @@ class StoreEntityTestCase(GpfTestCase):
         self.assertEqual(2, o_mock_sleep.call_count)
         reset_mock()
 
-        # suppression avec before_delete, avec annulation V1
-        o_mock_function = MagicMock()
-        o_mock_function.before_delete_function.return_value = []
-        StoreEntity.delete_liste_entities(l_entity, o_mock_function.before_delete_function)
-        o_mock_function.before_delete_function.assert_called_once_with(l_entity)
-        o_mock_1.api_delete.assert_not_called()
-        o_mock_2.api_delete.assert_not_called()
-        o_mock_3.api_delete.assert_not_called()
-        self.assertEqual(0, o_mock_sleep.call_count)
-        reset_mock()
-
-        # suppression avec before_delete, avec annulation V2
-        o_mock_function = MagicMock()
-        o_mock_function.before_delete_function.return_value = None
-        StoreEntity.delete_liste_entities(l_entity, o_mock_function.before_delete_function)
-        o_mock_function.before_delete_function.assert_called_once_with(l_entity)
-        o_mock_1.api_delete.assert_not_called()
-        o_mock_2.api_delete.assert_not_called()
-        self.assertEqual(0, o_mock_sleep.call_count)
-        reset_mock()
+        # suppression avec before_delete, avec annulation liste vide ou None
+        for o_return in [[], None]:  # type:ignore
+            o_mock_function = MagicMock()
+            o_mock_function.before_delete_function.return_value = o_return
+            StoreEntity.delete_liste_entities(l_entity, o_mock_function.before_delete_function)
+            o_mock_function.before_delete_function.assert_called_once_with(l_entity)
+            o_mock_1.api_delete.assert_not_called()
+            o_mock_2.api_delete.assert_not_called()
+            o_mock_3.api_delete.assert_not_called()
+            self.assertEqual(0, o_mock_sleep.call_count)
+            reset_mock()

--- a/tests/store/StoreEntityTestCase.py
+++ b/tests/store/StoreEntityTestCase.py
@@ -1,7 +1,9 @@
 import json
-from unittest.mock import call, patch
-from ignf_gpf_sdk.store.Errors import StoreEntityError
+import time
+from typing import List
+from unittest.mock import MagicMock, Mock, call, patch
 
+from ignf_gpf_sdk.store.Errors import StoreEntityError
 from ignf_gpf_sdk.store.StoreEntity import StoreEntity
 from ignf_gpf_sdk.io.ApiRequester import ApiRequester
 from tests.GpfTestCase import GpfTestCase
@@ -384,3 +386,90 @@ class StoreEntityTestCase(GpfTestCase):
             # Vérifications
             self.assertIsNotNone(o_datetime)
             o_mock_update.assert_not_called()
+
+    def test_delete_cascade(self) -> None:
+        """test de delete_cascade"""
+        o_store_entity = StoreEntity({"_id": "1", "datetime": "2022-09-20T10:45:04.396Z"})
+
+        # test sans before_delete
+        with patch.object(StoreEntity, "delete_liste_entities", return_value=None) as o_mock_delete:
+            o_store_entity.delete_cascade()
+            o_mock_delete.assert_called_once_with([o_store_entity], None)
+
+        # test avec before_delete
+        with patch.object(StoreEntity, "delete_liste_entities", return_value=None) as o_mock_delete:
+            o_mock = MagicMock()
+            o_mock.before_delete_function.return_value = [o_store_entity]
+            o_store_entity.delete_cascade(o_mock.before_delete_function)
+            o_mock_delete.assert_called_once_with([o_store_entity], o_mock.before_delete_function)
+
+    @patch.object(time, "sleep", return_value=None)
+    def test_delete_liste_entities(self, o_mock_sleep: Mock) -> None:
+        """test de delete_liste_entities"""
+
+        o_mock_1 = MagicMock()
+        o_mock_2 = MagicMock()
+        o_mock_3 = MagicMock()
+
+        def reset_mock() -> None:
+            """reset des mock de la fonction"""
+            o_mock_1.reset_mock()
+            o_mock_2.reset_mock()
+            o_mock_3.reset_mock()
+            o_mock_sleep.reset_mock()
+
+        # suppression d'un élément sans before_delete
+        StoreEntity.delete_liste_entities([o_mock_1])
+        o_mock_1.api_delete.assert_called_once_with()
+        self.assertEqual(1, o_mock_sleep.call_count)
+        reset_mock()
+
+        # suppression de plusieurs éléments sans before_delete
+        l_entity: List[StoreEntity] = [o_mock_1, o_mock_2]
+        StoreEntity.delete_liste_entities(l_entity)
+        o_mock_1.api_delete.assert_called_once_with()
+        o_mock_2.api_delete.assert_called_once_with()
+        self.assertEqual(2, o_mock_sleep.call_count)
+        reset_mock()
+
+        # suppression avec before_delete, sans modification
+        o_mock_function = MagicMock()
+        o_mock_function.before_delete_function.return_value = l_entity
+        StoreEntity.delete_liste_entities(l_entity, o_mock_function.before_delete_function)
+        o_mock_function.before_delete_function.assert_called_once_with(l_entity)
+        o_mock_1.api_delete.assert_called_once_with()
+        o_mock_2.api_delete.assert_called_once_with()
+        self.assertEqual(2, o_mock_sleep.call_count)
+        reset_mock()
+
+        # suppression avec before_delete, avec modification
+        o_mock_function = MagicMock()
+        o_mock_function.before_delete_function.return_value = [o_mock_1, o_mock_3]
+        StoreEntity.delete_liste_entities(l_entity, o_mock_function.before_delete_function)
+        o_mock_function.before_delete_function.assert_called_once_with(l_entity)
+        o_mock_1.api_delete.assert_called_once_with()
+        o_mock_2.api_delete.assert_not_called()
+        o_mock_3.api_delete.assert_called_once_with()
+        self.assertEqual(2, o_mock_sleep.call_count)
+        reset_mock()
+
+        # suppression avec before_delete, avec annulation V1
+        o_mock_function = MagicMock()
+        o_mock_function.before_delete_function.return_value = []
+        StoreEntity.delete_liste_entities(l_entity, o_mock_function.before_delete_function)
+        o_mock_function.before_delete_function.assert_called_once_with(l_entity)
+        o_mock_1.api_delete.assert_not_called()
+        o_mock_2.api_delete.assert_not_called()
+        o_mock_3.api_delete.assert_not_called()
+        self.assertEqual(0, o_mock_sleep.call_count)
+        reset_mock()
+
+        # suppression avec before_delete, avec annulation V2
+        o_mock_function = MagicMock()
+        o_mock_function.before_delete_function.return_value = None
+        StoreEntity.delete_liste_entities(l_entity, o_mock_function.before_delete_function)
+        o_mock_function.before_delete_function.assert_called_once_with(l_entity)
+        o_mock_1.api_delete.assert_not_called()
+        o_mock_2.api_delete.assert_not_called()
+        self.assertEqual(0, o_mock_sleep.call_count)
+        reset_mock()

--- a/tests/store/StoredDataTestCase.py
+++ b/tests/store/StoredDataTestCase.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock, patch
+from ignf_gpf_sdk.store.Configuration import Configuration
+
+from ignf_gpf_sdk.store.StoredData import StoredData
+from tests.GpfTestCase import GpfTestCase
+
+
+class StoredDataTestCase(GpfTestCase):
+    """Tests StoredData class.
+
+    cmd : python3 -m unittest -b tests.store.StoredDataTestCase
+    """
+
+    def test_delete_cascade(self) -> None:
+        """test de delete_cascade"""
+        o_store_entity = StoredData({"_id": "1", "datetime": "2022-09-20T10:45:04.396Z"})
+
+        # Mock offerings
+        o_mock_offering_1 = MagicMock()
+        o_mock_offering_2 = MagicMock()
+        o_mock_offering_3 = MagicMock()
+        # mock config 1 => 2 offering
+        o_mock_config_1 = MagicMock()
+        o_mock_config_1.api_list_offerings.return_value = [o_mock_offering_1, o_mock_offering_2]
+        # mock config 2 => 0 offering
+        o_mock_config_2 = MagicMock()
+        o_mock_config_2.api_list_offerings.return_value = []
+        # mock config 3 => 1 offering
+        o_mock_config_3 = MagicMock()
+        o_mock_config_3.api_list_offerings.return_value = [o_mock_offering_3]
+
+        # mock pour la fonction before_delete
+        o_mock = MagicMock()
+        o_mock.before_delete_function.return_value = [o_store_entity]
+
+        for f_before_delete in [None, o_mock.before_delete_function]:
+            # StoredData sans configuration
+            with patch.object(Configuration, "api_list", return_value=[]) as o_mock_list:
+                with patch.object(StoredData, "delete_liste_entities", return_value=None) as o_mock_delete:
+                    o_store_entity.delete_cascade(f_before_delete)
+                    o_mock_delete.assert_called_once_with([o_store_entity], f_before_delete)
+                    o_mock_list.assert_called_once_with({"stored_data": "1"})
+
+            # StoredData avec configuration et offres
+            with patch.object(Configuration, "api_list", return_value=[o_mock_config_1, o_mock_config_2, o_mock_config_3]) as o_mock_list:
+                with patch.object(StoredData, "delete_liste_entities", return_value=None) as o_mock_delete:
+                    o_store_entity.delete_cascade(f_before_delete)
+                    o_mock_delete.assert_called_once_with(
+                        [
+                            o_mock_offering_1,
+                            o_mock_offering_2,
+                            o_mock_config_1,
+                            o_mock_config_2,
+                            o_mock_offering_3,
+                            o_mock_config_3,
+                            o_store_entity,
+                        ],
+                        f_before_delete,
+                    )
+                    o_mock_list.assert_called_once_with({"stored_data": "1"})
+                    o_mock_config_1.api_list_offerings.assert_called_once_with()
+                    o_mock_config_2.api_list_offerings.assert_called_once_with()
+                    o_mock_config_3.api_list_offerings.assert_called_once_with()
+            o_mock_config_1.reset_mock()
+            o_mock_config_2.reset_mock()
+            o_mock_config_3.reset_mock()


### PR DESCRIPTION
Première partie de la résolution du #29 
Prise en compte des behaviors pour les configurations et les offres.

Il restera à traité la question de l'ajout ou non des suppression en cascade (offre, [configuration, [stored-data]]) : nouvelle option ou comportement de base de DELETE