### PR TITLE
Resolveur datastore : clef-valeur transmis à la résolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
 
 ### [Changed]
 
+* GlobalREsolver et Resolver : il est possible d'ajouter des couples clefs-valeurs dans la fonction `resolve()` de GlobalResolver et ils sont transmis aux résolveurs. Cela permet de base de résoudre la récupération d'entités (#68).
+
 ### [Fixed]
+
+* #68 : le datastore est transmis au moment de la résolution ce qui corriger le problème.
 
 ## v0.1.19
 

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -90,8 +90,6 @@ class Workflow:
         for d_action_raw in d_step_definition["actions"]:
             # création de l'action
             o_action = Workflow.generate(step_name, d_action_raw, o_parent_action, behavior)
-            # résolution
-            o_action.resolve()
             # choix du datastore
             ## par défaut datastore du workflow, si None il sera récupérer dans la configuration
             s_use_datastore = self.__datastore
@@ -102,6 +100,8 @@ class Workflow:
                 # datastore dans l'étape
                 s_use_datastore = o_action.definition_dict["datastore"]
 
+            # résolution
+            o_action.resolve(datastore=s_use_datastore)
             # exécution de l'action
             Config().om.info(f"Exécution de l'action '{o_action.workflow_context}-{o_action.index}'...")
             o_action.run(s_use_datastore)

--- a/sdk_entrepot_gpf/workflow/action/ActionAbstract.py
+++ b/sdk_entrepot_gpf/workflow/action/ActionAbstract.py
@@ -57,7 +57,7 @@ class ActionAbstract(ABC):
     def parent_action(self) -> Optional["ActionAbstract"]:
         return self.__parent_action
 
-    def resolve(self, **kwargs: Dict[str, Any]) -> None:
+    def resolve(self, **kwargs: Any) -> None:
         """Résout la définition de l'action.
 
         L'action peut faire référence à des entités via des filtres, on

--- a/sdk_entrepot_gpf/workflow/action/ActionAbstract.py
+++ b/sdk_entrepot_gpf/workflow/action/ActionAbstract.py
@@ -62,6 +62,12 @@ class ActionAbstract(ABC):
 
         L'action peut faire référence à des entités via des filtres, on
         veut donc résoudre ces éléments afin de soumettre une requête valide à l'API.
+
+        Args:
+            kwargs (Any): paramètres supplémentaires.
+
+        Raises:
+            StepActionError: _description_
         """
         Config().om.info(f"Résolution de l'action '{self.workflow_context}-{self.index}'...")
         # Pour faciliter la résolution, on repasse la définition de l'action en json

--- a/sdk_entrepot_gpf/workflow/action/ActionAbstract.py
+++ b/sdk_entrepot_gpf/workflow/action/ActionAbstract.py
@@ -57,7 +57,7 @@ class ActionAbstract(ABC):
     def parent_action(self) -> Optional["ActionAbstract"]:
         return self.__parent_action
 
-    def resolve(self) -> None:
+    def resolve(self, **kwargs: Dict[str, Any]) -> None:
         """Résout la définition de l'action.
 
         L'action peut faire référence à des entités via des filtres, on
@@ -67,7 +67,7 @@ class ActionAbstract(ABC):
         # Pour faciliter la résolution, on repasse la définition de l'action en json
         s_definition = str(json.dumps(self.__definition_dict, ensure_ascii=False))
         # lancement des résolveurs
-        s_resolved_definition = GlobalResolver().resolve(s_definition)
+        s_resolved_definition = GlobalResolver().resolve(s_definition, **kwargs)
         # on repasse en json
         try:
             self.__definition_dict = json.loads(s_resolved_definition)

--- a/sdk_entrepot_gpf/workflow/resolver/AbstractResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/AbstractResolver.py
@@ -22,6 +22,7 @@ class AbstractResolver(ABC):
 
         Args:
             string_to_solve (str): chaîne à résoudre
+            kwargs (Any): paramètres supplémentaires.
 
         Returns:
             chaîne résolue

--- a/sdk_entrepot_gpf/workflow/resolver/AbstractResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/AbstractResolver.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any, Dict
 
 
 class AbstractResolver(ABC):
@@ -16,7 +17,7 @@ class AbstractResolver(ABC):
         self.__name: str = name
 
     @abstractmethod
-    def resolve(self, string_to_solve: str) -> str:
+    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> str:
         """Résout la chaîne à traiter et retourne la chaîne obtenue.
 
         Args:

--- a/sdk_entrepot_gpf/workflow/resolver/AbstractResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/AbstractResolver.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 
 class AbstractResolver(ABC):
@@ -17,7 +17,7 @@ class AbstractResolver(ABC):
         self.__name: str = name
 
     @abstractmethod
-    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> str:
+    def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
         """Résout la chaîne à traiter et retourne la chaîne obtenue.
 
         Args:

--- a/sdk_entrepot_gpf/workflow/resolver/DictResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/DictResolver.py
@@ -25,6 +25,20 @@ class DictResolver(AbstractResolver):
         self.__key_value: Dict[str, Any] = key_value
 
     def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
+        """La chaîne à résoudre doit correspondre à une clef du dictionnaire.
+
+        Args:
+            string_to_solve (str): chaîne à résoudre.
+            kwargs (Any): paramètres supplémentaires.
+
+        Returns:
+
+        Raises:
+            ResolverError: levée si aucune clef ne correspond à la chaîne
+
+        Returns:
+            str: chaîne résolue
+        """
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
         if string_to_solve in self.__key_value:
             return str(self.__key_value[string_to_solve])

--- a/sdk_entrepot_gpf/workflow/resolver/DictResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/DictResolver.py
@@ -24,7 +24,7 @@ class DictResolver(AbstractResolver):
         super().__init__(name)
         self.__key_value: Dict[str, Any] = key_value
 
-    def resolve(self, string_to_solve: str) -> str:
+    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> str:
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
         if string_to_solve in self.__key_value:
             return str(self.__key_value[string_to_solve])

--- a/sdk_entrepot_gpf/workflow/resolver/DictResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/DictResolver.py
@@ -24,7 +24,7 @@ class DictResolver(AbstractResolver):
         super().__init__(name)
         self.__key_value: Dict[str, Any] = key_value
 
-    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> str:
+    def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
         if string_to_solve in self.__key_value:
             return str(self.__key_value[string_to_solve])

--- a/sdk_entrepot_gpf/workflow/resolver/DumbResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/DumbResolver.py
@@ -12,4 +12,13 @@ class DumbResolver(AbstractResolver):
     """
 
     def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
+        """Résolution bête : on retourne la chaîne à résoudre.
+
+        Args:
+            string_to_solve (str): chaîne à résoudre.
+            kwargs (Any): paramètres supplémentaires.
+
+        Returns:
+            str: chaîne résolue
+        """
         return string_to_solve

--- a/sdk_entrepot_gpf/workflow/resolver/DumbResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/DumbResolver.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from sdk_entrepot_gpf.workflow.resolver.AbstractResolver import AbstractResolver
+
+
+class DumbResolver(AbstractResolver):
+    """Classe permettant de résoudre en renvoyant la clef.
+
+    Attributes:
+        __name (str): nom de code du resolver
+        __key_value (Dict[str, Any]): liste des paramètres à résoudre
+    """
+
+    def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
+        return string_to_solve

--- a/sdk_entrepot_gpf/workflow/resolver/FileResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/FileResolver.py
@@ -1,6 +1,7 @@
 import re
 import json
 from pathlib import Path
+from typing import Any, Dict
 
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.resolver.AbstractResolver import AbstractResolver
@@ -133,7 +134,7 @@ class FileResolver(AbstractResolver):
             raise ResolveFileInvalidError(self.name, string_to_solve)
         return s_data
 
-    def resolve(self, string_to_solve: str) -> str:
+    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> str:
         """Fonction permettant de renvoyer sous forme de string la résolution
         des paramètres de fichier passés en entrée.
 

--- a/sdk_entrepot_gpf/workflow/resolver/FileResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/FileResolver.py
@@ -140,9 +140,11 @@ class FileResolver(AbstractResolver):
 
         Args:
             string_to_solve (str): chaîne à résoudre (type de fichier à traiter et chemin)
+            kwargs (Any): paramètres supplémentaires.
 
         Raises:
-            ResolverError: si le type n'est pas reconnu
+            ResolverError: si la chaîne à résoudre est incorrecte
+            ResolverError: si le type de donnée n'est pas str/list/dict
 
         Returns:
             le contenu du fichier en entrée sous forme de string

--- a/sdk_entrepot_gpf/workflow/resolver/FileResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/FileResolver.py
@@ -1,7 +1,7 @@
 import re
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.resolver.AbstractResolver import AbstractResolver
@@ -134,7 +134,7 @@ class FileResolver(AbstractResolver):
             raise ResolveFileInvalidError(self.name, string_to_solve)
         return s_data
 
-    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> str:
+    def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
         """Fonction permettant de renvoyer sous forme de string la résolution
         des paramètres de fichier passés en entrée.
 

--- a/sdk_entrepot_gpf/workflow/resolver/GlobalResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/GlobalResolver.py
@@ -25,7 +25,7 @@ class GlobalResolver(metaclass=Singleton):
         """Ajoute un résolveur à la liste."""
         self.__resolvers[resolver.name] = resolver
 
-    def resolve(self, string_to_solve_global: str, **kwargs: Dict[str, Any]) -> str:
+    def resolve(self, string_to_solve_global: str, **kwargs: Any) -> str:
         """Résout la chaîne à traiter et retourne la chaîne obtenue.
 
         Résout TOUT le paramétrage trouvé.
@@ -39,6 +39,7 @@ class GlobalResolver(metaclass=Singleton):
         Returns:
             chaîne résolue
         """
+
         # à laisser ici pour avoir la valeur de kwargs
         def resolve_group(match: Match[str]) -> str:
             """Résout la chaîne trouvé par la regex et permet de la remplacer.
@@ -84,5 +85,3 @@ class GlobalResolver(metaclass=Singleton):
     @property
     def regex(self) -> Pattern[str]:
         return self.__regex
-
-    @staticmethod

--- a/sdk_entrepot_gpf/workflow/resolver/GlobalResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/GlobalResolver.py
@@ -32,6 +32,7 @@ class GlobalResolver(metaclass=Singleton):
 
         Args:
             string_to_solve_global (str): chaîne globale à résoudre
+            kwargs (Any): paramètres supplémentaires.
 
         Raises:
             ResolverNotFoundError: levée si un résolveur demandé n'est pas trouvé

--- a/sdk_entrepot_gpf/workflow/resolver/GlobalResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/GlobalResolver.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Match, Pattern
+from typing import Any, Dict, Match, Pattern
 
 from sdk_entrepot_gpf.pattern.Singleton import Singleton
 from sdk_entrepot_gpf.workflow.resolver.AbstractResolver import AbstractResolver
@@ -25,7 +25,7 @@ class GlobalResolver(metaclass=Singleton):
         """Ajoute un résolveur à la liste."""
         self.__resolvers[resolver.name] = resolver
 
-    def resolve(self, string_to_solve_global: str) -> str:
+    def resolve(self, string_to_solve_global: str, **kwargs: Dict[str, Any]) -> str:
         """Résout la chaîne à traiter et retourne la chaîne obtenue.
 
         Résout TOUT le paramétrage trouvé.
@@ -39,7 +39,43 @@ class GlobalResolver(metaclass=Singleton):
         Returns:
             chaîne résolue
         """
-        return self.__regex.sub(GlobalResolver.resolve_group, string_to_solve_global)
+        # à laisser ici pour avoir la valeur de kwargs
+        def resolve_group(match: Match[str]) -> str:
+            """Résout la chaîne trouvé par la regex et permet de la remplacer.
+
+            Args:
+                match (Match[str]): groupe capturé par la regex
+
+            Raises:
+                ResolverNotFoundError: levée si le résolveur demandé n'est pas trouvé
+
+            Returns:
+                chaîne de remplacement
+            """
+            nonlocal kwargs
+            d_resolution = match.groupdict()
+            # La chaîne complète, à remplacer, est donnée par la clé "param"
+            s_all: str = d_resolution["param"]
+            # Si cette chaîne n'est pas déjà dans _solved_strings
+            if not s_all in GlobalResolver._solved_strings:
+                # Le nom du résolveur est donnée par la clé "resolver_name"
+                s_resolver_name: str = d_resolution["resolver_name"]
+                # La chaîne à résoudre est donnée par la clé "to_solve"
+                s_to_solve: str = d_resolution["to_solve"]
+                # Vérification de l’existante du resolver
+                if not s_resolver_name in GlobalResolver().resolvers:
+                    Config().om.debug(f"Resolvers : {', '.join(GlobalResolver().resolvers.keys())}")
+                    raise ResolverNotFoundError(s_resolver_name)
+                # On résout globalement la chaîne à résoudre (si jamais on a des paramètres dans des paramètres...)
+                s_to_solve = GlobalResolver().resolve(s_to_solve, **kwargs)
+                # Puis on la résout avec le résolveur à utiliser et on l'ajoute à la liste
+                s_solved = GlobalResolver().resolvers[s_resolver_name].resolve(s_to_solve, **kwargs)
+                GlobalResolver._solved_strings[s_all] = s_solved
+                Config().om.debug(f"resolve_group - {s_all} ({s_resolver_name} : {s_to_solve} => {s_solved})")
+            Config().om.debug(f"resolve_group - {s_all} (from cache)")
+            return GlobalResolver._solved_strings[s_all]
+
+        return self.__regex.sub(resolve_group, string_to_solve_global)
 
     @property
     def resolvers(self) -> Dict[str, AbstractResolver]:
@@ -50,36 +86,3 @@ class GlobalResolver(metaclass=Singleton):
         return self.__regex
 
     @staticmethod
-    def resolve_group(match: Match[str]) -> str:
-        """Résout la chaîne trouvé par la regex et permet de la remplacer.
-
-        Args:
-            match (Match[str]): groupe capturé par la regex
-
-        Raises:
-            ResolverNotFoundError: levée si le résolveur demandé n'est pas trouvé
-
-        Returns:
-            chaîne de remplacement
-        """
-        d_resolution = match.groupdict()
-        # La chaîne complète, à remplacer, est donnée par la clé "param"
-        s_all: str = d_resolution["param"]
-        # Si cette chaîne n'est pas déjà dans _solved_strings
-        if not s_all in GlobalResolver._solved_strings:
-            # Le nom du résolveur est donnée par la clé "resolver_name"
-            s_resolver_name: str = d_resolution["resolver_name"]
-            # La chaîne à résoudre est donnée par la clé "to_solve"
-            s_to_solve: str = d_resolution["to_solve"]
-            # Vérification de l’existante du resolver
-            if not s_resolver_name in GlobalResolver().resolvers:
-                Config().om.debug(f"Resolvers : {', '.join(GlobalResolver().resolvers.keys())}")
-                raise ResolverNotFoundError(s_resolver_name)
-            # On résout globalement la chaîne à résoudre (si jamais on a des paramètres dans des paramètres...)
-            s_to_solve = GlobalResolver().resolve(s_to_solve)
-            # Puis on la résout avec le résolveur à utiliser et on l'ajoute à la liste
-            s_solved = GlobalResolver().resolvers[s_resolver_name].resolve(s_to_solve)
-            GlobalResolver._solved_strings[s_all] = s_solved
-            Config().om.debug(f"resolve_group - {s_all} ({s_resolver_name} : {s_to_solve} => {s_solved})")
-        Config().om.debug(f"resolve_group - {s_all} (from cache)")
-        return GlobalResolver._solved_strings[s_all]

--- a/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
@@ -47,6 +47,20 @@ class StoreEntityResolver(AbstractResolver):
         self.__regex: Pattern[str] = re.compile(Config().get_str("workflow_resolution_regex", "store_entity_regex"))
 
     def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
+        """Résolution en listant les entités de l'API.
+
+        Args:
+            string_to_solve (str): chaîne à résoudre (type de l'entité, attribut à récupérer)
+            kwargs (Any): paramètres supplémentaires (datastore).
+
+        Raises:
+            ResolverError: si la chaîne à résoudre n'est pas parsable
+            NoEntityFoundError: si aucune entité n'est trouvée
+            ResolverError: si aucune information n'est retournée
+
+        Returns:
+            l'attribut demandé de l'entité demandée
+        """
         # On parse la chaîne à résoudre
         o_result = self.regex.search(string_to_solve)
         if o_result is None:

--- a/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
@@ -46,7 +46,7 @@ class StoreEntityResolver(AbstractResolver):
         super().__init__(name)
         self.__regex: Pattern[str] = re.compile(Config().get_str("workflow_resolution_regex", "store_entity_regex"))
 
-    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> str:
+    def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
         # On parse la chaîne à résoudre
         o_result = self.regex.search(string_to_solve)
         if o_result is None:
@@ -62,7 +62,12 @@ class StoreEntityResolver(AbstractResolver):
         # On récupère le type de StoreEntity demandé
         s_entity_type = str(d_groups["entity_type"])
         # On liste les éléments API via la fonction de classe
-        l_entities = self.__key_to_cls[s_entity_type].api_list(infos_filter=d_filter_infos, tags_filter=d_filter_tags, page=1, datastore=kwargs.get("datastore"))
+        l_entities = self.__key_to_cls[s_entity_type].api_list(
+            infos_filter=d_filter_infos,
+            tags_filter=d_filter_tags,
+            page=1,
+            datastore=kwargs.get("datastore"),
+        )
         # Si on a aucune entité trouvée
         if len(l_entities) == 0:
             raise NoEntityFoundError(self.name, string_to_solve)

--- a/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Optional, Pattern, Type
+from typing import Any, Dict, Optional, Pattern, Type
 
 from sdk_entrepot_gpf.workflow.resolver.AbstractResolver import AbstractResolver
 from sdk_entrepot_gpf.workflow.resolver.Errors import NoEntityFoundError, ResolverError
@@ -46,7 +46,7 @@ class StoreEntityResolver(AbstractResolver):
         super().__init__(name)
         self.__regex: Pattern[str] = re.compile(Config().get_str("workflow_resolution_regex", "store_entity_regex"))
 
-    def resolve(self, string_to_solve: str) -> str:
+    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> str:
         # On parse la chaîne à résoudre
         o_result = self.regex.search(string_to_solve)
         if o_result is None:
@@ -62,7 +62,7 @@ class StoreEntityResolver(AbstractResolver):
         # On récupère le type de StoreEntity demandé
         s_entity_type = str(d_groups["entity_type"])
         # On liste les éléments API via la fonction de classe
-        l_entities = self.__key_to_cls[s_entity_type].api_list(infos_filter=d_filter_infos, tags_filter=d_filter_tags, page=1)
+        l_entities = self.__key_to_cls[s_entity_type].api_list(infos_filter=d_filter_infos, tags_filter=d_filter_tags, page=1, datastore=kwargs.get("datastore"))
         # Si on a aucune entité trouvée
         if len(l_entities) == 0:
             raise NoEntityFoundError(self.name, string_to_solve)

--- a/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
@@ -27,7 +27,7 @@ class UserResolver(AbstractResolver):
         o_response = ApiRequester().route_request("user_get")
         self.__user_data: Dict[str, Any] = o_response.json()
 
-    def resolve(self, string_to_solve: str) -> Any:
+    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> Any:
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
         if string_to_solve in self.__user_data:
             return str(self.__user_data[string_to_solve])

--- a/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
@@ -27,7 +27,7 @@ class UserResolver(AbstractResolver):
         o_response = ApiRequester().route_request("user_get")
         self.__user_data: Dict[str, Any] = o_response.json()
 
-    def resolve(self, string_to_solve: str, **kwargs: Dict[str, Any]) -> Any:
+    def resolve(self, string_to_solve: str, **kwargs: Any) -> Any:
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
         if string_to_solve in self.__user_data:
             return str(self.__user_data[string_to_solve])

--- a/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
@@ -28,6 +28,18 @@ class UserResolver(AbstractResolver):
         self.__user_data: Dict[str, Any] = o_response.json()
 
     def resolve(self, string_to_solve: str, **kwargs: Any) -> Any:
+        """Récupération de l'utilisateur courant et récupération d'une des ces informations.
+
+        Args:
+            string_to_solve (str): chaîne à résoudre (attribut du JSON retourné)
+            kwargs (Any): paramètres supplémentaires.
+
+        Raises:
+            ResolveUserError: si l'attribut demandé n'existe pas
+
+        Returns:
+            valeur de l'attribut
+        """
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
         if string_to_solve in self.__user_data:
             return str(self.__user_data[string_to_solve])

--- a/tests/workflow/action/ActionAbstractTestCase.py
+++ b/tests/workflow/action/ActionAbstractTestCase.py
@@ -48,9 +48,11 @@ class ActionAbstractTestCase(GpfTestCase):
         # on mock GlobalResolver
         with patch.object(GlobalResolver, "resolve", return_value=str(json.dumps(d_resolved_dico))) as o_mock_resolve:
             o_action = ConcreteAction("nom", d_definition, None)
-            o_action.resolve()
+            # On ajout des couples clef-valeur...
+            o_action.resolve(key="value", datastore="datastore_id")
             assert o_action.definition_dict == d_resolved_dico
-            o_mock_resolve.assert_called_once_with(str(json.dumps(d_definition)))
+            # Qui doivent être transmis à la résolution
+            o_mock_resolve.assert_called_once_with(str(json.dumps(d_definition)), key="value", datastore="datastore_id")
 
     def test_get_filters(self) -> None:
         """Test de get_filters."""

--- a/tests/workflow/resolver/GlobalResolverTestCase.py
+++ b/tests/workflow/resolver/GlobalResolverTestCase.py
@@ -136,7 +136,7 @@ class GlobalResolverTestCase(GpfTestCase):
         self.assertEqual(GlobalResolver().resolve('{"_localization_":"{profession.sailor}_country"}'), "England")
         # Cas mock : validation valeur résolue + propagation des clefs valeurs (key/datastore ici)
         self.assertEqual(GlobalResolver().resolve("{mock_resolver.string_to_solve}", key="value", datastore="datastore_id"), "magic_resolved")
-        GlobalResolver().resolvers["mock_resolver"].resolve.assert_called_once_with(
+        GlobalResolver().resolvers["mock_resolver"].resolve.assert_called_once_with(  # type:ignore
             "string_to_solve",
             key="value",
             datastore="datastore_id",

--- a/tests/workflow/resolver/GlobalResolverTestCase.py
+++ b/tests/workflow/resolver/GlobalResolverTestCase.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from sdk_entrepot_gpf.workflow.resolver.DictResolver import DictResolver
 from sdk_entrepot_gpf.workflow.resolver.Errors import ResolverNotFoundError
 from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
@@ -31,16 +33,24 @@ class GlobalResolverTestCase(GpfTestCase):
         """fonction lancée une fois avant tous les tests de la classe"""
         super().setUpClass()
         GlobalResolver._instance = None  # pylint:disable=protected-access
+        # On ajoute 2 vrais résolveurs, pour vvérifier la résolution
         GlobalResolver().add_resolver(DictResolver("localization", GlobalResolverTestCase.localization))
         GlobalResolver().add_resolver(DictResolver("profession", GlobalResolverTestCase.profession))
+        # On ajoute un mock résolveur, pour vvérifier l'appel de la fonction resolve
+        o_mock_resolver = MagicMock()
+        o_mock_resolver.name = "mock_resolver"
+        o_mock_resolver.resolve = MagicMock()
+        o_mock_resolver.resolve.return_value = "magic_resolved"
+        GlobalResolver().add_resolver(o_mock_resolver)
 
     def test_add_resolver(self) -> None:
         """Vérifie le bon fonctionnement de la fonction add_resolver."""
         # La fonction a déjà été appelée dans le SetUpClass
-        # On vérifie juste que l'on a bien 2 résolveurs
-        self.assertEqual(len(GlobalResolver().resolvers), 2)
+        # On vérifie juste que l'on a bien 3 résolveurs
+        self.assertEqual(len(GlobalResolver().resolvers), 3)
         self.assertTrue("localization" in GlobalResolver().resolvers)
         self.assertTrue("profession" in GlobalResolver().resolvers)
+        self.assertTrue("mock_resolver" in GlobalResolver().resolvers)
 
     def test_regex(self) -> None:
         """Vérifie que la regex fonctionne bien sur les cas particuliers."""
@@ -124,6 +134,13 @@ class GlobalResolverTestCase(GpfTestCase):
         self.assertEqual(GlobalResolver().resolve('["_localization_","{profession.sailor}_country"]'), "England")
         # Comme dict (pour insérer une string)
         self.assertEqual(GlobalResolver().resolve('{"_localization_":"{profession.sailor}_country"}'), "England")
+        # Cas mock : validation valeur résolue + propagation des clefs valeurs (key/datastore ici)
+        self.assertEqual(GlobalResolver().resolve("{mock_resolver.string_to_solve}", key="value", datastore="datastore_id"), "magic_resolved")
+        GlobalResolver().resolvers["mock_resolver"].resolve.assert_called_once_with(
+            "string_to_solve",
+            key="value",
+            datastore="datastore_id",
+        )
         # Cas erreur :
         with self.assertRaises(ResolverNotFoundError) as o_arc:
             GlobalResolver().resolve("{resolver_not_found.foo}")

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -46,7 +46,12 @@ class StoreEntityResolverTestCase(GpfTestCase):
             # Vérification erreur
             self.assertEqual(o_arc.exception.message, f"Impossible de trouver une entité correspondante (résolveur 'store_entity') avec la chaîne '{s_to_solve}'.")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"name": "start_%"}, tags_filter={"k_tag": "v_tag"}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"name": "start_%"},
+                tags_filter={"k_tag": "v_tag"},
+                page=1,
+                datastore=None,
+            )
 
     def test_resolve_upload(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un upload."""
@@ -57,11 +62,18 @@ class StoreEntityResolverTestCase(GpfTestCase):
             Upload({"_id": "upload_2", "name": "Name 2", "tags": {"k_tag": "v_tag"}}),
         ]
 
+        # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
+
         # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
         with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
             s_result = o_store_entity_resolver.resolve("upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"name": "start_%"}, tags_filter={"k_tag": "v_tag"}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"name": "start_%"},
+                tags_filter={"k_tag": "v_tag"},
+                page=1,
+                datastore=None,
+            )
             # Vérification id récupérée
             self.assertEqual(s_result, "upload_1")
 
@@ -69,7 +81,12 @@ class StoreEntityResolverTestCase(GpfTestCase):
         with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
             s_result = o_store_entity_resolver.resolve("upload.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"name": "start_%"}, tags_filter={"k_tag": "v_tag"}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"name": "start_%"},
+                tags_filter={"k_tag": "v_tag"},
+                page=1,
+                datastore=None,
+            )
             # Vérification name récupérée
             self.assertEqual(s_result, "Name 1")
 
@@ -77,9 +94,32 @@ class StoreEntityResolverTestCase(GpfTestCase):
         with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
             s_result = o_store_entity_resolver.resolve("upload.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"name": "start_%"}, tags_filter={"k_tag": "v_tag"}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"name": "start_%"},
+                tags_filter={"k_tag": "v_tag"},
+                page=1,
+                datastore=None,
+            )
             # Vérification name récupérée
             self.assertEqual(s_result, "v_tag")
+
+        # TEST 2 : avec on sens datastore, on vérifie qu'un datastore passé est bien transmis
+
+        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
+        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
+            s_result = o_store_entity_resolver.resolve(
+                "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]",
+                datastore="datastore_1",  # On précise un datastore
+            )
+            # Vérifications o_mock_api_list
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"name": "start_%"},
+                tags_filter={"k_tag": "v_tag"},
+                page=1,
+                datastore="datastore_1",  # Il est bien transmis
+            )
+            # Vérification id récupérée
+            self.assertEqual(s_result, "upload_1")
 
     def test_resolve_endpoint(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un endpoint."""
@@ -93,7 +133,12 @@ class StoreEntityResolverTestCase(GpfTestCase):
         with patch.object(Endpoint, "api_list", return_value=l_uploads) as o_mock_api_list:
             s_result = o_store_entity_resolver.resolve("endpoint.infos._id [INFOS(type=ARCHIVE)]")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"type": "ARCHIVE"}, tags_filter={}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"type": "ARCHIVE"},
+                tags_filter={},
+                page=1,
+                datastore=None,
+            )
             # Vérification id récupérée
             self.assertEqual(s_result, "endpoint")
 
@@ -101,7 +146,12 @@ class StoreEntityResolverTestCase(GpfTestCase):
         with patch.object(Endpoint, "api_list", return_value=l_uploads) as o_mock_api_list:
             s_result = o_store_entity_resolver.resolve("endpoint.infos.name [INFOS(type=ARCHIVE)]")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"type": "ARCHIVE"}, tags_filter={}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"type": "ARCHIVE"},
+                tags_filter={},
+                page=1,
+                datastore=None,
+            )
             # Vérification name récupérée
             self.assertEqual(s_result, "Name")
 
@@ -113,7 +163,12 @@ class StoreEntityResolverTestCase(GpfTestCase):
             # Vérification erreur
             self.assertEqual(o_arc.exception.message, f"Erreur du résolveur 'store_entity' avec la chaîne '{s_to_solve}'.")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"type": "ARCHIVE"}, tags_filter={}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"type": "ARCHIVE"},
+                tags_filter={},
+                page=1,
+                datastore=None,
+            )
 
     def test_resolve_datastore(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un store.
@@ -129,7 +184,12 @@ class StoreEntityResolverTestCase(GpfTestCase):
         with patch.object(Datastore, "api_list", return_value=l_entities) as o_mock_api_list:
             s_result = o_store_entity_resolver.resolve("datastore.infos._id [INFOS(name=ds1)]")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"name": "ds1"}, tags_filter={}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"name": "ds1"},
+                tags_filter={},
+                page=1,
+                datastore=None,
+            )
             # Vérification id récupérée
             self.assertEqual(s_result, "1")
 
@@ -137,6 +197,11 @@ class StoreEntityResolverTestCase(GpfTestCase):
         with patch.object(Datastore, "api_list", return_value=l_entities) as o_mock_api_list:
             s_result = o_store_entity_resolver.resolve("datastore.infos._id [INFOS(name=Datastore 1)]")
             # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(infos_filter={"name": "Datastore 1"}, tags_filter={}, page=1)
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"name": "Datastore 1"},
+                tags_filter={},
+                page=1,
+                datastore=None,
+            )
             # Vérification id récupérée
             self.assertEqual(s_result, "1")

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -116,19 +116,22 @@ class StoreEntityResolverTestCase(GpfTestCase):
 
         # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
         with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            s_result = o_store_entity_resolver.resolve(
-                "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]",
-                datastore="datastore_1",  # On précise un datastore
-            )
-            # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(
-                infos_filter={"name": "start_%"},
-                tags_filter={"k_tag": "v_tag"},
-                page=1,
-                datastore="datastore_1",  # Il est bien transmis
-            )
-            # Vérification id récupérée
-            self.assertEqual(s_result, "upload_1")
+            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
+                s_result = o_store_entity_resolver.resolve(
+                    "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]",
+                    datastore="datastore_1",  # On précise un datastore
+                )
+                # Vérifications o_mock_api_list
+                o_mock_api_list.assert_called_once_with(
+                    infos_filter={"name": "start_%"},
+                    tags_filter={"k_tag": "v_tag"},
+                    page=1,
+                    datastore="datastore_1",  # Il est bien transmis
+                )
+                # Vérification id récupérée
+                self.assertEqual(s_result, "upload_1")
+                # Vérification maj entité via appel de api_update
+                o_mock_api_update.assert_called_once_with()
 
     def test_resolve_endpoint(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un endpoint."""


### PR DESCRIPTION
Pour corriger le bug #68 : des couples clefs-valeur peuvent être passés en paramètres de la fonction `GlobalResolver.resolve()`, ils seront transmis à chaque résolveur.

Cela corrige le problème du datastore non prise en compte car le datastore est transmis par défaut à la résolution d'une action.

```
## v0.1.20

### [Changed]

* GlobalREsolver et Resolver : il est possible d'ajouter des couples clefs-valeurs dans la fonction `resolve()` de GlobalResolver et ils sont transmis aux résolveurs. Cela permet de base de résoudre la récupération d'entités (#68).

### [Fixed]

* #68 : le datastore est transmis au moment de la résolution ce qui corriger le problème.
* ``