### PR TITLE
Action edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### [Added]
 
-* DeleteAction : suppression des upload, stored_data, configuration et offering dans un workflow # 63
+* DeleteAction : suppression des upload, stored_data, configuration et offering dans un workflow #63
 * EditAction : édition(modification) des upload, stored_data, configuration et offering dans un workflow (entité + tags + commentaires) #66
 * Offering #58 :
     * ajout fonction Offering.api_synchronize() : synchronisation de l'offre avec la configuration
@@ -15,7 +15,7 @@
 
 * Workflow : ajout des actions DeleteAction, EditAction, SynchronizeOfferingAction
 * StoreEntity: ajout de `edit()` permettant de gérer l'édition des entités si possible. Ici impossible de mettre à jour les entités.
-* PartialEditInterface: surcharge de `edit()` pour permettre l’édition partiel
+* PartialEditInterface: surcharge de `edit()` pour permettre l’édition partielle
 * FullEditInterface: surcharge de `edit()` pour permettre l’édition complète
 
 ### [Fixed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@
 
 ### [Added]
 
-* DeleteAction : suppression des upload, stored_data, configuration et offering dans un workflow
-* Offering :
+* DeleteAction : suppression des upload, stored_data, configuration et offering dans un workflow # 63
+* EditAction : édition(modification) des upload, stored_data, configuration et offering dans un workflow (entité + tags + commentaires) #66
+* Offering #58 :
     * ajout fonction Offering.api_synchronize() : synchronisation de l'offre avec la configuration
     * ajout de la fonction Offering.get_url() : récupération de la liste des urls d'une offre
     * ajout de l'action `SynchronizeOfferingAction` : synchronisation de l'offre avec la configuration depuis un workflow
 
 ### [Changed]
+
+* Workflow : ajout des actions DeleteAction, EditAction, SynchronizeOfferingAction
+* StoreEntity: ajout de `edit()` permettant de gérer l'édition des entités si possible. Ici impossible de mettre à jour les entités.
+* PartialEditInterface: surcharge de `edit()` pour permettre l’édition partiel
+* FullEditInterface: surcharge de `edit()` pour permettre l’édition complète
 
 ### [Fixed]
 

--- a/sdk_entrepot_gpf/store/StoreEntity.py
+++ b/sdk_entrepot_gpf/store/StoreEntity.py
@@ -290,7 +290,7 @@ class StoreEntity(ABC):
             data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
         """
 
-        raise StoreEntityError("Il est impossible de mettre à jour cette entité")
+        raise StoreEntityError("Il est impossible d'éditer cette entité.")
 
     ##############################################################
     # Récupération du JSON

--- a/sdk_entrepot_gpf/store/StoreEntity.py
+++ b/sdk_entrepot_gpf/store/StoreEntity.py
@@ -283,6 +283,15 @@ class StoreEntity(ABC):
             time.sleep(1)
         Config().om.info("Suppression effectuée.", green_colored=True)
 
+    def edit(self, data_edit: Dict[str, Any]) -> None:
+        """Mise à jour de l'entité
+
+        Args:
+            data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
+        """
+
+        raise StoreEntityError("Il est impossible de mettre à jour cette entité")
+
     ##############################################################
     # Récupération du JSON
     ##############################################################

--- a/sdk_entrepot_gpf/store/interface/FullEditInterface.py
+++ b/sdk_entrepot_gpf/store/interface/FullEditInterface.py
@@ -30,6 +30,6 @@ class FullEditInterface(StoreEntity):
             data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
         """
         # fusion des dictionnaire actuelle et nouveau
-        d_data = {**data_edit, **self.get_store_properties()}
+        d_data = {**self.get_store_properties(), **data_edit}
 
         self.api_full_edit(d_data)

--- a/sdk_entrepot_gpf/store/interface/FullEditInterface.py
+++ b/sdk_entrepot_gpf/store/interface/FullEditInterface.py
@@ -24,12 +24,12 @@ class FullEditInterface(StoreEntity):
         self.api_update()
 
     def edit(self, data_edit: Dict[str, Any]) -> None:
-        """Mise à jour totale de l'entité
+        """Mise à jour totale de l'entité en fusionnant le nouveau dictionnaire (prioritaire) et l'ancien.
 
         Args:
             data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
         """
-        # fusion des dictionnaire actuelle et nouveau
+        # fusion des dictionnaires actuel et nouveau (prioritaire)
         d_data = {**self.get_store_properties(), **data_edit}
 
         self.api_full_edit(d_data)

--- a/sdk_entrepot_gpf/store/interface/FullEditInterface.py
+++ b/sdk_entrepot_gpf/store/interface/FullEditInterface.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any, Dict
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
 
@@ -22,3 +22,14 @@ class FullEditInterface(StoreEntity):
 
         # Mise à jour du stockage local (_store_api_dict)
         self.api_update()
+
+    def edit(self, data_edit: Dict[str, Any]) -> None:
+        """Mise à jour totale de l'entité
+
+        Args:
+            data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
+        """
+        # fusion des dictionnaire actuelle et nouveau
+        d_data = {**data_edit, **self.get_store_properties()}
+
+        self.api_full_edit(d_data)

--- a/sdk_entrepot_gpf/store/interface/PartialEditInterface.py
+++ b/sdk_entrepot_gpf/store/interface/PartialEditInterface.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any, Dict
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
 
@@ -22,3 +22,11 @@ class PartialEditInterface(StoreEntity):
 
         # Mise à jour du stockage local (_store_api_dict)
         self.api_update()
+
+    def edit(self, data_edit: Dict[str, Any]) -> None:
+        """Mise à jour partiel de l'entité
+
+        Args:
+            data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
+        """
+        self.api_partial_edit(data_edit)

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -11,6 +11,7 @@ from sdk_entrepot_gpf.workflow.Errors import WorkflowError
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
+from sdk_entrepot_gpf.workflow.action.EditAction import EditAction
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
@@ -253,6 +254,8 @@ class Workflow:
             return OfferingAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "synchronize-offering":
             return SynchronizeOfferingAction(workflow_context, definition_dict, parent_action)
+        if definition_dict["type"] == "edit-entity":
+            return EditAction(workflow_context, definition_dict, parent_action)
         raise WorkflowError(f"Aucune correspondance pour ce type d'action : {definition_dict['type']}")
 
     @staticmethod

--- a/sdk_entrepot_gpf/workflow/action/EditAction.py
+++ b/sdk_entrepot_gpf/workflow/action/EditAction.py
@@ -51,4 +51,4 @@ class EditAction(ActionAbstract):
                 # si le commentaire n'existe pas déjà on l'ajoute
                 if s_comment not in l_actual_comments:
                     o_entity.api_add_comment({"text": s_comment})
-            Config().om.info(f"les {len(self.definition_dict['comments'])} commentaires ont été ajoutés avec succès.")
+            Config().om.info(f"Les {len(self.definition_dict['comments'])} commentaires ont été ajoutés avec succès.")

--- a/sdk_entrepot_gpf/workflow/action/UpdateAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UpdateAction.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from sdk_entrepot_gpf.store.Configuration import Configuration
+from sdk_entrepot_gpf.store.Offering import Offering
+from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
+from sdk_entrepot_gpf.store.StoredData import StoredData
+from sdk_entrepot_gpf.store.Upload import Upload
+from sdk_entrepot_gpf.store.interface.CommentInterface import CommentInterface
+from sdk_entrepot_gpf.store.interface.TagInterface import TagInterface
+from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
+from sdk_entrepot_gpf.io.Config import Config
+from sdk_entrepot_gpf import store
+from sdk_entrepot_gpf.workflow.Errors import StepActionError
+
+
+class UpdateAction(ActionAbstract):
+    """Classe dédiée à la Mise à jour des entités.
+
+    Attributes:
+        __workflow_context (str): nom du contexte du workflow
+        __definition_dict (Dict[str, Any]): définition de l'action
+        __parent_action (Optional["Action"]): action parente
+    """
+
+    UPDATABLE_TYPES = [Upload.entity_name(), StoredData.entity_name(), Configuration.entity_name(), Offering.entity_name()]
+
+    def run(self, datastore: Optional[str] = None) -> None:
+        Config().om.info("Suppression...")
+        if "entity_type" not in self.definition_dict:
+            raise StepActionError('La clef "entity_type" est obligatoire pour cette action')
+        if self.definition_dict["entity_type"] not in UpdateAction.UPDATABLE_TYPES:
+            raise StepActionError(f"Type {self.definition_dict['entity_type']} non reconnu. Types valides : {', '.join(UpdateAction.UPDATABLE_TYPES)}")
+        if not self.definition_dict.get("entity_id"):
+            raise StepActionError('La clef "entity_id" est obligatoire pour cette action.')
+        o_entity: StoreEntity = store.TYPE__ENTITY[self.definition_dict["entity_type"]].api_get(self.definition_dict["entity_id"], datastore=datastore)
+
+        # Lancement de la mise à jour si demandé
+        if self.definition_dict.get("body_parameters"):
+            o_entity.edit(self.definition_dict["body_parameters"])
+
+        # ajout des tags si possible
+        if self.definition_dict.get("tags") and isinstance(o_entity, TagInterface):
+            o_entity.api_add_tags(self.definition_dict["tags"])
+        # ajout des commentaires si possible
+        if self.definition_dict.get("comments") and isinstance(o_entity, CommentInterface):
+            o_entity.api_add_comment(self.definition_dict["comments"])

--- a/tests/store/StoreEntityTestCase.py
+++ b/tests/store/StoreEntityTestCase.py
@@ -464,3 +464,10 @@ class StoreEntityTestCase(GpfTestCase):
             o_mock_3.api_delete.assert_not_called()
             self.assertEqual(0, o_mock_sleep.call_count)
             reset_mock()
+
+    def test_edit(self) -> None:
+        """test de edit"""
+        o_store_entity = StoreEntity({"_id": "1"})
+        with self.assertRaises(StoreEntityError) as o_arc:
+            o_store_entity.edit({"key": "val"})
+        self.assertEqual("Il est impossible d'éditer cette entité.", o_arc.exception.message)

--- a/tests/store/interface/FullEditInterfaceTestCase.py
+++ b/tests/store/interface/FullEditInterfaceTestCase.py
@@ -45,3 +45,16 @@ class FullEditInterfaceTestCase(GpfTestCase):
                     data=d_full_modified_api_data,
                 )
                 o_mock_update.assert_called_once_with()
+
+    def test_edit(self) -> None:
+        """test de edit"""
+        d_edit = {"key": "val", "comm_key": "edit"}
+        d_entity = {"_id": "1", "comm_key": "origine"}
+        d_fusion = {**d_entity, **d_edit}
+
+        print(d_fusion)
+
+        o_entity = FullEditInterface({"_id": "1"})
+        with patch.object(FullEditInterface, "api_full_edit", return_value=None) as o_mock_api_edit:
+            o_entity.edit(d_edit)
+            o_mock_api_edit.assert_called_once_with(d_fusion)

--- a/tests/store/interface/PartialEditInterfaceTestCase.py
+++ b/tests/store/interface/PartialEditInterfaceTestCase.py
@@ -44,3 +44,11 @@ class PartialEditInterfaceTestCase(GpfTestCase):
                     data=d_partly_modified_api_data,
                 )
                 o_mock_update.assert_called_once_with()
+
+    def test_edit(self) -> None:
+        """test de edit"""
+        d_edit = {"key": "val"}
+        o_entity = PartialEditInterface({"_id": "1"})
+        with patch.object(PartialEditInterface, "api_partial_edit", return_value=None) as o_mock_api_edit:
+            o_entity.edit(d_edit)
+            o_mock_api_edit.assert_called_once_with(d_edit)

--- a/tests/workflow/action/EditActionTestCase.py
+++ b/tests/workflow/action/EditActionTestCase.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# cSpell:ignore operateur
+
+from typing import Any, Dict
+from unittest.mock import MagicMock, call, patch
+from sdk_entrepot_gpf.store.Configuration import Configuration
+from sdk_entrepot_gpf.store.Offering import Offering
+from sdk_entrepot_gpf.store.StoredData import StoredData
+from sdk_entrepot_gpf.store.Upload import Upload
+from sdk_entrepot_gpf.store.interface.TagInterface import TagInterface
+from sdk_entrepot_gpf.store.interface.CommentInterface import CommentInterface
+from sdk_entrepot_gpf.workflow.Errors import StepActionError
+from sdk_entrepot_gpf.workflow.action.EditAction import EditAction
+
+from tests.GpfTestCase import GpfTestCase
+
+
+class EditActionTestCase(GpfTestCase):
+    """Tests EditAction class.
+
+    cmd : python3 -m unittest -b tests.workflow.action.EditActionTestCase
+    """
+
+    def test_run_ko(self) -> None:
+        """test pour la fonction run() sortie en erreur"""
+        s_datastore = "datastore"
+
+        # problème de avec le workflow : entity_type non présent
+        d_action: Dict[str, Any] = {"type": "edit-entity"}
+        o_action_delete = EditAction("contexte", d_action)
+        with self.assertRaises(StepActionError) as o_err:
+            o_action_delete.run(s_datastore)
+        self.assertEqual('La clef "entity_type" est obligatoire pour cette action', o_err.exception.message)
+
+        # problème de avec le workflow : entity_type non valide
+        d_action = {"type": "edit-entity", "entity_type": "non valide"}
+        o_action_delete = EditAction("contexte", d_action)
+        with self.assertRaises(StepActionError) as o_err:
+            o_action_delete.run(s_datastore)
+        self.assertEqual(f"Type {d_action['entity_type']} non reconnu. Types valides : {', '.join(EditAction.UPDATABLE_TYPES)}", o_err.exception.message)
+
+        # problème de avec le workflow : entity_type non valide
+        d_action = {"type": "edit-entity", "entity_type": "offering"}
+        o_action_delete = EditAction("contexte", d_action)
+        with self.assertRaises(StepActionError) as o_err:
+            o_action_delete.run(s_datastore)
+        self.assertEqual('La clef "entity_id" est obligatoire pour cette action.', o_err.exception.message)
+
+    def test_run_ok(self) -> None:  # pylint: disable=too-many-locals,too-many-statements
+        """test pour la fonction run() sortie sans erreur"""
+        s_datastore = "datastore"
+        s_entity_id = "entity_id"
+        for c_classe in [Upload, StoredData, Configuration, Offering]:
+            # ne fait rien
+            o_entity = MagicMock(spec=c_classe)
+            d_action: Dict[str, Any] = {"type": "edit-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id}
+            o_action_delete = EditAction("contexte", d_action)
+            with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
+                o_action_delete.run(s_datastore)
+            o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
+            o_entity.edit.assert_not_called()
+            if isinstance(o_entity, TagInterface):
+                o_entity.api_add_tags.assert_not_called()
+            if isinstance(o_entity, CommentInterface):
+                o_entity.api_add_comment.assert_not_called()
+
+            # edition entity seule
+            o_entity = MagicMock(spec=c_classe)
+            d_action = {"type": "edit-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id, "body_parameters": {"key": "val"}}
+            o_action_delete = EditAction("contexte", d_action)
+            with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
+                o_action_delete.run(s_datastore)
+            o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
+            o_entity.edit.assert_called_once_with(d_action["body_parameters"])
+            if isinstance(o_entity, TagInterface):
+                o_entity.api_add_tags.assert_not_called()
+            if isinstance(o_entity, CommentInterface):
+                o_entity.api_add_comment.assert_not_called()
+
+            # edition entity + comments + tags
+            o_entity = MagicMock(spec=c_classe)
+            d_action = {
+                "type": "edit-entity",
+                "entity_type": c_classe.entity_name(),
+                "entity_id": s_entity_id,
+                "body_parameters": {"key": "val"},
+                "tags": {"key1": "val1", "key2": "val2"},
+                "comments": ["comm1", "comm2"],
+            }
+            o_action_delete = EditAction("contexte", d_action)
+            with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
+                o_action_delete.run(s_datastore)
+            o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
+            o_entity.edit.assert_called_once_with(d_action["body_parameters"])
+            if isinstance(o_entity, TagInterface):
+                o_entity.api_add_tags.assert_called_once_with(d_action["tags"])
+            if isinstance(o_entity, CommentInterface):
+                # o_entity.api_add_comment.
+                self.assertEqual(o_entity.api_add_comment.call_args_list, [call({"text": s_comm}) for s_comm in d_action["comments"]])


### PR DESCRIPTION
développement pour le ticket #66 

## [Added]

* EditAction : édition(modification) des upload, stored_data, configuration et offering dans un workflow (entité + tags + commentaires)

## [Changed]

* Workflow : ajout de l'actions EditAction + tests
* StoreEntity: ajout de `edit()` permettant de gérer l'édition des entités si possible. Ici impossible de mettre à jour les entités.
* PartialEditInterface: surcharge de `edit()` pour permettre l’édition partiel
* FullEditInterface: surcharge de `edit()` pour permettre l’édition complète
