### PR TITLE
Action delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Added]
 
+* DeleteAction : suppression des upload, stored_data, configuration et offering dans un workflow
+
 ### [Changed]
 
 ### [Fixed]

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -670,7 +670,7 @@ class Main:
 
         if self.o_args.type in Main.DELETABLE_TYPES:
             # récupération de l'entité de base
-            o_entity = store.TYPE__ENTITY[self.o_args.type].api_get(self.o_args.id)
+            o_entity = store.TYPE__ENTITY[self.o_args.type].api_get(self.o_args.id, self.o_args.datastore)
         else:
             raise GpfSdkError(f"Type {self.o_args.type} non reconnu. Types valides : {', '.join(Main.DELETABLE_TYPES)}")
 

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -22,15 +22,13 @@ from sdk_entrepot_gpf.store.Annexe import Annexe
 from sdk_entrepot_gpf.store.Metadata import Metadata
 from sdk_entrepot_gpf.store.Static import Static
 from sdk_entrepot_gpf.workflow.Workflow import Workflow
+from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
 from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
 from sdk_entrepot_gpf.workflow.resolver.StoreEntityResolver import StoreEntityResolver
 from sdk_entrepot_gpf.workflow.action.UploadAction import UploadAction
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.io.UploadDescriptorFileReader import UploadDescriptorFileReader
 from sdk_entrepot_gpf import store
-from sdk_entrepot_gpf.store.Offering import Offering
-from sdk_entrepot_gpf.store.Configuration import Configuration
-from sdk_entrepot_gpf.store.StoredData import StoredData
 from sdk_entrepot_gpf.store.Upload import Upload
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.store.ProcessingExecution import ProcessingExecution
@@ -40,8 +38,6 @@ from sdk_entrepot_gpf.workflow.resolver.UserResolver import UserResolver
 
 class Main:
     """Classe d'entrée pour utiliser la lib comme binaire."""
-
-    DELETABLE_TYPES = [Upload.entity_name(), StoredData.entity_name(), Configuration.entity_name(), Offering.entity_name()]
 
     def __init__(self) -> None:
         """Constructeur."""
@@ -160,7 +156,7 @@ class Main:
 
         # Parser pour delete
         o_sub_parser = o_sub_parsers.add_parser("delete", help="Delete")
-        o_sub_parser.add_argument("--type", choices=Main.DELETABLE_TYPES, required=True, help="Type de l'entité à supprimer")
+        o_sub_parser.add_argument("--type", choices=DeleteAction.DELETABLE_TYPES, required=True, help="Type de l'entité à supprimer")
         o_sub_parser.add_argument("--id", type=str, required=True, help="Identifiant de l'entité à supprimer")
         o_sub_parser.add_argument("--cascade", action="store_true", help="Action à effectuer si l'exécution de traitement existe déjà")
         o_sub_parser.add_argument("--force", action="store_true", help="Mode forcé, les suppressions sont faites sans aucune interaction")
@@ -649,6 +645,7 @@ class Main:
 
     def delete(self) -> None:
         """suppression d'une entité par son type et son id"""
+        # TODO: passé à l'utilisation de DeleteAction
 
         def question_before_delete(l_delete: List[StoreEntity]) -> List[StoreEntity]:
             Config().om.info("suppression de :")
@@ -668,11 +665,11 @@ class Main:
                 Config().om.info(str(o_entity), green_colored=True)
             return l_delete
 
-        if self.o_args.type in Main.DELETABLE_TYPES:
+        if self.o_args.type in DeleteAction.DELETABLE_TYPES:
             # récupération de l'entité de base
             o_entity = store.TYPE__ENTITY[self.o_args.type].api_get(self.o_args.id, self.o_args.datastore)
         else:
-            raise GpfSdkError(f"Type {self.o_args.type} non reconnu. Types valides : {', '.join(Main.DELETABLE_TYPES)}")
+            raise GpfSdkError(f"Type {self.o_args.type} non reconnu. Types valides : {', '.join(DeleteAction.DELETABLE_TYPES)}")
 
         # choix de la fonction exécuté avant la suppression
         ## force : juste affichage

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -29,14 +29,14 @@
                                 "items": {
                                     "type": "object",
                                     "required": [
-                                        "type",
-                                        "body_parameters"
+                                        "type"
                                     ],
                                     "additionalProperties": false,
                                     "properties": {
                                         "type": {
                                             "type": "string",
                                             "enum": [
+                                                "delete-entity",
                                                 "processing-execution",
                                                 "configuration",
                                                 "offering"
@@ -59,6 +59,32 @@
                                         },
                                         "datastore": {
                                             "type": "string"
+                                        },
+                                        "entity_type": {
+                                            "type": "string"
+                                        },
+                                        "entity_id": {
+                                            "type": "string"
+                                        },
+                                        "filter_infos": {
+                                            "type": "object"
+                                        },
+                                        "filter_tags": {
+                                            "type": "object"
+                                        },
+                                        "cascade": {
+                                            "type": "boolean"
+                                        },
+                                        "not_found_ok": {
+                                            "type": "boolean"
+                                        },
+                                        "if_multi": {
+                                            "type": "string",
+                                            "enum": [
+                                                "first",
+                                                "all",
+                                                "error"
+                                            ]
                                         }
                                     }
                                 }

--- a/sdk_entrepot_gpf/store/Configuration.py
+++ b/sdk_entrepot_gpf/store/Configuration.py
@@ -47,16 +47,14 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
         """
         return Offering.api_create(data_offering, route_params={self._entity_name: self.id})
 
-    def delete_cascade(self, before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
-        """Fonction de suppression de la Configuration en supprimant en cascade les offres liées (et uniquement les offres, pas les données stockées).
+    def get_liste_deletable_cascade(self) -> List[StoreEntity]:
+        """liste les entités à supprimé lors d'une suppression en cascade de la Configuration en supprimant en cascade les offres liées (et uniquement les offres, pas les données stockées).
 
-        Args:
-            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancer avant la suppression (entrée : liste des entités à supprimer,
-                sortie : liste définitive des entités à supprimer). Defaults to None.
+        Returns:
+            List[StoreEntity]: liste des entités qui seront supprimé
         """
-        # suppression d'une configuration : offres puis configuration
         l_entities: List[StoreEntity] = []
         l_offering = self.api_list_offerings()
         l_entities += l_offering
         l_entities.append(self)
-        self.delete_liste_entities(l_entities, before_delete)
+        return l_entities

--- a/sdk_entrepot_gpf/store/Configuration.py
+++ b/sdk_entrepot_gpf/store/Configuration.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List
 
 from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity

--- a/sdk_entrepot_gpf/store/StoreEntity.py
+++ b/sdk_entrepot_gpf/store/StoreEntity.py
@@ -243,6 +243,14 @@ class StoreEntity(ABC):
                     raise StoreEntityError(s_error_message)
         return d_filter
 
+    def get_liste_deletable_cascade(self) -> List["StoreEntity"]:
+        """liste les entités à supprimé lors d'une suppression en cascade
+
+        Returns:
+            List[StoreEntity]: liste des entités qui seront supprimé
+        """
+        return [self]
+
     def delete_cascade(self, before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
         """Suppression en cascade d'une entité en supprimant les entités liées (qui vont dépendre du type de l'entité, donc cf. les classes filles).
 
@@ -250,8 +258,8 @@ class StoreEntity(ABC):
             before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancer avant la suppression (entrée : liste des entités à supprimer,
                 sortie : liste définitive des entités à supprimer). Defaults to None.
         """
-        # suppression d'une configuration : offres puis configuration
-        self.delete_liste_entities([self], before_delete)
+        l_entities: List[StoreEntity] = self.get_liste_deletable_cascade()
+        self.delete_liste_entities(l_entities, before_delete)
 
     @staticmethod
     def delete_liste_entities(l_entities: List["StoreEntity"], before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:

--- a/sdk_entrepot_gpf/store/StoreEntity.py
+++ b/sdk_entrepot_gpf/store/StoreEntity.py
@@ -244,7 +244,7 @@ class StoreEntity(ABC):
         return d_filter
 
     def get_liste_deletable_cascade(self) -> List["StoreEntity"]:
-        """liste les entités à supprimé lors d'une suppression en cascade
+        """liste les entités à supprimer lors d'une suppression en cascade
 
         Returns:
             List[StoreEntity]: liste des entités qui seront supprimé

--- a/sdk_entrepot_gpf/store/StoredData.py
+++ b/sdk_entrepot_gpf/store/StoredData.py
@@ -23,10 +23,10 @@ class StoredData(TagInterface, CommentInterface, SharingInterface, EventInterfac
     STATUS_UNSTABLE = "UNSTABLE"
 
     def get_liste_deletable_cascade(self) -> List[StoreEntity]:
-        """liste les entités à supprimé lors d'une suppression en cascade des configuration liées et des offres liées à chaque configuration.
+        """liste les entités à supprimer lors d'une suppression en cascade des configuration liées et des offres liées à chaque configuration.
 
         Returns:
-            List[StoreEntity]: liste des entités qui seront supprimé
+            List[StoreEntity]: liste des entités qui seront supprimées
         """
         # suppression d'une stored_data : offering et configuration liées puis la stored_data
         l_entities: List[StoreEntity] = []

--- a/sdk_entrepot_gpf/store/StoredData.py
+++ b/sdk_entrepot_gpf/store/StoredData.py
@@ -22,12 +22,11 @@ class StoredData(TagInterface, CommentInterface, SharingInterface, EventInterfac
     STATUS_DELETED = "DELETED"
     STATUS_UNSTABLE = "UNSTABLE"
 
-    def delete_cascade(self, before_delete: Optional[Callable[[List["StoreEntity"]], List["StoreEntity"]]] = None) -> None:
-        """Suppression de la donnée stockée avec suppression en cascade des configuration liées et des offres liées à chaque configuration.
+    def get_liste_deletable_cascade(self) -> List[StoreEntity]:
+        """liste les entités à supprimé lors d'une suppression en cascade des configuration liées et des offres liées à chaque configuration.
 
-        Args:
-            before_delete (Optional[Callable[[List[StoreEntity]], List[StoreEntity]]], optional): fonction à lancer avant la suppression (entrée : liste des entités à supprimer,
-                sortie : liste définitive des entités à supprimer). Defaults to None.
+        Returns:
+            List[StoreEntity]: liste des entités qui seront supprimé
         """
         # suppression d'une stored_data : offering et configuration liées puis la stored_data
         l_entities: List[StoreEntity] = []
@@ -41,6 +40,4 @@ class StoredData(TagInterface, CommentInterface, SharingInterface, EventInterfac
             l_entities.append(o_configuration)
         # ajout de la stored_data
         l_entities.append(self)
-
-        # suppression
-        self.delete_liste_entities(l_entities, before_delete)
+        return l_entities

--- a/sdk_entrepot_gpf/store/StoredData.py
+++ b/sdk_entrepot_gpf/store/StoredData.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Callable
+from typing import List
 
 from sdk_entrepot_gpf.store.Configuration import Configuration
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -10,6 +10,7 @@ from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.workflow.Errors import WorkflowError
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
+from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
@@ -241,6 +242,8 @@ class Workflow:
         Returns:
             instance permettant de lancer l'action
         """
+        if definition_dict["type"] == "delete-entity":
+            return DeleteAction(workflow_context, definition_dict, parent_action)
         if definition_dict["type"] == "processing-execution":
             return ProcessingExecutionAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "configuration":

--- a/sdk_entrepot_gpf/workflow/action/DeleteAction.py
+++ b/sdk_entrepot_gpf/workflow/action/DeleteAction.py
@@ -1,11 +1,15 @@
 from typing import List, Optional
 
-from sdk_entrepot_gpf.__main__ import Main
+from sdk_entrepot_gpf.store.Configuration import Configuration
+from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
+from sdk_entrepot_gpf.store.StoredData import StoredData
+from sdk_entrepot_gpf.store.Upload import Upload
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.io.Errors import NotFoundError
 from sdk_entrepot_gpf import store
+from sdk_entrepot_gpf.workflow.Errors import StepActionError
 
 
 class DeleteAction(ActionAbstract):
@@ -17,44 +21,57 @@ class DeleteAction(ActionAbstract):
         __parent_action (Optional["Action"]): action parente
     """
 
-    def run(self, datastore: Optional[str] = None) -> None:
-        def question_before_delete(l_delete: List[StoreEntity]) -> List[StoreEntity]:
-            Config().om.info("suppression de :")
-            for o_entity in l_delete:
-                Config().om.info(str(o_entity), green_colored=True)
-            Config().om.info("Voulez-vous effectué la suppression ? (oui/NON)")
-            s_rep = input()
-            # si la réponse ne correspond pas à oui on sort
-            if s_rep.lower() not in ["oui", "o", "yes", "y"]:
-                Config().om.info("La suppression est annulée.")
-                return []
-            return l_delete
+    DELETABLE_TYPES = [Upload.entity_name(), StoredData.entity_name(), Configuration.entity_name(), Offering.entity_name()]
 
+    @staticmethod
+    def question_before_delete(l_delete: List[StoreEntity]) -> List[StoreEntity]:
+        """question posé avant que la suppression soit effectuée
+
+        Args:
+            l_delete (List[StoreEntity]): liste des entités à supprimé
+
+        Returns:
+            List[StoreEntity]: liste final des entités à supprimé
+        """
+        Config().om.info("suppression de :")
+        for o_entity in l_delete:
+            Config().om.info(str(o_entity), green_colored=True)
+        Config().om.info("Voulez-vous effectué la suppression ? (oui/NON)")
+        s_rep = input()
+        # si la réponse ne correspond pas à oui on sort
+        if s_rep.lower() not in ["oui", "o", "yes", "y"]:
+            Config().om.info("La suppression est annulée.")
+            return []
+        return l_delete
+
+    def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Suppression...")
         if "entity_type" not in self.definition_dict:
-            raise Exception("La valeur entity_type est obligatoire pour cette action")
-        if self.definition_dict["entity_type"] not in Main.DELETABLE_TYPES:
-            raise Exception(f"Type {self.definition_dict['entity_type']} non reconnu. Types valides : {', '.join(Main.DELETABLE_TYPES)}")
+            raise StepActionError('La clef "entity_type" est obligatoire pour cette action')
+        if self.definition_dict["entity_type"] not in DeleteAction.DELETABLE_TYPES:
+            raise StepActionError(f"Type {self.definition_dict['entity_type']} non reconnu. Types valides : {', '.join(DeleteAction.DELETABLE_TYPES)}")
         # Recherche de la/ les entité à supprimé
         l_entities = []
         if self.definition_dict.get("entity_id"):
             ## si id => on recherche directement
             try:
-                l_entities.append(store.TYPE__ENTITY[self.definition_dict["entity_type"]].api_get(self.definition_dict["entity_id"], datastore))
-            except NotFoundError as e:
-                if not self.definition_dict.get("not_found_ok"):
-                    raise e
+                l_entities.append(store.TYPE__ENTITY[self.definition_dict["entity_type"]].api_get(self.definition_dict["entity_id"], datastore=datastore))
+            except NotFoundError:
+                # sera gérer plus bas
+                pass
         elif "filter_infos" in self.definition_dict or "filter_tags" in self.definition_dict:
             ## par liste des éléments
             l_entities = store.TYPE__ENTITY[self.definition_dict["entity_type"]].api_list(self.definition_dict.get("filter_infos"), self.definition_dict.get("filter_infos"), datastore=datastore)
+        else:
+            raise StepActionError('Il faut au moins une des clefs suivantes : "entity_id", "filter_infos", "filter_tags" pour cette action.')
 
         if len(l_entities) == 0 and not self.definition_dict.get("not_found_ok"):
-            raise Exception("Aucune entité trouvé pour la suppression")
+            raise StepActionError("Aucune entité trouvé pour la suppression")
         if len(l_entities) > 1:
             if self.definition_dict.get("if_multi") == "error":
                 # On sort en erreur
-                raise Exception("Aucune entité trouvé pour la suppression")
-            elif self.definition_dict.get("if_multi") == "first":
+                raise StepActionError(f"Plusieurs entités trouvé pour la suppression : {l_entities}")
+            if self.definition_dict.get("if_multi") == "first":
                 # on ne supprime que le 1er élément trouvé
                 l_entities = [l_entities[0]]
             # on les supprimera tous
@@ -68,4 +85,4 @@ class DeleteAction(ActionAbstract):
                 l_entities_cascade += o_entity.get_liste_deletable_cascade()
             l_entities = l_entities_cascade
         ## suppression
-        StoreEntity.delete_liste_entities(l_entities, question_before_delete)
+        StoreEntity.delete_liste_entities(l_entities, self.question_before_delete)

--- a/sdk_entrepot_gpf/workflow/action/DeleteAction.py
+++ b/sdk_entrepot_gpf/workflow/action/DeleteAction.py
@@ -1,0 +1,71 @@
+from typing import List, Optional
+
+from sdk_entrepot_gpf.__main__ import Main
+from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
+from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
+from sdk_entrepot_gpf.io.Config import Config
+from sdk_entrepot_gpf.io.Errors import NotFoundError
+from sdk_entrepot_gpf import store
+
+
+class DeleteAction(ActionAbstract):
+    """Classe dédiée à la création des Offering.
+
+    Attributes:
+        __workflow_context (str): nom du contexte du workflow
+        __definition_dict (Dict[str, Any]): définition de l'action
+        __parent_action (Optional["Action"]): action parente
+    """
+
+    def run(self, datastore: Optional[str] = None) -> None:
+        def question_before_delete(l_delete: List[StoreEntity]) -> List[StoreEntity]:
+            Config().om.info("suppression de :")
+            for o_entity in l_delete:
+                Config().om.info(str(o_entity), green_colored=True)
+            Config().om.info("Voulez-vous effectué la suppression ? (oui/NON)")
+            s_rep = input()
+            # si la réponse ne correspond pas à oui on sort
+            if s_rep.lower() not in ["oui", "o", "yes", "y"]:
+                Config().om.info("La suppression est annulée.")
+                return []
+            return l_delete
+
+        Config().om.info("Suppression...")
+        if "entity_type" not in self.definition_dict:
+            raise Exception("La valeur entity_type est obligatoire pour cette action")
+        if self.definition_dict["entity_type"] not in Main.DELETABLE_TYPES:
+            raise Exception(f"Type {self.definition_dict['entity_type']} non reconnu. Types valides : {', '.join(Main.DELETABLE_TYPES)}")
+        # Recherche de la/ les entité à supprimé
+        l_entities = []
+        if self.definition_dict.get("entity_id"):
+            ## si id => on recherche directement
+            try:
+                l_entities.append(store.TYPE__ENTITY[self.definition_dict["entity_type"]].api_get(self.definition_dict["entity_id"], datastore))
+            except NotFoundError as e:
+                if not self.definition_dict.get("not_found_ok"):
+                    raise e
+        elif "filter_infos" in self.definition_dict or "filter_tags" in self.definition_dict:
+            ## par liste des éléments
+            l_entities = store.TYPE__ENTITY[self.definition_dict["entity_type"]].api_list(self.definition_dict.get("filter_infos"), self.definition_dict.get("filter_infos"), datastore=datastore)
+
+        if len(l_entities) == 0 and not self.definition_dict.get("not_found_ok"):
+            raise Exception("Aucune entité trouvé pour la suppression")
+        if len(l_entities) > 1:
+            if self.definition_dict.get("if_multi") == "error":
+                # On sort en erreur
+                raise Exception("Aucune entité trouvé pour la suppression")
+            elif self.definition_dict.get("if_multi") == "first":
+                # on ne supprime que le 1er élément trouvé
+                l_entities = [l_entities[0]]
+            # on les supprimera tous
+
+        # suppression
+        if self.definition_dict.get("cascade"):
+            Config().om.info("Suppression en cascade, recherche des entités à supprimer ...")
+            l_entities_cascade = []
+            ## suppression des entités en cascades
+            for o_entity in l_entities:
+                l_entities_cascade += o_entity.get_liste_deletable_cascade()
+            l_entities = l_entities_cascade
+        ## suppression
+        StoreEntity.delete_liste_entities(l_entities, question_before_delete)

--- a/sdk_entrepot_gpf/workflow/action/DeleteAction.py
+++ b/sdk_entrepot_gpf/workflow/action/DeleteAction.py
@@ -25,18 +25,18 @@ class DeleteAction(ActionAbstract):
 
     @staticmethod
     def question_before_delete(l_delete: List[StoreEntity]) -> List[StoreEntity]:
-        """question posé avant que la suppression soit effectuée
+        """question posée avant que la suppression soit effectuée
 
         Args:
-            l_delete (List[StoreEntity]): liste des entités à supprimé
+            l_delete (List[StoreEntity]): liste des entités à supprimer
 
         Returns:
-            List[StoreEntity]: liste final des entités à supprimé
+            List[StoreEntity]: liste final des entités à supprimer
         """
         Config().om.info("suppression de :")
         for o_entity in l_delete:
             Config().om.info(str(o_entity), green_colored=True)
-        Config().om.info("Voulez-vous effectué la suppression ? (oui/NON)")
+        Config().om.info("Voulez-vous effectuer la suppression ? (oui/NON)")
         s_rep = input()
         # si la réponse ne correspond pas à oui on sort
         if s_rep.lower() not in ["oui", "o", "yes", "y"]:
@@ -50,7 +50,7 @@ class DeleteAction(ActionAbstract):
             raise StepActionError('La clef "entity_type" est obligatoire pour cette action')
         if self.definition_dict["entity_type"] not in DeleteAction.DELETABLE_TYPES:
             raise StepActionError(f"Type {self.definition_dict['entity_type']} non reconnu. Types valides : {', '.join(DeleteAction.DELETABLE_TYPES)}")
-        # Recherche de la/ les entité à supprimé
+        # Recherche de la/ les entité à supprimer
         l_entities = []
         if self.definition_dict.get("entity_id"):
             ## si id => on recherche directement
@@ -66,11 +66,11 @@ class DeleteAction(ActionAbstract):
             raise StepActionError('Il faut au moins une des clefs suivantes : "entity_id", "filter_infos", "filter_tags" pour cette action.')
 
         if len(l_entities) == 0 and not self.definition_dict.get("not_found_ok"):
-            raise StepActionError("Aucune entité trouvé pour la suppression")
+            raise StepActionError("Aucune entité trouvée pour la suppression")
         if len(l_entities) > 1:
             if self.definition_dict.get("if_multi") == "error":
                 # On sort en erreur
-                raise StepActionError(f"Plusieurs entités trouvé pour la suppression : {l_entities}")
+                raise StepActionError(f"Plusieurs entités trouvées pour la suppression : {l_entities}")
             if self.definition_dict.get("if_multi") == "first":
                 # on ne supprime que le 1er élément trouvé
                 l_entities = [l_entities[0]]

--- a/tests/workflow/action/DeleteActionTestCase.py
+++ b/tests/workflow/action/DeleteActionTestCase.py
@@ -57,7 +57,7 @@ class DeleteActionTestCase(GpfTestCase):
             with patch.object(c_classe, "api_list", return_value=[]) as o_mock_api_list:
                 with self.assertRaises(StepActionError) as o_err:
                     o_action_delete.run(s_datastore)
-            self.assertEqual("Aucune entité trouvé pour la suppression", o_err.exception.message)
+            self.assertEqual("Aucune entité trouvée pour la suppression", o_err.exception.message)
             o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
 
             # rien trouvé avec "entity_id"
@@ -66,7 +66,7 @@ class DeleteActionTestCase(GpfTestCase):
             with patch.object(c_classe, "api_get", side_effect=NotFoundError("", "", None, None, "")) as o_mock_api_list:
                 with self.assertRaises(StepActionError) as o_err:
                     o_action_delete.run(s_datastore)
-            self.assertEqual("Aucune entité trouvé pour la suppression", o_err.exception.message)
+            self.assertEqual("Aucune entité trouvée pour la suppression", o_err.exception.message)
             o_mock_api_list.assert_called_once_with(s_entity_id, datastore=s_datastore)
 
         d_action = {"type": "delete-entity", "entity_type": "offering", "filter_infos": {}, "if_multi": "error"}
@@ -75,7 +75,7 @@ class DeleteActionTestCase(GpfTestCase):
         with patch.object(Offering, "api_list", return_value=l_entities) as o_mock_api_list:
             with self.assertRaises(StepActionError) as o_err:
                 o_action_delete.run(s_datastore)
-        self.assertEqual(f"Plusieurs entités trouvé pour la suppression : {l_entities}", o_err.exception.message)
+        self.assertEqual(f"Plusieurs entités trouvées pour la suppression : {l_entities}", o_err.exception.message)
         o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
 
     def test_run_ok(self) -> None:  # pylint: disable=too-many-locals,too-many-statements

--- a/tests/workflow/action/DeleteActionTestCase.py
+++ b/tests/workflow/action/DeleteActionTestCase.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+# cSpell:ignore operateur
+
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+from sdk_entrepot_gpf.io.Errors import NotFoundError
+from sdk_entrepot_gpf.store.Offering import Offering
+from sdk_entrepot_gpf.store.Configuration import Configuration
+from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
+from sdk_entrepot_gpf.store.StoredData import StoredData
+from sdk_entrepot_gpf.store.Upload import Upload
+from sdk_entrepot_gpf.workflow.Errors import StepActionError
+from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
+
+from tests.GpfTestCase import GpfTestCase
+
+
+class DeleteActionTestCase(GpfTestCase):
+    """Tests DeleteAction class.
+
+    cmd : python3 -m unittest -b tests.workflow.action.DeleteActionTestCase
+    """
+
+    def test_run_ko(self) -> None:
+        """test pour la fonction run() sortie en erreur"""
+        s_datastore = "datastore"
+
+        # problème de avec le workflow : entity_type non présent
+        d_action: Dict[str, Any] = {"type": "delete-entity"}
+        o_action_delete = DeleteAction("contexte", d_action)
+        with self.assertRaises(StepActionError) as o_err:
+            o_action_delete.run()
+        self.assertEqual('La clef "entity_type" est obligatoire pour cette action', o_err.exception.message)
+
+        # problème de avec le workflow : entity_type non valide
+        d_action = {"type": "delete-entity", "entity_type": "non valide"}
+        o_action_delete = DeleteAction("contexte", d_action)
+        with self.assertRaises(StepActionError) as o_err:
+            o_action_delete.run()
+        self.assertEqual(f"Type {d_action['entity_type']} non reconnu. Types valides : {', '.join(DeleteAction.DELETABLE_TYPES)}", o_err.exception.message)
+
+        # problème de avec le workflow : il manque "entity_id", "filter_infos", "filter_tags"
+        d_action = {"type": "delete-entity", "entity_type": "offering"}
+        o_action_delete = DeleteAction("contexte", d_action)
+        with self.assertRaises(StepActionError) as o_err:
+            o_action_delete.run()
+        self.assertEqual('Il faut au moins une des clefs suivantes : "entity_id", "filter_infos", "filter_tags" pour cette action.', o_err.exception.message)
+
+        s_entity_id = "entity_id"
+        for c_classe in [Upload, StoredData, Configuration, Offering]:
+            print(c_classe.entity_name())
+            # rien trouvé avec les filtres
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "filter_infos": {}}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_list", return_value=[]) as o_mock_api_list:
+                with self.assertRaises(StepActionError) as o_err:
+                    o_action_delete.run(s_datastore)
+            self.assertEqual("Aucune entité trouvé pour la suppression", o_err.exception.message)
+            o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
+
+            # rien trouvé avec "entity_id"
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_get", side_effect=NotFoundError("", "", None, None, "")) as o_mock_api_list:
+                with self.assertRaises(StepActionError) as o_err:
+                    o_action_delete.run(s_datastore)
+            self.assertEqual("Aucune entité trouvé pour la suppression", o_err.exception.message)
+            o_mock_api_list.assert_called_once_with(s_entity_id, datastore=s_datastore)
+
+        d_action = {"type": "delete-entity", "entity_type": "offering", "filter_infos": {}, "if_multi": "error"}
+        o_action_delete = DeleteAction("contexte", d_action)
+        l_entities = [MagicMock(), MagicMock(), MagicMock()]
+        with patch.object(Offering, "api_list", return_value=l_entities) as o_mock_api_list:
+            with self.assertRaises(StepActionError) as o_err:
+                o_action_delete.run(s_datastore)
+        self.assertEqual(f"Plusieurs entités trouvé pour la suppression : {l_entities}", o_err.exception.message)
+        o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
+
+    def test_run_ok(self) -> None:  # pylint: disable=too-many-locals,too-many-statements
+        """test pour la fonction run() sortie sans erreur"""
+        s_datastore = "datastore"
+        s_entity_id = "entity_id"
+        for c_classe in [Upload, StoredData, Configuration, Offering]:
+            # Aucune entité mais c'est OK
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "filter_infos": {}, "if_multi": "error", "not_found_ok": True}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_list", return_value=[]) as o_mock_api_list:
+                with patch.object(StoreEntity, "delete_liste_entities", return_value=[]) as o_mock_delete:
+                    o_action_delete.run(s_datastore)
+            o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
+            o_mock_delete.assert_called_once_with([], DeleteAction.question_before_delete)
+
+            # suppression avec entity_id
+            o_entity = MagicMock()
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_list:
+                with patch.object(StoreEntity, "delete_liste_entities", return_value=[]) as o_mock_delete:
+                    o_action_delete.run(s_datastore)
+            o_mock_api_list.assert_called_once_with(s_entity_id, datastore=s_datastore)
+            o_mock_delete.assert_called_once_with([o_entity], DeleteAction.question_before_delete)
+            o_entity.get_liste_deletable_cascade.assert_not_called()
+
+            # suppression avec entity_id en cascade
+            o_entity = MagicMock()
+            l_cascade = [MagicMock(), MagicMock()]
+            o_entity.get_liste_deletable_cascade.return_value = l_cascade
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id, "cascade": True}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_list:
+                with patch.object(StoreEntity, "delete_liste_entities") as o_mock_delete:
+                    o_action_delete.run(s_datastore)
+            o_mock_api_list.assert_called_once_with(s_entity_id, datastore=s_datastore)
+            o_mock_delete.assert_called_once_with(l_cascade, DeleteAction.question_before_delete)
+            o_entity.get_liste_deletable_cascade.assert_called_once_with()
+
+            # suppression avec les filtres
+            o_entity_1 = MagicMock()
+            o_entity_2 = MagicMock()
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "filter_infos": {}}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_list", return_value=[o_entity_1, o_entity_2]) as o_mock_api_list:
+                with patch.object(StoreEntity, "delete_liste_entities", return_value=[]) as o_mock_delete:
+                    o_action_delete.run(s_datastore)
+            o_mock_delete.assert_called_once_with([o_entity_1, o_entity_2], DeleteAction.question_before_delete)
+            o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
+            o_entity_1.get_liste_deletable_cascade.assert_not_called()
+            o_entity_2.get_liste_deletable_cascade.assert_not_called()
+
+            # suppression avec les filtres cascade
+            o_entity_1 = MagicMock()
+            l_cascade = [MagicMock(), MagicMock()]
+            o_entity_1.get_liste_deletable_cascade.return_value = l_cascade
+            o_entity_2 = MagicMock()
+            o_entity_2.get_liste_deletable_cascade.return_value = l_cascade
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "filter_infos": {}, "cascade": True}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_list", return_value=[o_entity_1, o_entity_2]) as o_mock_api_list:
+                with patch.object(StoreEntity, "delete_liste_entities", return_value=[]) as o_mock_delete:
+                    o_action_delete.run(s_datastore)
+            o_mock_delete.assert_called_once_with(l_cascade * 2, DeleteAction.question_before_delete)
+            o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
+            o_entity_1.get_liste_deletable_cascade.assert_called_once_with()
+            o_entity_2.get_liste_deletable_cascade.assert_called_once_with()
+
+            # suppression avec les filtres avec "if_multi": "first"
+            o_entity_1 = MagicMock()
+            o_entity_2 = MagicMock()
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "filter_infos": {}, "if_multi": "first"}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_list", return_value=[o_entity_1, o_entity_2]) as o_mock_api_list:
+                with patch.object(StoreEntity, "delete_liste_entities", return_value=[]) as o_mock_delete:
+                    o_action_delete.run(s_datastore)
+            o_mock_delete.assert_called_once_with([o_entity_1], DeleteAction.question_before_delete)
+            o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
+            o_entity_1.get_liste_deletable_cascade.assert_not_called()
+            o_entity_2.get_liste_deletable_cascade.assert_not_called()


### PR DESCRIPTION
Développement pour #63 

supprimer dans un workflow une ou des entités de type  upload, stored_data, configuration et offering.
Le programme demandera la confirmation à l'utilisateur avant d'effectuer la suppression des entités.

Structure de l'action :

* suppression pas ID de l'entité
```jsonc
{
    "type": "delete-entity",
    // Type de l'entité à supprimer (upload, stored_data, configuration, offering)
    "entity_type": "configuration",
    // Id de l'entité à supprimer
    "entity_id": "{uuid}",
    // Suppression en cascade autorisée ou pas ? par défaut à false
    "cascade": true,
    // Ok si non trouvés ? par défaut à true
    "not_found_ok": true,
}
```
* suppression par filtre sur la liste
```jsonc
{
    "type": "delete-entity",
    // Type de l'entité à supprimer (upload, stored_data, configuration, offering)
    "entity_type": "configuration",
    // Critères pour filtrer filter_infos et/ou filter_tags
    "filter_infos": { ... },
    "filter_tags": { ... },
    // Suppression en cascade autorisée ou pas ? par défaut à false
    "cascade": true,
    // Ok si non trouvés ? par défaut à true
    "not_found_ok": true,
    // Que faire plusieurs résultats ?  first => uniquement 1er de la liste; all => on prend tout (défaut); error => sortie en erreur du programme 
    "if_multi": "first|all|error",
}
```
pour filter_infos voir les possibilité des fonction de liste des entités :

* upload: [/datastores/{datastore}/uploads](https://data.geopf.fr/api/swagger-ui/index.html#/Livraisons%20et%20v%C3%A9rifications/getAll_1)
* stored_data: [/datastores/{datastore}/stored_data](https://data.geopf.fr/api/swagger-ui/index.html#/Donn%C3%A9es%20stock%C3%A9es/getAll_2)
* configuration: [/datastores/{datastore}/configurations](https://data.geopf.fr/api/swagger-ui/index.html#/Configurations%20et%20publications/getAll_8)
* offering: [/datastores/{datastore}/offerings](https://data.geopf.fr/api/swagger-ui/index.html#/Configurations%20et%20publications/getAll_6)