### PR TITLE
Action delete: question confirmation optionel

### DIFF
--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -86,6 +86,9 @@
                                                 "all",
                                                 "error"
                                             ]
+                                        },
+                                        "confirm": {
+                                            "type": "boolean"
                                         }
                                     }
                                 }

--- a/sdk_entrepot_gpf/workflow/action/DeleteAction.py
+++ b/sdk_entrepot_gpf/workflow/action/DeleteAction.py
@@ -46,13 +46,13 @@ class DeleteAction(ActionAbstract):
 
     @staticmethod
     def print_before_delete(l_delete: List[StoreEntity]) -> List[StoreEntity]:
-        """affichage avant que la suppression soit effectuée
+        """Affichage avant que la suppression soit effectuée
 
         Args:
-            l_delete (List[StoreEntity]): liste des entités à supprimé
+            l_delete (List[StoreEntity]): liste des entités à supprimer
 
         Returns:
-            List[StoreEntity]: liste final des entités à supprimé
+            List[StoreEntity]: liste finale des entités à supprimer
         """
         Config().om.info("suppression de :")
         for o_entity in l_delete:

--- a/sdk_entrepot_gpf/workflow/action/DeleteAction.py
+++ b/sdk_entrepot_gpf/workflow/action/DeleteAction.py
@@ -13,7 +13,7 @@ from sdk_entrepot_gpf.workflow.Errors import StepActionError
 
 
 class DeleteAction(ActionAbstract):
-    """Classe dédiée à la création des Offering.
+    """Classe dédiée à la suppression des entités.
 
     Attributes:
         __workflow_context (str): nom du contexte du workflow

--- a/sdk_entrepot_gpf/workflow/action/DeleteAction.py
+++ b/sdk_entrepot_gpf/workflow/action/DeleteAction.py
@@ -44,6 +44,21 @@ class DeleteAction(ActionAbstract):
             return []
         return l_delete
 
+    @staticmethod
+    def print_before_delete(l_delete: List[StoreEntity]) -> List[StoreEntity]:
+        """affichage avant que la suppression soit effectuée
+
+        Args:
+            l_delete (List[StoreEntity]): liste des entités à supprimé
+
+        Returns:
+            List[StoreEntity]: liste final des entités à supprimé
+        """
+        Config().om.info("suppression de :")
+        for o_entity in l_delete:
+            Config().om.info(str(o_entity), green_colored=True)
+        return l_delete
+
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Suppression...")
         if "entity_type" not in self.definition_dict:
@@ -57,7 +72,6 @@ class DeleteAction(ActionAbstract):
             try:
                 l_entities.append(store.TYPE__ENTITY[self.definition_dict["entity_type"]].api_get(self.definition_dict["entity_id"], datastore=datastore))
             except NotFoundError:
-                # sera gérer plus bas
                 pass
         elif "filter_infos" in self.definition_dict or "filter_tags" in self.definition_dict:
             ## par liste des éléments
@@ -76,13 +90,16 @@ class DeleteAction(ActionAbstract):
                 l_entities = [l_entities[0]]
             # on les supprimera tous
 
-        # suppression
-        if self.definition_dict.get("cascade"):
+        # récupération des entités en cascades si demandé
+        if self.definition_dict.get("cascade", False):
             Config().om.info("Suppression en cascade, recherche des entités à supprimer ...")
             l_entities_cascade = []
-            ## suppression des entités en cascades
             for o_entity in l_entities:
                 l_entities_cascade += o_entity.get_liste_deletable_cascade()
             l_entities = l_entities_cascade
-        ## suppression
-        StoreEntity.delete_liste_entities(l_entities, self.question_before_delete)
+
+        # choix de la fonction d'affichage.
+        o_before_delete = self.question_before_delete if self.definition_dict.get("confirm", True) else self.print_before_delete
+
+        # suppression
+        StoreEntity.delete_liste_entities(l_entities, o_before_delete)

--- a/tests/workflow/action/DeleteActionTestCase.py
+++ b/tests/workflow/action/DeleteActionTestCase.py
@@ -2,7 +2,7 @@
 
 # cSpell:ignore operateur
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
 
 from sdk_entrepot_gpf.io.Errors import NotFoundError
@@ -157,3 +157,35 @@ class DeleteActionTestCase(GpfTestCase):
             o_mock_api_list.assert_called_once_with(d_action.get("filter_infos"), d_action.get("filter_infos"), datastore=s_datastore)
             o_entity_1.get_liste_deletable_cascade.assert_not_called()
             o_entity_2.get_liste_deletable_cascade.assert_not_called()
+
+            # suppression avec entity_id
+            o_entity = MagicMock()
+            d_action = {"type": "delete-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id, "confirm": False}
+            o_action_delete = DeleteAction("contexte", d_action)
+            with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_list:
+                with patch.object(StoreEntity, "delete_liste_entities", return_value=[]) as o_mock_delete:
+                    o_action_delete.run(s_datastore)
+            o_mock_api_list.assert_called_once_with(s_entity_id, datastore=s_datastore)
+            o_mock_delete.assert_called_once_with([o_entity], DeleteAction.print_before_delete)
+            o_entity.get_liste_deletable_cascade.assert_not_called()
+
+    def test_question_before_delete(self) -> None:
+        """test de question_before_delete"""
+        # on force le type pour pylint
+        l_entity: List[StoreEntity] = [MagicMock(spec=StoreEntity), MagicMock(spec=StoreEntity)]
+        # réponse oui
+        with patch("builtins.input", lambda: "o"):
+            l_res = DeleteAction.question_before_delete(l_entity)
+        self.assertListEqual(l_entity, l_res)
+
+        # réponse non
+        with patch("builtins.input", lambda: "n"):
+            l_res = DeleteAction.question_before_delete(l_entity)
+        self.assertListEqual([], l_res)
+
+    def test_print_before_delete(self) -> None:
+        """test de print_before_delete"""
+        # on force le type pour pylint
+        l_entity: List[StoreEntity] = [MagicMock(), MagicMock()]
+        l_res = DeleteAction.print_before_delete(l_entity)
+        self.assertListEqual(l_entity, l_res)


### PR DESCRIPTION
Ajoute d'un paramètre  `"confirm": true` pour rendre optionnel la question confirmation avant suppression.
Main.delete() : utilisation de DeleteAction