### PR TITLE
gestion des fichiers static, metadata et annexe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### [Added]
 
 * Classe Metadata + configuration associée et tests
+* Classe DescriptorFileReader pour la livraisons des fichiers static, metadata et annexe
+* Main: gestion des fichiers static, metadata et annexe (upload, liste, détail, publication et dépublication)
 
 ### [Changed]
 
@@ -12,6 +14,11 @@
     * `ActionAbstract` : si l'action après résolution n'est plus un JSON valide, on log le texte obtenue en niveau debug ;
     * `ActionAbstract` : on n'indente pas le JSON avant résolution
     * Regex resolver : ajout de `_` avant et après le nom du résolveur si format list ou dict.
+* renommage DescriptorFileReader en UploadDescriptorFileReader
+
+### [Fixed]
+
+* Bug de config pour les URL des fichiers statics
 
 ## v0.1.18
 

--- a/docs/comme-module.md
+++ b/docs/comme-module.md
@@ -24,12 +24,12 @@ Cela sera plus simple d'un point de vue Python mais moins modulaire.
 Voici un exemple de code Python permettant de le faire (à lancer après le chargement de la config !) :
 
 ```py
-# Importation des classes DescriptorFileReader et UploadAction
-from sdk_entrepot_gpf.io.DescriptorFileReader import DescriptorFileReader
+# Importation des classes UploadDescriptorFileReader et UploadAction
+from sdk_entrepot_gpf.io.UploadDescriptorFileReader import UploadDescriptorFileReader
 from sdk_entrepot_gpf.workflow.action.UploadAction import UploadAction
 
-# Instanciation d'une DescriptorFileReader
-descriptor_file_reader = DescriptorFileReader(p_descriptor)
+# Instanciation d'une UploadDescriptorFileReader
+descriptor_file_reader = UploadDescriptorFileReader(p_descriptor)
 
 # Instanciation d'une UploadAction à partir du Reader
 o_upload_action = UploadAction(o_dataset, behavior=s_behavior)

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -6,7 +6,7 @@
 
 ::: sdk_entrepot_gpf.io.Dataset
 
-::: sdk_entrepot_gpf.io.DescriptorFileReader
+::: sdk_entrepot_gpf.io.UploadDescriptorFileReader
 
 ::: sdk_entrepot_gpf.io.JsonConverter
 

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -166,7 +166,13 @@ class Main:
         o_sub_parser.add_argument("--force", action="store_true", help="Mode forcé, les suppressions sont faites sans aucune interaction")
 
         # Parser pour annexes
-        o_sub_parser = o_sub_parsers.add_parser("annexe", help="Annexes", epilog="TODO", formatter_class=argparse.RawTextHelpFormatter)
+        s_epilog_annexe = """quatre types de lancement :
+        * livraison d'annexes : `-f FICHIER`
+        * liste des annexes, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
+        * détail d'une annexe, avec option publication/dépublication : `--id ID [--publish|--unpublish]`
+        * publication /dépublication par label : `--publish-by-label label1,lable2` et `--unpublish-by-label label1,lable2`
+        """
+        o_sub_parser = o_sub_parsers.add_parser("annexe", help="Annexes", epilog=s_epilog_annexe, formatter_class=argparse.RawTextHelpFormatter)
         o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier descriptor dont on veut effectuer la livraison)")
         o_sub_parser.add_argument("--infos", "-i", type=str, default=None, help="Filtrer les livraisons selon les infos")
         o_sub_parser.add_argument("--id", type=str, default=None, help="Affiche l'annexe demandée")
@@ -176,13 +182,24 @@ class Main:
         o_sub_parser.add_argument("--unpublish-by-label", type=str, default=None, help="dépublication des annexes portant les labels donnés (ex: label1,label2)")
 
         # Parser pour static
-        o_sub_parser = o_sub_parsers.add_parser("static", help="Fichiers statiques", epilog="TODO", formatter_class=argparse.RawTextHelpFormatter)
+        s_epilog_static = """trois types de lancement :
+        * livraison de fichiers statics : `-f FICHIER`
+        * liste des fichiers statics, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
+        * détail d'un ficher static : `--id ID`
+        """
+        o_sub_parser = o_sub_parsers.add_parser("static", help="Fichiers statiques", epilog=s_epilog_static, formatter_class=argparse.RawTextHelpFormatter)
         o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier descriptor dont on veut effectuer la livraison)")
         o_sub_parser.add_argument("--infos", "-i", type=str, default=None, help="Filtrer les livraisons selon les infos")
         o_sub_parser.add_argument("--id", type=str, default=None, help="Affiche du fichier demandée")
 
         # Parser pour metadata
-        o_sub_parser = o_sub_parsers.add_parser("metadata", help="Métadonnées", epilog="TODO", formatter_class=argparse.RawTextHelpFormatter)
+        s_epilog_metadata = """quatre types de lancement :
+        * livraison d'une metadonnées : `-f FICHIER`
+        * liste des metadonnées, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]` ``
+        * détail d'une metadonnée : `--id ID`
+        * publication /dépublication : `--publish NOM_FICHIER [NOM_FICHIER] --id-endpoint ID_ENDPOINT` et `--unpublish NOM_FICHIER [NOM_FICHIER] --id-endpoint ID_ENDPOINT`
+        """
+        o_sub_parser = o_sub_parsers.add_parser("metadata", help="Métadonnées", epilog=s_epilog_metadata, formatter_class=argparse.RawTextHelpFormatter)
         o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier descriptor dont on veut effectuer la livraison)")
         o_sub_parser.add_argument("--infos", "-i", type=str, default=None, help="Filtrer les livraisons selon les infos")
         o_sub_parser.add_argument("--id", type=str, default=None, help="Affiche du fichier métadonnée demandée")

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -84,7 +84,7 @@ class Main:
             self.metadata()
 
     @staticmethod
-    def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:  # pylint:disable=too-many-statements
         """Parse les paramètres utilisateurs.
 
         Args:
@@ -653,7 +653,7 @@ class Main:
         else:
             Config().om.info(f"BILAN : les {len(d_res['ok'])} téléversements se sont bien passées", green_colored=True)
 
-    def annexe(self):
+    def annexe(self) -> None:
         """Gestion des annexes"""
         if self.o_args.file is not None:
             # on livre les données selon le fichier descripteur donné
@@ -664,17 +664,17 @@ class Main:
             if self.o_args.publish:
                 if o_annexe["published"]:
                     Config().om.info(f"L'annexe ({o_annexe}) est déjà publiée.")
-                else:
-                    # modification de la publication
-                    o_annexe.api_partial_edit({"published": True})
-                    Config().om.info(f"L'annexe ({o_annexe}) viens d'être publiée.")
+                    return
+                # modification de la publication
+                o_annexe.api_partial_edit({"published": str(True)})
+                Config().om.info(f"L'annexe ({o_annexe}) viens d'être publiée.")
             elif self.o_args.unpublish:
                 if not o_annexe["published"]:
                     Config().om.info(f"L'annexe ({o_annexe}) est déjà dépubliée.")
-                else:
-                    # modification de la publication
-                    o_annexe.api_partial_edit({"published": False})
-                    Config().om.info(f"L'annexe ({o_annexe}) viens d'être dépubliée.")
+                    return
+                # modification de la publication
+                o_annexe.api_partial_edit({"published": str(False)})
+                Config().om.info(f"L'annexe ({o_annexe}) viens d'être dépubliée.")
             else:
                 # affichage
                 Config().om.info(o_annexe.to_json(indent=3))
@@ -729,7 +729,7 @@ class Main:
         Config().om.info("Fin des livraisons.", green_colored=True)
         return {"ok": l_uploads, "upload_fail": d_upload_fail}
 
-    def static(self):
+    def static(self) -> None:
         """Gestion des fichiers statics"""
         if self.o_args.file is not None:
             # on livre les données selon le fichier descripteur donné

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -22,7 +22,7 @@ from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
 from sdk_entrepot_gpf.workflow.resolver.StoreEntityResolver import StoreEntityResolver
 from sdk_entrepot_gpf.workflow.action.UploadAction import UploadAction
 from sdk_entrepot_gpf.io.Config import Config
-from sdk_entrepot_gpf.io.DescriptorFileReader import DescriptorFileReader
+from sdk_entrepot_gpf.io.UploadDescriptorFileReader import UploadDescriptorFileReader
 from sdk_entrepot_gpf import store
 from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.Configuration import Configuration
@@ -302,7 +302,7 @@ class Main:
                 "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
                 "check_fail": liste des livraisons dont les vérification ont échouée
         """
-        o_dfu = DescriptorFileReader(Path(file))
+        o_dfu = UploadDescriptorFileReader(Path(file))
         s_behavior = str(behavior).upper() if behavior is not None else None
 
         l_uploads: List[Upload] = []  # liste des uploads lancées

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -19,6 +19,7 @@ from sdk_entrepot_gpf.io.DescriptorFileReader import DescriptorFileReader
 from sdk_entrepot_gpf.io.Errors import ConflictError
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
 from sdk_entrepot_gpf.store.Annexe import Annexe
+from sdk_entrepot_gpf.store.Metadata import Metadata
 from sdk_entrepot_gpf.store.Static import Static
 from sdk_entrepot_gpf.workflow.Workflow import Workflow
 from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
@@ -179,6 +180,7 @@ class Main:
         o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier descriptor dont on veut effectuer la livraison)")
         o_sub_parser.add_argument("--infos", "-i", type=str, default=None, help="Filtrer les livraisons selon les infos")
         o_sub_parser.add_argument("--id", type=str, default=None, help="Affiche du fichier demandée")
+
         # Parser pour metadata
         o_sub_parser = o_sub_parsers.add_parser("metadata", help="Métadonnées", epilog="TODO", formatter_class=argparse.RawTextHelpFormatter)
         o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier descriptor dont on veut effectuer la livraison)")
@@ -779,12 +781,10 @@ class Main:
             d_res = self.upload_metadata_from_descriptor_file(self.o_args.file, self.o_args.datastore)
             self._display_bilan_upload_file(d_res)
         elif self.o_args.id is not None:
-            raise NotImplementedError()
             o_metadata = Metadata.api_get(self.o_args.id, datastore=self.datastore)
             # affichage
             Config().om.info(o_metadata.to_json(indent=3))
         else:
-            raise NotImplementedError()
             # on liste toutes les fichiers métadonnées selon les filtres
             d_infos_filter = StoreEntity.filter_dict_from_str(self.o_args.infos)
             l_metadatas = Metadata.api_list(infos_filter=d_infos_filter, datastore=self.datastore)
@@ -804,7 +804,6 @@ class Main:
                 "ok" : liste des livraisons sans problèmes,
                 "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
         """
-        raise NotImplementedError()
         o_dfu = DescriptorFileReader(Path(file), "metadata")
 
         l_uploads: List[Metadata] = []  # liste des uploads effectué

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -292,7 +292,7 @@ class Main:
         """réalisation des livraison décrite par le fichier
 
         Args:
-            file (Union[Path, str]): chemin du ficher descripteur de livraison
+            file (Union[Path, str]): chemin du fichier descripteur de livraison
             behavior (Optional[str]): comportement dans le cas où une livraison de même nom existe, comportment par défaut su None
             datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
 
@@ -399,7 +399,7 @@ class Main:
         Sinon on liste les Livraisons avec éventuellement des filtres.
         """
         if self.o_args.file is not None:
-            # on livre les données selon le ficher descripteur donné
+            # on livre les données selon le fichier descripteur donné
             d_res = self.upload_from_descriptor_file(self.o_args.file, self.o_args.behavior, self.o_args.datastore)
             # Affichage du bilan
             Config().om.info("-" * 100)

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -713,6 +713,7 @@ class Main:
                 l_uploads.append(o_upload)
             except Exception as e:
                 d_upload_fail[s_nom] = e
+                Config().om.debug(traceback.format_exc())
                 Config().om.error(f"livraison {s_nom} : {e}")
 
         # vérification des livraisons
@@ -764,6 +765,7 @@ class Main:
                 l_uploads.append(o_upload)
             except Exception as e:
                 d_upload_fail[s_nom] = e
+                Config().om.debug(traceback.format_exc())
                 Config().om.error(f"livraison {s_nom} : {e}")
 
         # vérification des livraisons
@@ -818,6 +820,7 @@ class Main:
                 l_uploads.append(o_upload)
             except Exception as e:
                 d_upload_fail[s_nom] = e
+                Config().om.debug(traceback.format_exc())
                 Config().om.error(f"livraison {s_nom} : {e}")
 
         # vérification des livraisons

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -206,6 +206,9 @@ create_file_key=file
 [annexe]
 create_file_key=file
 
+[metadata]
+create_file_key=file
+
 [miscellaneous]
 # Répertoire contenant les données sur l'entrepôt
 data_directory_on_store=data
@@ -244,4 +247,7 @@ time_pattern = %H:%M:%S
 [json_schemas]
 # Les chemins sont définis relativement à sdk_entrepot_gpf/conf
 descriptor_file=json_schemas/upload_descriptor_file.json
-workflow_config=json_schemas/workflow_config.json
+workflow_config=json_schemas/workflow.json
+annexe_descriptor_file=json_schemas/annexe_descriptor_file.json
+static_descriptor_file=json_schemas/static_descriptor_file.json
+metadata_descriptor_file=json_schemas/metadata_descriptor_file.json

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -133,16 +133,16 @@ check_execution_logs=${routing:check_execution_get}/logs
 # fichiers static
 static_list=${store_api:root_datastore}/statics
 static_get=${routing:static_list}/{static}
-static_upload=${routing:static_list}/{static}
-static_delete=${routing:static_list}/{static}
-static_re_upload=${routing:static_list}/{static}
-static_partial_edit=${routing:static_list}/{static}
+static_upload=${routing:static_list}
+static_delete=${routing:static_get}
+static_re_upload=${routing:static_get}
+static_partial_edit=${routing:static_get}
 static_download=${routing:static_get}/file
 
 # annexe
 annexe_list=${store_api:root_datastore}/annexes
 annexe_get=${routing:annexe_list}/{annexe}
-annexe_upload=${routing:annexe_get}
+annexe_upload=${routing:annexe_list}
 annexe_delete=${routing:annexe_get}
 annexe_re_upload=${routing:annexe_get}
 annexe_partial_edit=${routing:annexe_get}

--- a/sdk_entrepot_gpf/_conf/json_schemas/annexe_descriptor_file.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/annexe_descriptor_file.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Schéma JSON pour un fichier descripteur de livraison pour les annexes",
+    "description": "",
+    "type": "object",
+    "required": [
+        "annexe"
+    ],
+    "properties": {
+        "annexe": {
+            "type": "array",
+            "minLength": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "file",
+                    "paths"
+                ],
+                "properties": {
+                    "file": {
+                        "type": "string"
+                    },
+                    "paths": {
+                        "type": "array",
+                        "minLength": 1,
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "published": {
+                        "type": "boolean"
+                    },
+                    "labels": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk_entrepot_gpf/_conf/json_schemas/metadata_descriptor_file.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/metadata_descriptor_file.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Schéma JSON pour un fichier descripteur de livraison pour les métadonnées",
+    "description": "",
+    "type": "object",
+    "required": [
+        "metadata"
+    ],
+    "properties": {
+        "metadata": {
+            "type": "array",
+            "minLength": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "file"
+                ],
+                "properties": {
+                    "file": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "INSPIRE",
+                            "ISOAP"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk_entrepot_gpf/_conf/json_schemas/static_descriptor_file.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/static_descriptor_file.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Schéma JSON pour un fichier descripteur de livraison pour les fichiers statiques",
+    "description": "",
+    "type": "object",
+    "required": [
+        "static"
+    ],
+    "properties": {
+        "static": {
+            "type": "array",
+            "minLength": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "file",
+                    "name",
+                    "type"
+                ],
+                "properties": {
+                    "file": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "GEOSERVER-FTL",
+                            "GEOSERVER-STYLE",
+                            "ROK4-STYLE",
+                            "DERIVATION-SQL"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk_entrepot_gpf/io/ApiRequester.py
+++ b/sdk_entrepot_gpf/io/ApiRequester.py
@@ -219,8 +219,7 @@ class ApiRequester(metaclass=Singleton):
             d_headers["content-type"] = o_me.content_type
             # Execution de la requête
             # TODO : contournement pour les uploads, supprimer `"verify": False` une fois le problème résolu + suppression proxy
-            d_requests.update({"data": o_me, "verify": False})
-            del d_requests["proxies"]
+            d_requests.update({"data": o_me})
         else:
             d_requests.update({"params": params, "json": data})
 

--- a/sdk_entrepot_gpf/io/ApiRequester.py
+++ b/sdk_entrepot_gpf/io/ApiRequester.py
@@ -210,11 +210,10 @@ class ApiRequester(metaclass=Singleton):
             "method": method,
             "headers": d_headers,
             "proxies": self.__proxy,
+            "params": params,
         }
         if files:
             d_fields = {**files}
-            if params:
-                d_fields.update(params)
             o_me = MultipartEncoder(fields=d_fields)
             d_headers["content-type"] = o_me.content_type
             # Execution de la requête

--- a/sdk_entrepot_gpf/io/DescriptorFileReader.py
+++ b/sdk_entrepot_gpf/io/DescriptorFileReader.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from sdk_entrepot_gpf.helper.JsonHelper import JsonHelper
+from sdk_entrepot_gpf.io.Config import Config
+from sdk_entrepot_gpf.Errors import GpfSdkError
+
+
+class DescriptorFileReader:
+    """Classe permettant de lire et de valider le fichier descripteur de téléversement de fichiers .
+
+    Attributes:
+        __descriptor_dict (Optional[Dict[Any, Any]]): Contenu du fichier descriptif
+        __data (List[Dict[str, Any]]): Liste des data contenus dans le fichier descripteur de téléversement
+        __parent_folder (path): Chemin du dossier parent des données
+        __data_type (str): type de donnée traité
+    """
+
+    def __init__(self, descriptor_file_path: Path, data_type: str) -> None:
+        """La classe est instanciée à partir du fichier descripteur de téléversement.
+
+        Les différents chemins indiqués sont alors vérifiés et les fichiers à téléverser sont listés.
+
+        Args:
+            descriptor_file_path (Path): chemin vers le fichier descripteur de téléversement
+        """
+        # Définition des attributs
+        self.__data_type = data_type
+        self.__descriptor_dict: Optional[Dict[Any, Any]] = None
+        self.__data: List[Dict[str, Any]] = []
+        self.__parent_folder = descriptor_file_path.parent.absolute()
+        # Ouverture du fichier descripteur de téléversement
+        self.__descriptor_dict = JsonHelper.load(descriptor_file_path, file_not_found_pattern="Fichier descripteur de téléversement {json_path} non trouvé.")
+
+        # Ouverture du schéma JSON à respecter
+        p_schema_file_path = Config.conf_dir_path / Config().get_str("json_schemas", f"{data_type}_descriptor_file")
+        d_schema = JsonHelper.load(p_schema_file_path, file_not_found_pattern="Schéma de fichier descriptif de téléversement {json_path} non trouvé. Contactez le support.")
+
+        # Valide le fichier descriptif
+        JsonHelper.validate_object(
+            self.__descriptor_dict,
+            d_schema,
+            f"Fichier descriptif de téléversement {descriptor_file_path} non valide.",
+            "Schéma du fichier descriptif de téléversement non valide. Contactez le support.",
+        )
+
+        # Vérification de l'existence des répertoires décrits dans le fichier
+        self.__validate_pathes()
+        # Vérification de l'existence des répertoires décrits dans le fichier et fabrication des chemins absolus à partir des chemins relatifs
+        self.__instantiate_data()
+
+    def __validate_pathes(self) -> None:
+        """Vérifie si les répertoires existent (s'interrompt si l'un d'entre eux n'existe pas).
+
+        Raises:
+            GpfSdkError : si un répertoire décrit dans le fichier descripteur n'existe pas
+        """
+        # liste qui va servir à lister les dossiers en erreurs
+        l_liste_file_non_valide: List[str] = []
+        # On parcours la liste des datasets
+        if self.__descriptor_dict is not None:
+            for l_dataset in self.__descriptor_dict[self.__data_type]:
+                # on parcours la liste des dossiers de chaque dataset
+                if l_dataset["file"]:
+                    p_file_path = self.__parent_folder / l_dataset["file"]
+                    if not p_file_path.exists():
+                        l_liste_file_non_valide.append(str(p_file_path))
+            # si à la fin du parcours des dossiers la liste n'est pas vide, on lève une erreur:
+            if l_liste_file_non_valide:
+                # affiche la liste des dossiers non valides
+                Config().om.error("Liste des fichiers à téléverser non existants :\n  * {}".format("\n  * ".join(l_liste_file_non_valide)))
+                raise GpfSdkError("Au moins un des fichier listés dans le fichier descripteur de téléversement n'existe pas.")
+
+    def __instantiate_data(self) -> None:
+        """Instancie les datasets."""
+        if self.__descriptor_dict is not None:
+            self.__data = list(self.__descriptor_dict[self.__data_type])
+
+    @property
+    def data(self) -> List[Dict[str, Any]]:
+        return self.__data

--- a/sdk_entrepot_gpf/io/UploadDescriptorFileReader.py
+++ b/sdk_entrepot_gpf/io/UploadDescriptorFileReader.py
@@ -7,7 +7,7 @@ from sdk_entrepot_gpf.io.Dataset import Dataset
 from sdk_entrepot_gpf.Errors import GpfSdkError
 
 
-class DescriptorFileReader:
+class UploadDescriptorFileReader:
     """Classe permettant de lire et de valider le fichier descripteur de livraison.
 
     Attributes:

--- a/sdk_entrepot_gpf/store/Metadata.py
+++ b/sdk_entrepot_gpf/store/Metadata.py
@@ -35,7 +35,7 @@ class Metadata(CreatedByUploadFileInterface, DownloadInterface, PartialEditInter
         ApiRequester().route_request(
             s_route,
             route_params={"datastore": datastore},
-            params={"file_identifiers": file_identifiers, "endpoint": endpoint_id},
+            data={"file_identifiers": file_identifiers, "endpoint": endpoint_id},
             method=ApiRequester.POST,
         )
 
@@ -56,6 +56,6 @@ class Metadata(CreatedByUploadFileInterface, DownloadInterface, PartialEditInter
         ApiRequester().route_request(
             s_route,
             route_params={"datastore": datastore},
-            params={"file_identifiers": file_identifiers, "endpoint": endpoint_id},
+            data={"file_identifiers": file_identifiers, "endpoint": endpoint_id},
             method=ApiRequester.POST,
         )

--- a/sdk_entrepot_gpf/store/interface/CreatedByUploadFileInterface.py
+++ b/sdk_entrepot_gpf/store/interface/CreatedByUploadFileInterface.py
@@ -32,13 +32,12 @@ class CreatedByUploadFileInterface(StoreEntity):
         s_route = f"{cls._entity_name}_upload"
 
         # récupération du fichier et du nom du fichier après livraison
-        if not data or "file" not in data or "api_path" not in data:
-            raise StoreEntityError('Entité créée par l\'upload d\'un fichier, les clefs "file": Path("chemin fichier") et "api_path": "nom fichier" sont obligatoires dans data')
+        if not data or "file" not in data:
+            raise StoreEntityError('Entité créée par l\'upload d\'un fichier, les clefs "file": Path("chemin fichier") est obligatoire dans data')
         p_file = Path(data.pop("file"))
-        s_api_path = data.pop("api_path")
 
         # nom de la clef dans le fichier
-        s_file_key = Config().get_str(cls.entity_name(), "create_file_key")
+        s_file_key = Config().get_str(cls.entity_name(), "create_file_key", "file")
 
         # Requête
         o_response = ApiRequester().route_upload_file(
@@ -46,9 +45,8 @@ class CreatedByUploadFileInterface(StoreEntity):
             p_file,
             s_file_key,
             route_params=route_params,
-            params={"path": s_api_path},
+            params=data,
             method=ApiRequester.POST,
-            data=data,
         )
 
         # Instanciation

--- a/sdk_entrepot_gpf/store/interface/CreatedByUploadFileInterface.py
+++ b/sdk_entrepot_gpf/store/interface/CreatedByUploadFileInterface.py
@@ -17,7 +17,7 @@ class CreatedByUploadFileInterface(StoreEntity):
         """Crée une nouvelle entité dans l'API.
 
         Args:
-            data: Données nécessaires pour la création. Dont "file": Path("chemin fichier") et "api_path": "nom fichier"
+            data: Données nécessaires pour la création. Dont "file": Path("chemin fichier") (obligatoire)
             route_params: Paramètres de résolution de la route.
 
         Returns:

--- a/tests/io/UploadDescriptorFileReaderTestCase.py
+++ b/tests/io/UploadDescriptorFileReaderTestCase.py
@@ -1,13 +1,13 @@
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.io.Dataset import Dataset
-from sdk_entrepot_gpf.io.DescriptorFileReader import DescriptorFileReader
+from sdk_entrepot_gpf.io.UploadDescriptorFileReader import UploadDescriptorFileReader
 
 from tests.GpfTestCase import GpfTestCase
 
 
-class DescriptorFileReaderTestCase(GpfTestCase):
-    """Test de la classe DescriptorFileReader.
+class UploadDescriptorFileReaderTestCase(GpfTestCase):
+    """Test de la classe UploadDescriptorFileReader.
 
     cmd : python3 -m unittest -b tests.io.DescriptorFileReaderTestCase
     """
@@ -15,7 +15,7 @@ class DescriptorFileReaderTestCase(GpfTestCase):
     def test_init_ok_1(self) -> None:
         """Test du constructeur quand tout va bien n°1."""
         # Ouverture
-        o_dsr = DescriptorFileReader(Config.data_dir_path / "datasets" / "1_dataset_vector" / "upload_descriptor.json")
+        o_dsr = UploadDescriptorFileReader(Config.data_dir_path / "datasets" / "1_dataset_vector" / "upload_descriptor.json")
         # Vérifications
         self.assertEqual(len(o_dsr.datasets), 1)
         self.assertIsInstance(o_dsr.datasets[0], Dataset)
@@ -23,7 +23,7 @@ class DescriptorFileReaderTestCase(GpfTestCase):
     def test_init_ok_2(self) -> None:
         """Test du constructeur quand tout va bien n°2."""
         # Ouverture
-        o_dsr = DescriptorFileReader(Config.data_dir_path / "datasets" / "2_dataset_archive" / "upload_descriptor.json")
+        o_dsr = UploadDescriptorFileReader(Config.data_dir_path / "datasets" / "2_dataset_archive" / "upload_descriptor.json")
         # Vérifications
         self.assertEqual(len(o_dsr.datasets), 1)
         self.assertEqual(o_dsr.datasets[0].upload_infos["name"], "EXAMPLE_DATASET_ARCHIVE")
@@ -32,6 +32,6 @@ class DescriptorFileReaderTestCase(GpfTestCase):
         """Test du constructeur quand au moins un dossier indiqué n'est pas trouvé."""
         with self.assertRaises(GpfSdkError) as o_arc:
             # Ouverture
-            DescriptorFileReader(GpfTestCase.data_dir_path / "datasets" / "1_test_dataset_bad_pathes" / "upload_descriptor.json")
+            UploadDescriptorFileReader(GpfTestCase.data_dir_path / "datasets" / "1_test_dataset_bad_pathes" / "upload_descriptor.json")
         # Vérifications
         self.assertEqual(o_arc.exception.message, "Au moins un des répertoires listés dans le fichier descripteur de livraison n'existe pas.")

--- a/tests/store/MetadataTestCase.py
+++ b/tests/store/MetadataTestCase.py
@@ -27,7 +27,7 @@ class MetadataTestCase(GpfTestCase):
                 o_mock_request.assert_called_once_with(
                     "metadata_publish",
                     route_params={"datastore": s_datastore},
-                    params={"file_identifiers": l_file, "endpoint": s_endpoint_id},
+                    data={"file_identifiers": l_file, "endpoint": s_endpoint_id},
                     method=ApiRequester.POST,
                 )
 
@@ -47,6 +47,6 @@ class MetadataTestCase(GpfTestCase):
                 o_mock_request.assert_called_once_with(
                     "metadata_unpublish",
                     route_params={"datastore": s_datastore},
-                    params={"file_identifiers": l_file, "endpoint": s_endpoint_id},
+                    data={"file_identifiers": l_file, "endpoint": s_endpoint_id},
                     method=ApiRequester.POST,
                 )

--- a/tests/store/interface/CreatedByUploadFileInterfaceTestCase.py
+++ b/tests/store/interface/CreatedByUploadFileInterfaceTestCase.py
@@ -20,10 +20,9 @@ class CreatedByUploadFileInterfaceTestCase(GpfTestCase):
     def test_api_create(self) -> None:
         "Vérifie le bon fonctionnement de api_create."
         p_file = Path("rep/file")
-        s_api_path = "path/dans_api"
         d_res_data = {"base": "data"}
         s_key_file = "file"
-        d_data = {**d_res_data, "file": p_file, "api_path": s_api_path}
+        d_data: Dict[str, Any] = {**d_res_data, "file": p_file}
         o_response = self.get_response(json={"_id": "123456789"})
 
         for s_datastore in [None, "api_create"]:
@@ -42,19 +41,18 @@ class CreatedByUploadFileInterfaceTestCase(GpfTestCase):
                         p_file,
                         s_key_file,
                         route_params=d_route_params,
-                        params={"path": s_api_path},
                         method=ApiRequester.POST,
-                        data=d_res_data,
+                        params=d_res_data,
                     )
-                    o_mock_config.assert_any_call("store_entity", "create_file_key")
+                    o_mock_config.assert_any_call("store_entity", "create_file_key", "file")
                     self.assertIsInstance(o_entity, CreatedByUploadFileInterface)
                     self.assertEqual(o_entity.id, "123456789")
                     self.assertEqual(o_entity.datastore, s_datastore)
 
         # problème de paramétrage :
-        s_message = 'Entité créée par l\'upload d\'un fichier, les clefs "file": Path("chemin fichier") et "api_path": "nom fichier" sont obligatoires dans data'
+        s_message = 'Entité créée par l\'upload d\'un fichier, les clefs "file": Path("chemin fichier") est obligatoire dans data'
 
-        l_data: List[Dict[str, Any]] = [{}, {"file": p_file}, {"api_path": s_api_path}]
+        l_data: List[Dict[str, Any]] = [{}, {"path": "path/dans_api"}]
         for d_data in l_data:
             with self.assertRaises(StoreEntityError) as o_arc:
                 CreatedByUploadFileInterface.api_create(d_data, d_route_params)


### PR DESCRIPTION
ajout dans le main de la gestion des fichiers static, metadata et annexe (upload, liste, détail, publication et dépublication)

### [Added]

* Classe DescriptorFileReader pour la livraisons des fichiers static, metadata et annexe
* Main: gestion des fichiers static, metadata et annexe (upload, liste, détail, publication et dépublication)

### [Changed]

* renommage DescriptorFileReader en UploadDescriptorFileReader

### [Fixed]

* Bug de config pour les URL des fichiers statics