### PR TITLE
Action SynchronizeOfferingAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### [Added]
 
+* ajout fonction Offering.api_synchronize() : synchronisation de l'offre avec la configuration
+* ajout de la fonction Offering.get_url() : récupération de la liste des url d'une offre
+* ajout de l'action `SynchronizeOfferingAction` : synchronisation de l'offre avec la configuration depuis un workflow
+
 ### [Changed]
 
 ### [Fixed]

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -119,6 +119,7 @@ offering_get=${offering_list}/{offering}
 offering_create=${configuration_list_offerings}
 offering_delete=${offering_get}
 offering_partial_edit=${offering_get}
+offering_synchronize=${offering_get}
 
 # Check
 check_list=${store_api:root_datastore}/checks

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -29,8 +29,7 @@
                                 "items": {
                                     "type": "object",
                                     "required": [
-                                        "type",
-                                        "body_parameters"
+                                        "type"
                                     ],
                                     "additionalProperties": false,
                                     "properties": {
@@ -60,6 +59,32 @@
                                         },
                                         "datastore": {
                                             "type": "string"
+                                        },
+                                        "entity_type": {
+                                            "type": "string"
+                                        },
+                                        "entity_id": {
+                                            "type": "string"
+                                        },
+                                        "filter_infos": {
+                                            "type": "object"
+                                        },
+                                        "filter_tags": {
+                                            "type": "object"
+                                        },
+                                        "cascade": {
+                                            "type": "boolean"
+                                        },
+                                        "not_found_ok": {
+                                            "type": "boolean"
+                                        },
+                                        "if_multi": {
+                                            "type": "string",
+                                            "enum": [
+                                                "first",
+                                                "all",
+                                                "error"
+                                            ]
                                         }
                                     }
                                 }

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -39,7 +39,8 @@
                                             "enum": [
                                                 "processing-execution",
                                                 "configuration",
-                                                "offering"
+                                                "offering",
+                                                "synchronize-offering"
                                             ]
                                         },
                                         "url_parameters": {

--- a/sdk_entrepot_gpf/store/Offering.py
+++ b/sdk_entrepot_gpf/store/Offering.py
@@ -2,6 +2,7 @@ import time
 from sdk_entrepot_gpf.io.Errors import NotFoundError
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.store.interface.PartialEditInterface import PartialEditInterface
+from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
 
 
 class Offering(PartialEditInterface, StoreEntity):
@@ -33,3 +34,14 @@ class Offering(PartialEditInterface, StoreEntity):
         except NotFoundError:
             # on a un 404 donc l'offre est bien supprimée
             return
+
+    def api_synchronize(self) -> None:
+        """répercuter des modifications sur la configuration ou les données stockées utilisées au niveau des services de diffusion"""
+        ApiRequester().route_request(
+            f"{self._entity_name}_synchronize",
+            method=ApiRequester.PUT,
+            route_params={self._entity_name: self.id, "datastore": self.datastore},
+        )
+
+        # Mise à jour du stockage local (_store_api_dict)
+        self.api_update()

--- a/sdk_entrepot_gpf/store/Offering.py
+++ b/sdk_entrepot_gpf/store/Offering.py
@@ -1,4 +1,5 @@
 import time
+from typing import List
 from sdk_entrepot_gpf.io.Errors import NotFoundError
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.store.interface.PartialEditInterface import PartialEditInterface
@@ -45,3 +46,15 @@ class Offering(PartialEditInterface, StoreEntity):
 
         # Mise à jour du stockage local (_store_api_dict)
         self.api_update()
+
+    def get_url(self) -> List[str]:
+        """récupération de la liste des URL
+
+        Returns:
+            List[str]: liste des URL
+        """
+        if len(self["urls"]) > 0 and isinstance(self["urls"][0], dict):
+            # si les url sont récupérées sous forme de dict on affiche l'url uniquement
+            return [str(d_url["url"]) for d_url in self["urls"]]
+        # directement sous forme de liste de texte
+        return [str(url) for url in self["urls"]]

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -13,6 +13,7 @@ from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
+from sdk_entrepot_gpf.workflow.action.SynchronizeOfferingAction import SynchronizeOfferingAction
 
 
 class Workflow:
@@ -247,6 +248,8 @@ class Workflow:
             return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "offering":
             return OfferingAction(workflow_context, definition_dict, parent_action, behavior=behavior)
+        if definition_dict["type"] == "synchronize-offering":
+            return SynchronizeOfferingAction(workflow_context, definition_dict, parent_action)
         raise WorkflowError(f"Aucune correspondance pour ce type d'action : {definition_dict['type']}")
 
     @staticmethod

--- a/sdk_entrepot_gpf/workflow/action/OfferingAction.py
+++ b/sdk_entrepot_gpf/workflow/action/OfferingAction.py
@@ -40,13 +40,7 @@ class OfferingAction(ActionAbstract):
 
         # Récupération des liens
         o_offering.api_update()
-        if len(o_offering["urls"]) > 0 and isinstance(o_offering["urls"][0], dict):
-            # si les url sont récupérées sous forme de dict on affiche l'url uniquement
-            s_urls = "\n   - ".join([d_url["url"] for d_url in o_offering["urls"]])
-        else:
-            # si les url sont récupérées sous forme de liste
-            s_urls = "\n   - ".join(o_offering["urls"])
-        Config().om.info(f"Offre créée : {self.__offering}\n   - {s_urls}", green_colored=True)
+        Config().om.info(f"Offre créée : {self.__offering}\n   - " + "\n   - ".join(o_offering.get_url()), green_colored=True)
         # vérification du status.
         Config().om.info("vérification du statut ...")
         while True:

--- a/sdk_entrepot_gpf/workflow/action/SynchronizeOfferingAction.py
+++ b/sdk_entrepot_gpf/workflow/action/SynchronizeOfferingAction.py
@@ -19,14 +19,14 @@ class SynchronizeOfferingAction(ActionAbstract):
     """
 
     def _find_offerings(self, datastore: Optional[str] = None) -> List[Offering]:
-        """recherche de la liste des offerings à traiter
+        """Recherche de la liste des offerings à traiter
 
         Args:
-            datastore (Optional[str], optional): Datastore à utilisé. Defaults to None.
+            datastore (Optional[str], optional): Datastore à utiliser. Defaults to None.
 
         Raises:
             StepActionError: Impossible de trouver l'offre (uniquement avec "entity_id")
-            StepActionError: Action mal paramétrer : il faut obligatoirement "entity_id" ou "filter_infos"
+            StepActionError: Action mal paramétrée : il faut obligatoirement "entity_id" ou "filter_infos"
 
         Returns:
             List[Offering]: Liste des offres à synchroniser
@@ -73,20 +73,20 @@ class SynchronizeOfferingAction(ActionAbstract):
             datastore (Optional[str], optional): surcharge du datastore, sinon utilisation de celui par défaut. Defaults to None.
 
         Raises:
-            StepActionError: Aucune offres trouvé pour la synchronisation
-            StepActionError: Plusieurs offres trouvé pour la synchronisation (uniquement si "if_multi" == "error")
-            StepActionError: La synchronisation d'au moins une offre est terminé en erreur
+            StepActionError: Aucune offre trouvée pour la synchronisation
+            StepActionError: Plusieurs offres trouvées pour la synchronisation (uniquement si "if_multi" == "error")
+            StepActionError: La synchronisation d'au moins une offre est terminée en erreur
         """
         Config().om.info("Synchronisation d'une offre...")
         # récupération des offres
         l_offering = self._find_offerings(datastore)
         # gestion des cas particuliers
         if len(l_offering) == 0:
-            raise StepActionError("Aucune offres trouvé pour la synchronisation")
+            raise StepActionError("Aucune offre trouvée pour la synchronisation")
         if len(l_offering) > 1:
             if self.definition_dict.get("if_multi") == "error":
                 # On sort en erreur
-                raise StepActionError(f"Plusieurs offres trouvé pour la synchronisation : {l_offering}")
+                raise StepActionError(f"Plusieurs offres trouvées pour la synchronisation : {l_offering}")
             if self.definition_dict.get("if_multi") == "first":
                 # on ne synchronise que le 1er élément trouvé
                 l_offering = [l_offering[0]]
@@ -101,7 +101,7 @@ class SynchronizeOfferingAction(ActionAbstract):
                 # synchronisation (l'offre met du temps à synchroniser donc on lance tout puis on fera le suivi)
                 o_offering.api_synchronize()
             except NotFoundError as e:
-                s_message = f"Impossible de trouvé l'offre {o_offering}. Elle a été supprimée ?"
+                s_message = f"Impossible de trouver l'offre {o_offering}. A-elle été supprimée ?"
                 Config().om.error(s_message)
                 Config().om.debug(str(e))
                 l_errors.append(s_message)
@@ -134,4 +134,4 @@ class SynchronizeOfferingAction(ActionAbstract):
                 Config().om.debug(f"Status : '{s_status}', on attend ...")
                 time.sleep(1)
         if l_errors:
-            raise StepActionError("La synchronisation d'au moins une offre est terminé en erreur \n * " + "\n * ".join(l_errors))
+            raise StepActionError("La synchronisation d'au moins une offre est terminée en erreur \n * " + "\n * ".join(l_errors))

--- a/sdk_entrepot_gpf/workflow/action/SynchronizeOfferingAction.py
+++ b/sdk_entrepot_gpf/workflow/action/SynchronizeOfferingAction.py
@@ -1,8 +1,8 @@
 import time
-from typing import Any, Dict, Optional
+from typing import List, Optional
 
-from sdk_entrepot_gpf.Errors import GpfSdkError
-from sdk_entrepot_gpf.io.Errors import NotFoundError
+from sdk_entrepot_gpf.io.Errors import ConflictError, NotFoundError
+from sdk_entrepot_gpf.store.Configuration import Configuration
 from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
@@ -10,56 +10,128 @@ from sdk_entrepot_gpf.io.Config import Config
 
 
 class SynchronizeOfferingAction(ActionAbstract):
-    """Classe dédiée à la création des Offering.
+    """Classe dédiée à la synchronization des Offering.
 
     Attributes:
         __workflow_context (str): nom du contexte du workflow
         __definition_dict (Dict[str, Any]): définition de l'action
         __parent_action (Optional["Action"]): action parente
-        __offering (Optional[Offering]): représentation Python de la Offering créée
     """
 
-    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None) -> None:
-        super().__init__(workflow_context, definition_dict, parent_action)
-        # Autres attributs
-        self.__offering: Optional[Offering] = None
+    def _find_offerings(self, datastore: Optional[str] = None) -> List[Offering]:
+        """recherche de la liste des offerings à traiter
+
+        Args:
+            datastore (Optional[str], optional): Datastore à utilisé. Defaults to None.
+
+        Raises:
+            StepActionError: Impossible de trouver l'offre (uniquement avec "entity_id")
+            StepActionError: Action mal paramétrer : il faut obligatoirement "entity_id" ou "filter_infos"
+
+        Returns:
+            List[Offering]: Liste des offres à synchroniser
+        """
+        l_offering = []
+        if self.definition_dict.get("entity_id"):
+            ## si id => on recherche directement
+            try:
+                l_offering.append(Offering.api_get(self.definition_dict["entity_id"], datastore=datastore))
+            except NotFoundError as e:
+                raise StepActionError(f"Impossible de trouver l'offre : {self.definition_dict['entity_id']}.") from e
+        elif "filter_infos" in self.definition_dict:
+            d_filter_infos = self.definition_dict["filter_infos"]
+            ## par liste des éléments
+            ####################################################################################################################
+            # solution temporaire en attendant que la liste des offres permette le filtrage que les configurations
+            if "configuration" in d_filter_infos:
+                # si on a configuration on recherche la configuration puis les filtres sur les offres lé à la configuration
+                o_config = Configuration.api_get(d_filter_infos["configuration"], datastore=datastore)
+                # trie selon les autre filtre possibles
+                l_stored_data = [d_data["stored_data"] for d_data in o_config["type_infos"]["used_data"]]
+                if d_filter_infos.get("stored_data", l_stored_data[0]) in l_stored_data:
+                    l_config_offering = o_config.api_list_offerings()
+                    for o_offering in l_config_offering:
+                        o_offering.api_update()
+                        if (
+                            d_filter_infos.get("type", o_offering["type"]) == o_offering["type"]
+                            and d_filter_infos.get("endpoint", o_offering["endpoint"]["_id"]) == o_offering["endpoint"]["_id"]
+                            and d_filter_infos.get("status", o_offering["status"]) == o_offering["status"]
+                        ):
+                            l_offering.append(o_offering)
+
+            ####################################################################################################################
+            else:
+                l_offering = Offering.api_list(d_filter_infos, datastore=datastore)
+        else:
+            raise StepActionError('Il faut L\'une des clefs suivantes : "entity_id" ou "filter_infos" pour cette action.')
+        return l_offering
 
     def run(self, datastore: Optional[str] = None) -> None:
+        """lancement de la synchronization des Offering.
+
+        Args:
+            datastore (Optional[str], optional): surcharge du datastore, sinon utilisation de celui par défaut. Defaults to None.
+
+        Raises:
+            StepActionError: Aucune offres trouvé pour la synchronisation
+            StepActionError: Plusieurs offres trouvé pour la synchronisation (uniquement si "if_multi" == "error")
+            StepActionError: La synchronisation d'au moins une offre est terminé en erreur
+        """
         Config().om.info("Synchronisation d'une offre...")
-        # récupération de l'offre
-        try:
-            self.__offering = Offering.api_get(self.definition_dict["url_parameters"]["offering"], datastore)
-        except NotFoundError as e:
-            # gestion du 404 not found
-            raise GpfSdkError(f"Impossible de trouver l'offre : {self.definition_dict['url_parameters']['offering']}.") from e
+        # récupération des offres
+        l_offering = self._find_offerings(datastore)
+        # gestion des cas particuliers
+        if len(l_offering) == 0:
+            raise StepActionError("Aucune offres trouvé pour la synchronisation")
+        if len(l_offering) > 1:
+            if self.definition_dict.get("if_multi") == "error":
+                # On sort en erreur
+                raise StepActionError(f"Plusieurs offres trouvé pour la synchronisation : {l_offering}")
+            if self.definition_dict.get("if_multi") == "first":
+                # on ne synchronise que le 1er élément trouvé
+                l_offering = [l_offering[0]]
+            # sinon  on les synchronise tous
 
-        # lancement de la mise à jour de l'offering
-        self.offering.api_synchronize()
-        # Affichage
-        o_offering = self.offering
+        l_errors: List[str] = []
+        # lancement de la synchronise des offering
+        Config().om.info(f"Synchronisation de {len(l_offering)} offres :\n * " + "\n * ".join([str(o_offering) for o_offering in l_offering]))
+        # on copie l_offering car on va enlever de la liste des offering si on a un problème
+        for o_offering in [*l_offering]:
+            try:
+                # synchronisation (l'offre met du temps à synchroniser donc on lance tout puis on fera le suivi)
+                o_offering.api_synchronize()
+            except NotFoundError as e:
+                s_message = f"Impossible de trouvé l'offre {o_offering}. Elle a été supprimée ?"
+                Config().om.error(s_message)
+                Config().om.debug(str(e))
+                l_errors.append(s_message)
+                l_offering.remove(o_offering)
+                print("-" * 500)
+            except ConflictError as e:
+                s_message = f"Problème lors de la synchronisation de {o_offering} : {e.message}"
+                Config().om.error(s_message)
+                Config().om.debug(str(e))
+                l_errors.append(s_message)
+                l_offering.remove(o_offering)
 
-        # Récupération des liens
-        if len(o_offering["urls"]) > 0 and isinstance(o_offering["urls"][0], dict):
-            # si les url sont récupérées sous forme de dict on affiche l'url uniquement
-            s_urls = "\n   - ".join([d_url["url"] for d_url in o_offering["urls"]])
-        else:
-            # si les url sont récupérées sous forme de liste
-            s_urls = "\n   - ".join(o_offering["urls"])
-        Config().om.info(f"Offre synchroniser : {o_offering}\n   - {s_urls}", green_colored=True)
-        # vérification du status.
-        Config().om.info("vérification du statut ...")
-        while True:
-            o_offering.api_update()
-            s_status = o_offering["status"]
-            if s_status == Offering.STATUS_PUBLISHED:
-                Config().om.info("Synchronisation d'une offre : terminé")
-                break
-            if s_status == Offering.STATUS_UNSTABLE:
-                raise StepActionError("Synchronisation d'une offre : terminé en erreur.")
-            # on fixe à 1 seconde, normalement quasiment instantané
-            Config().om.debug(f"Status : '{s_status}', on attend ...")
-            time.sleep(1)
-
-    @property
-    def offering(self) -> Optional[Offering]:
-        return self.__offering
+        # puis affichage et attente de la fin de la synchronisation
+        for o_offering in l_offering:
+            ## Récupération des liens
+            Config().om.info(f"Offre synchronisée : {o_offering}\n   - " + "\n   - ".join(o_offering.get_url()), green_colored=True)
+            ## vérification du status.
+            Config().om.info("vérification du statut ...")
+            while True:
+                o_offering.api_update()
+                s_status = o_offering["status"]
+                if s_status == Offering.STATUS_PUBLISHED:
+                    Config().om.info(f"Synchronisation de {o_offering} : terminé")
+                    break
+                if s_status == Offering.STATUS_UNSTABLE:
+                    Config().om.error(f"Synchronisation de {o_offering} : terminé en erreur.")
+                    l_errors.append(f"Synchronisation de {o_offering} : terminé en erreur.")
+                    break
+                # on fixe à 1 seconde, normalement quasiment instantané
+                Config().om.debug(f"Status : '{s_status}', on attend ...")
+                time.sleep(1)
+        if l_errors:
+            raise StepActionError("La synchronisation d'au moins une offre est terminé en erreur \n * " + "\n * ".join(l_errors))

--- a/sdk_entrepot_gpf/workflow/action/SynchronizeOfferingAction.py
+++ b/sdk_entrepot_gpf/workflow/action/SynchronizeOfferingAction.py
@@ -1,0 +1,65 @@
+import time
+from typing import Any, Dict, Optional
+
+from sdk_entrepot_gpf.Errors import GpfSdkError
+from sdk_entrepot_gpf.io.Errors import NotFoundError
+from sdk_entrepot_gpf.store.Offering import Offering
+from sdk_entrepot_gpf.workflow.Errors import StepActionError
+from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
+from sdk_entrepot_gpf.io.Config import Config
+
+
+class SynchronizeOfferingAction(ActionAbstract):
+    """Classe dédiée à la création des Offering.
+
+    Attributes:
+        __workflow_context (str): nom du contexte du workflow
+        __definition_dict (Dict[str, Any]): définition de l'action
+        __parent_action (Optional["Action"]): action parente
+        __offering (Optional[Offering]): représentation Python de la Offering créée
+    """
+
+    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None) -> None:
+        super().__init__(workflow_context, definition_dict, parent_action)
+        # Autres attributs
+        self.__offering: Optional[Offering] = None
+
+    def run(self, datastore: Optional[str] = None) -> None:
+        Config().om.info("Synchronisation d'une offre...")
+        # récupération de l'offre
+        try:
+            self.__offering = Offering.api_get(self.definition_dict["url_parameters"]["offering"], datastore)
+        except NotFoundError as e:
+            # gestion du 404 not found
+            raise GpfSdkError(f"Impossible de trouver l'offre : {self.definition_dict['url_parameters']['offering']}.") from e
+
+        # lancement de la mise à jour de l'offering
+        self.offering.api_synchronize()
+        # Affichage
+        o_offering = self.offering
+
+        # Récupération des liens
+        if len(o_offering["urls"]) > 0 and isinstance(o_offering["urls"][0], dict):
+            # si les url sont récupérées sous forme de dict on affiche l'url uniquement
+            s_urls = "\n   - ".join([d_url["url"] for d_url in o_offering["urls"]])
+        else:
+            # si les url sont récupérées sous forme de liste
+            s_urls = "\n   - ".join(o_offering["urls"])
+        Config().om.info(f"Offre synchroniser : {o_offering}\n   - {s_urls}", green_colored=True)
+        # vérification du status.
+        Config().om.info("vérification du statut ...")
+        while True:
+            o_offering.api_update()
+            s_status = o_offering["status"]
+            if s_status == Offering.STATUS_PUBLISHED:
+                Config().om.info("Synchronisation d'une offre : terminé")
+                break
+            if s_status == Offering.STATUS_UNSTABLE:
+                raise StepActionError("Synchronisation d'une offre : terminé en erreur.")
+            # on fixe à 1 seconde, normalement quasiment instantané
+            Config().om.debug(f"Status : '{s_status}', on attend ...")
+            time.sleep(1)
+
+    @property
+    def offering(self) -> Optional[Offering]:
+        return self.__offering

--- a/tests/store/OfferingTestCase.py
+++ b/tests/store/OfferingTestCase.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
+from sdk_entrepot_gpf.io.Errors import NotFoundError
+from sdk_entrepot_gpf.store.Offering import Offering
+from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
+from tests.GpfTestCase import GpfTestCase
+
+
+class OfferingTestCase(GpfTestCase):
+    """Tests Offering class.
+
+    cmd : python3 -m unittest -b tests.store.OfferingTestCase
+    """
+
+    def test_api_delete(self) -> None:
+        """Vérifie le bon fonctionnement de api_delete."""
+        with patch.object(StoreEntity, "api_delete", return_value=None) as o_mock_delete:
+            with patch.object(Offering, "api_update", side_effect=[None, None, NotFoundError("", "", {}, {}, "")]) as o_mock_update:
+                # on appelle la fonction à tester : api_abort
+                o_offering = Offering({"_id": "id_entité"})
+                o_offering.api_delete()
+
+        o_mock_delete.assert_called_once_with()
+        self.assertEqual(3, o_mock_update.call_count)
+
+    def test_api_synchronize(self) -> None:
+        """Vérifie le bon fonctionnement de api_synchronize."""
+        for s_datastore in [None, "datastore_offering"]:
+            # On mock la fonction route_request, on veut vérifier qu'elle est appelée avec les bons params
+            with patch.object(ApiRequester, "route_request", return_value=None) as o_mock_request:
+                with patch.object(Offering, "api_update", return_value=None) as o_mock_update:
+                    # on appelle la fonction à tester : api_abort
+                    o_offering = Offering({"_id": "id_entité"}, s_datastore)
+                    o_offering.api_synchronize()
+
+                    # on vérifie que route_request est appelé correctement
+                    o_mock_request.assert_called_once_with(
+                        "offering_synchronize",
+                        route_params={"offering": "id_entité", "datastore": s_datastore},
+                        method=ApiRequester.PUT,
+                    )
+                    o_mock_update.assert_called_once_with()
+
+    def test_get_url(self) -> None:
+        """Vérifie le bon fonctionnement de get_url."""
+        # urls sous forme de liste de string
+        o_offering = Offering({"_id": "id_entité", "urls": [f"url_{i}" for i in range(3)]})
+        l_url = o_offering.get_url()
+        self.assertListEqual([f"url_{i}" for i in range(3)], l_url)
+
+        # urls sous forme de liste de dict
+        o_offering = Offering({"_id": "id_entité", "urls": [{"url": f"url_{i}"} for i in range(3)]})
+        l_url = o_offering.get_url()
+        self.assertListEqual([f"url_{i}" for i in range(3)], l_url)

--- a/tests/workflow/action/SynchronizeOfferingActionTestCase.py
+++ b/tests/workflow/action/SynchronizeOfferingActionTestCase.py
@@ -115,7 +115,7 @@ class SynchronizeOfferingActionTestCase(GpfTestCase):
         with patch.object(SynchronizeOfferingAction, "_find_offerings", return_value=[]) as o_mock_find:
             with self.assertRaises(StepActionError) as o_err:
                 o_action.run(s_datastore)
-            self.assertEqual("Aucune offres trouvé pour la synchronisation", o_err.exception.message)
+            self.assertEqual("Aucune offre trouvée pour la synchronisation", o_err.exception.message)
             o_mock_find.assert_called_once_with(s_datastore)
 
         # plusieurs résultat et "if_multi" == "error"
@@ -125,7 +125,7 @@ class SynchronizeOfferingActionTestCase(GpfTestCase):
         with patch.object(SynchronizeOfferingAction, "_find_offerings", return_value=l_offering) as o_mock_find:
             with self.assertRaises(StepActionError) as o_err:
                 o_action.run(s_datastore)
-            self.assertEqual(f"Plusieurs offres trouvé pour la synchronisation : {l_offering}", o_err.exception.message)
+            self.assertEqual(f"Plusieurs offres trouvées pour la synchronisation : {l_offering}", o_err.exception.message)
             o_mock_find.assert_called_once_with(s_datastore)
 
         # Différentes erreurs lors de la synchronisation
@@ -142,7 +142,7 @@ class SynchronizeOfferingActionTestCase(GpfTestCase):
         o_mock_2 = MagicMock()
         o_mock_2.api_synchronize.side_effect = NotFoundError("", "", {}, {}, "erreur type NotFoundError")
         l_offering.append(o_mock_2)
-        l_errors.append(f"Impossible de trouvé l'offre {o_mock_2}. Elle a été supprimée ?")
+        l_errors.append(f"Impossible de trouver l'offre {o_mock_2}. A-elle été supprimée ?")
         # Offering.STATUS_UNSTABLE
         o_mock_3 = MagicMock()
         o_mock_3.api_synchronize.return_value = None
@@ -173,7 +173,7 @@ class SynchronizeOfferingActionTestCase(GpfTestCase):
         with patch.object(SynchronizeOfferingAction, "_find_offerings", return_value=l_offering) as o_mock_find:
             with self.assertRaises(StepActionError) as o_err:
                 o_action.run(s_datastore)
-            self.assertEqual("La synchronisation d'au moins une offre est terminé en erreur \n * " + "\n * ".join(l_errors), o_err.exception.message)
+            self.assertEqual("La synchronisation d'au moins une offre est terminée en erreur \n * " + "\n * ".join(l_errors), o_err.exception.message)
             o_mock_find.assert_called_once_with(s_datastore)
 
     def test_run_ok(self) -> None:

--- a/tests/workflow/action/SynchronizeOfferingActionTestCase.py
+++ b/tests/workflow/action/SynchronizeOfferingActionTestCase.py
@@ -1,0 +1,216 @@
+from typing import Any, Dict, List
+from unittest.mock import patch, MagicMock
+from sdk_entrepot_gpf.io.Errors import ConflictError, NotFoundError
+from sdk_entrepot_gpf.store.Configuration import Configuration
+from sdk_entrepot_gpf.store.Offering import Offering
+from sdk_entrepot_gpf.workflow.Errors import StepActionError
+
+from sdk_entrepot_gpf.workflow.action.SynchronizeOfferingAction import SynchronizeOfferingAction
+
+from tests.GpfTestCase import GpfTestCase
+
+
+class TestFind(SynchronizeOfferingAction):
+    """Fonction pour test de SynchronizeOfferingAction._find_offerings()"""
+
+    def find_offerings(self, datastore: str) -> List[Offering]:
+        """passe plat pour _find_offerings
+
+        Args:
+            datastore (str): datastore
+
+        Returns:
+            List[Offering]: sortie de _find_offerings
+        """
+        return self._find_offerings(datastore)
+
+
+class SynchronizeOfferingActionTestCase(GpfTestCase):
+    """Tests SynchronizeOfferingAction class.
+
+    cmd : python3 -m unittest -b tests.workflow.action.SynchronizeOfferingActionTestCase
+    """
+
+    def test__find_offerings(self) -> None:  # pylint: disable=too-many-locals,too-many-statements
+        """test de _find_offerings"""
+        # problème dans la définition de l'action
+        s_datastore = "datastore_run"
+        d_definition: Dict[str, Any] = {}
+        o_action = TestFind("base", d_definition)
+
+        with self.assertRaises(StepActionError) as o_err:
+            o_action.find_offerings(s_datastore)
+        self.assertEqual('Il faut L\'une des clefs suivantes : "entity_id" ou "filter_infos" pour cette action.', o_err.exception.message)
+
+        # Entité non trouvé avec l'id
+        d_definition = {"entity_id": "123"}
+        o_action = TestFind("base", d_definition)
+        with patch.object(Offering, "api_get", side_effect=NotFoundError("", "", {}, {}, "")) as o_mock_api_get:
+            with self.assertRaises(StepActionError) as o_err:
+                o_action.find_offerings(s_datastore)
+            self.assertEqual(f"Impossible de trouver l'offre : {d_definition['entity_id']}.", o_err.exception.message)
+            o_mock_api_get.assert_called_once_with(d_definition["entity_id"], datastore=s_datastore)
+
+        # entité trouvé par l'ID
+        o_mock_1 = MagicMock()
+        with patch.object(Offering, "api_get", return_value=o_mock_1) as o_mock_api_get:
+            l_offering = o_action.find_offerings(s_datastore)
+        self.assertListEqual([o_mock_1], l_offering)
+        o_mock_api_get.assert_called_once_with(d_definition["entity_id"], datastore=s_datastore)
+
+        # liste par Offering.api_list()
+        d_definition = {"filter_infos": {"key": "123"}}
+        o_action = TestFind("base", d_definition)
+        l_mock = [MagicMock() for i in range(3)]
+        with patch.object(Offering, "api_list", return_value=l_mock) as o_mock_api_list:
+            l_offering = o_action.find_offerings(s_datastore)
+        self.assertListEqual(l_mock, l_offering)
+        o_mock_api_list.assert_called_once_with(d_definition["filter_infos"], datastore=s_datastore)
+
+        d_config = {"type_infos": {"used_data": [{"stored_data": "1"}, {"stored_data": "2"}]}}
+        l_mock = [MagicMock() for i in range(3)]
+        o_mock_2 = MagicMock()
+        o_mock_2.api_list_offerings.return_value = l_mock
+        o_mock_2.__getitem__.side_effect = lambda key: d_config[key]
+        # liste par o_config.api_list_offerings
+        for d_definition in [{"filter_infos": {"configuration": "123"}}, {"filter_infos": {"configuration": "123", "stored_data": "2"}}]:
+            o_action = TestFind("base", d_definition)
+            with patch.object(Configuration, "api_get", return_value=o_mock_2) as o_mock_api_get:
+                l_offering = o_action.find_offerings(s_datastore)
+            self.assertListEqual(l_mock, l_offering)
+            o_mock_api_get.assert_called_once_with(d_definition["filter_infos"]["configuration"], datastore=s_datastore)
+            o_mock_2.api_list_offerings.assert_called_once_with()
+            o_mock_2.reset_mock()
+
+        # différents filtres
+        d_definition = {"filter_infos": {"configuration": "123", "stored_data": "2", "type": "a", "endpoint": "b", "status": "c"}}
+        o_action = TestFind("base", d_definition)
+        d_mock_offering = {"type": "a", "endpoint": {"_id": "b"}, "status": "c"}
+        o_mock_3 = MagicMock()
+        o_mock_3.__getitem__.side_effect = lambda key: d_mock_offering[key]
+        l_mock.append(o_mock_3)
+        with patch.object(Configuration, "api_get", return_value=o_mock_2) as o_mock_api_get:
+            l_offering = o_action.find_offerings(s_datastore)
+        self.assertListEqual([o_mock_3], l_offering)
+        o_mock_api_get.assert_called_once_with(d_definition["filter_infos"]["configuration"], datastore=s_datastore)
+        o_mock_2.api_list_offerings.assert_called_once_with()
+
+        # vide car stored_data différent de celle de config
+        d_definition = {"filter_infos": {"configuration": "123", "stored_data": "incompatible"}}
+        o_action = TestFind("base", d_definition)
+        o_mock_2.reset_mock()
+        with patch.object(Configuration, "api_get", return_value=o_mock_2) as o_mock_api_get:
+            l_offering = o_action.find_offerings(s_datastore)
+        self.assertListEqual([], l_offering)
+        o_mock_api_get.assert_called_once_with(d_definition["filter_infos"]["configuration"], datastore=s_datastore)
+        o_mock_2.api_list_offerings.assert_not_called()
+
+    def test_run_ko(self) -> None:
+        """test de run en erreur"""
+        s_datastore = "datastore_run"
+
+        # Liste vide
+        d_definition: Dict[str, Any] = {"filter_infos": {"test": "123"}}
+        o_action = SynchronizeOfferingAction("base", d_definition)
+        with patch.object(SynchronizeOfferingAction, "_find_offerings", return_value=[]) as o_mock_find:
+            with self.assertRaises(StepActionError) as o_err:
+                o_action.run(s_datastore)
+            self.assertEqual("Aucune offres trouvé pour la synchronisation", o_err.exception.message)
+            o_mock_find.assert_called_once_with(s_datastore)
+
+        # plusieurs résultat et "if_multi" == "error"
+        d_definition = {"filter_infos": {"test": "123"}, "if_multi": "error"}
+        l_offering = [MagicMock(), MagicMock()]
+        o_action = SynchronizeOfferingAction("base", d_definition)
+        with patch.object(SynchronizeOfferingAction, "_find_offerings", return_value=l_offering) as o_mock_find:
+            with self.assertRaises(StepActionError) as o_err:
+                o_action.run(s_datastore)
+            self.assertEqual(f"Plusieurs offres trouvé pour la synchronisation : {l_offering}", o_err.exception.message)
+            o_mock_find.assert_called_once_with(s_datastore)
+
+        # Différentes erreurs lors de la synchronisation
+        d_definition = {"filter_infos": {"test": "123"}}
+        l_offering = []
+        l_errors = []
+        ## api_synchronize => ConflictError
+        o_mock_1 = MagicMock()
+        e_conflict = ConflictError("", "", {}, {}, "erreur type ConflictError")
+        o_mock_1.api_synchronize.side_effect = e_conflict
+        l_offering.append(o_mock_1)
+        l_errors.append(f"Problème lors de la synchronisation de {o_mock_1} : {e_conflict.message}")
+        ## api_synchronize => NotFoundError
+        o_mock_2 = MagicMock()
+        o_mock_2.api_synchronize.side_effect = NotFoundError("", "", {}, {}, "erreur type NotFoundError")
+        l_offering.append(o_mock_2)
+        l_errors.append(f"Impossible de trouvé l'offre {o_mock_2}. Elle a été supprimée ?")
+        # Offering.STATUS_UNSTABLE
+        o_mock_3 = MagicMock()
+        o_mock_3.api_synchronize.return_value = None
+        o_mock_3.api_update.return_value = None
+        i = -1
+
+        def side_effect_getitem(key: str) -> str:
+            """fonction pour le side effect de o_mock_3.__getitem__
+
+            Args:
+                key (str): clef
+
+            Returns:
+                str: valeur
+            """
+            # récupération de 'i' dans la fonction mère
+            nonlocal i
+            if key == "status":
+                i = i + 1
+                return ["non", "non", Offering.STATUS_UNSTABLE][i]
+            return key
+
+        o_mock_3.__getitem__.side_effect = side_effect_getitem
+        l_offering.append(o_mock_3)
+        l_errors.append(f"Synchronisation de {o_mock_3} : terminé en erreur.")
+
+        o_action = SynchronizeOfferingAction("base", d_definition)
+        with patch.object(SynchronizeOfferingAction, "_find_offerings", return_value=l_offering) as o_mock_find:
+            with self.assertRaises(StepActionError) as o_err:
+                o_action.run(s_datastore)
+            self.assertEqual("La synchronisation d'au moins une offre est terminé en erreur \n * " + "\n * ".join(l_errors), o_err.exception.message)
+            o_mock_find.assert_called_once_with(s_datastore)
+
+    def test_run_ok(self) -> None:
+        """test de run OK"""
+        s_datastore = "datastore_run"
+
+        # OK multiple
+        l_mock = []
+        d_mock = {"status": Offering.STATUS_PUBLISHED}
+        for i in range(3):
+            o_mock = MagicMock()
+            o_mock.__getitem__.side_effect = lambda key: d_mock[key]
+            o_mock.get_url.return_value = [f"url {i}"]
+            l_mock.append(o_mock)
+
+        d_definition: Dict[str, Any] = {"filter_infos": {"test": "123"}}
+        o_action = SynchronizeOfferingAction("base", d_definition)
+        with patch.object(SynchronizeOfferingAction, "_find_offerings", return_value=l_mock) as o_mock_find:
+            o_action.run(s_datastore)
+            o_mock_find.assert_called_once_with(s_datastore)
+        for o_mock in l_mock:
+            o_mock.get_url.assert_called_once_with()
+            o_mock.__getitem__.assert_called_once_with("status")
+            o_mock.reset_mock()
+
+        # OK multiple + "if_multi" == "first"
+        d_definition = {"filter_infos": {"test": "123"}, "if_multi": "first"}
+        o_action = SynchronizeOfferingAction("base", d_definition)
+        with patch.object(SynchronizeOfferingAction, "_find_offerings", return_value=l_mock) as o_mock_find:
+            o_action.run(s_datastore)
+            o_mock_find.assert_called_once_with(s_datastore)
+        ## premier élément appeler
+        l_mock[0].get_url.assert_called_once_with()
+        l_mock[0].__getitem__.assert_called_once_with("status")
+        l_mock[0].reset_mock()
+        ## autres non
+        for o_mock in l_mock[1:]:
+            o_mock.get_url.assert_not_called()
+            o_mock.__getitem__.assert_not_called()
+            # o_mock.reset_mock()


### PR DESCRIPTION
Développement suite à la demande #58 
Ajout de l'action `SynchronizeOfferingAction` pour la synchronisation de l'offre avec la configuration depuis un workflow.

## [Added]

* ajout fonction Offering.api_synchronize() : synchronisation de l'offre avec la configuration
* ajout de la fonction Offering.get_url() : récupération de la liste des url d'une offre
* ajout de l'action `SynchronizeOfferingAction` : synchronisation de l'offre avec la configuration depuis un workflow