### PR TITLE
Copy configuration. Close #77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### [Changed]
 
+* Renommage de `CopieConfigurationAction` en `CopyConfigurationAction`
+
 ### [Fixed]
 
 * Upload: modification de la requête suite modification de l'API GPF #54
@@ -15,8 +17,6 @@
 ### [Added]
 
 ### [Changed]
-
-* Renommage de `CopieConfigurationAction` en `CopyConfigurationAction`
 
 ### [Fixed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### [Changed]
 
+* Renommage de `CopieConfigurationAction` en `CopyConfigurationAction`
+
 ### [Fixed]
+
+* Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
 
 ## v0.1.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### [Fixed]
 
-* Upload: modification de la requête suite modification de l'API GPF #54
+* Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
 
 ## v0.1.21
 
@@ -20,7 +20,7 @@
 
 ### [Fixed]
 
-* Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
+* Upload: modification de la requête suite modification de l'API GPF #54
 
 ## v0.1.20
 

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -39,7 +39,7 @@
                                                 "delete-entity",
                                                 "processing-execution",
                                                 "configuration",
-                                                "copie-configuration",
+                                                "copy-configuration",
                                                 "offering",
                                                 "synchronize-offering"
                                             ]

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -253,7 +253,7 @@ class Workflow:
             return ProcessingExecutionAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "configuration":
             return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
-        if definition_dict["type"] == "copie-configuration":
+        if definition_dict["type"] == "copy-configuration":
             return CopyConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "offering":
             return OfferingAction(workflow_context, definition_dict, parent_action, behavior=behavior)

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -10,7 +10,7 @@ from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.workflow.Errors import WorkflowError
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
-from sdk_entrepot_gpf.workflow.action.CopieConfigurationAction import CopieConfigurationAction
+from sdk_entrepot_gpf.workflow.action.CopyConfigurationAction import CopyConfigurationAction
 from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
 from sdk_entrepot_gpf.workflow.action.EditAction import EditAction
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
@@ -254,7 +254,7 @@ class Workflow:
         if definition_dict["type"] == "configuration":
             return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "copie-configuration":
-            return CopieConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
+            return CopyConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "offering":
             return OfferingAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "synchronize-offering":

--- a/sdk_entrepot_gpf/workflow/action/CopyConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/CopyConfigurationAction.py
@@ -5,7 +5,7 @@ from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 
 
-class CopieConfigurationAction(ConfigurationAction):
+class CopyConfigurationAction(ConfigurationAction):
     """Classe dédiée à la copie des Configuration.
 
     Attributes:

--- a/tests/workflow/action/CopyConfigurationActionTestCase.py
+++ b/tests/workflow/action/CopyConfigurationActionTestCase.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 
 from sdk_entrepot_gpf.store.Configuration import Configuration
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
-from sdk_entrepot_gpf.workflow.action.CopieConfigurationAction import CopieConfigurationAction
+from sdk_entrepot_gpf.workflow.action.CopyConfigurationAction import CopyConfigurationAction
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 
 from tests.GpfTestCase import GpfTestCase
@@ -14,10 +14,10 @@ from tests.GpfTestCase import GpfTestCase
 # pylint:disable=too-many-branches
 
 
-class CopieConfigurationActionTestCase(GpfTestCase):
-    """Tests CopieConfigurationAction class.
+class CopyConfigurationActionTestCase(GpfTestCase):
+    """Tests CopyConfigurationAction class.
 
-    cmd : python3 -m unittest -b tests.workflow.action.CopieConfigurationActionTestCase
+    cmd : python3 -m unittest -b tests.workflow.action.CopyConfigurationActionTestCase
     """
 
     def test_run(self) -> None:
@@ -25,13 +25,13 @@ class CopieConfigurationActionTestCase(GpfTestCase):
         # manque des paramétres
         l_dict_definition: List[Dict[str, Any]] = [{}, {"body_parameters": {}}, {"body_parameters": {"name": "nouveau name"}}, {"body_parameters": {"layer_name": "nouveau layer_name"}}]
         for d_definition in l_dict_definition:
-            o_action = CopieConfigurationAction("contexte", d_definition, None, "CONTINUE")
+            o_action = CopyConfigurationAction("contexte", d_definition, None, "CONTINUE")
             with self.assertRaises(StepActionError) as o_mock_err:
                 o_action.run("datastore")
             self.assertEqual('Les clefs "name" et "layer_name" sont obligatoires dans "body_parameters"', o_mock_err.exception.message)
 
         d_definition = {"url_parameters": {"configuration": "123"}, "body_parameters": {"layer_name": "nouveau layer_name", "name": "nouveau name"}}
-        o_action = CopieConfigurationAction("contexte", d_definition, None, "CONTINUE")
+        o_action = CopyConfigurationAction("contexte", d_definition, None, "CONTINUE")
 
         # fonctionnement OK
         o_mock_base_config = MagicMock()


### PR DESCRIPTION
Correction de #77 

## [Changed]

* Renommage de `CopieConfigurationAction` en `CopyConfigurationAction`

## [Fixed]

* problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`

