### PR TITLE
Resolver date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Added]
 
+* DateResolver: ajout d'un résolveur pour les dates #86
+
 ### [Changed]
 
 ### [Fixed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGE LOG
 
+## v0.1.22
+
+### [Added]
+
+### [Changed]
+
+### [Fixed]
+
 ## v0.1.21
 
 ### [Added]

--- a/docs/resolveurs.md
+++ b/docs/resolveurs.md
@@ -191,6 +191,92 @@ prénom de l'utilisateur >{user.first_name}<
 print(GlobalResolver().resolve(text))
 ```
 
+### DateResolver
+
+Permet d'ajouté la date actuelle ou une date relative à la date actuelle dans le workflow.
+
+Utilisation, resolver nommé *my_date* et date actuelle `19/02/2024 14:01`:
+
+* date actuelle : `my_date.now.date` => `19/02/2024`
+* heure actuelle : `my_date.now.time` => `14:01`
+* date et heure actuelle : `date.now.datetime`=> `19/02/2024 14:01`
+* changement de pattern de sortie : `date.now.strtime(%Y-%m-%dT%H:%M:%S)` => `2024-02-19T14:01:02`
+
+* date et heure actuelle + ajout/enlever temps :
+  * `my_date.now.add(hour=4,year=1,month=2,day=3,minutes=5).datetime` => `22/04/2025 18:06`
+  * `my_date.now.datetime.add(year=-1).datetime` => `19/02/2023 14:01`
+  * `my_date.now.datetime.add(weak=-1).datetime` => `19/02/2023 14:01`
+
+donc `{nom_resolver}.now[.add\(year(s)=X,month(s)=X,day(s)=X,hour(s)=X,minute(s)=X,second(s)=X,week(s)=X\)].(date|time|datetime|strtime\({pattern}\))`
+
+Pour add on a les options : `year`,`month` ,`day`, `hour`, `minute`, `second`, `week` (ou avec des `s`) qui permettent d'ajouter (valeur positive) ou enlever (valeur négative) du temps à la date. Il n'y a pas d'ordre dans les paramètres et il ne sont pas tous obligatoires.
+
+Les pattern pour les date (date, time, datetime, pattern donné avec strtime) suivent les [patterns de datetime](https://docs.python.org/fr/3/library/datetime.html#strftime-and-strptime-format-codes). Les pattern des sorties par défaut (date, time, datetime) sont dans la configuration.
+
+```ini
+datetime_pattern = %d/%m/%Y %H:%M
+date_pattern = %d/%m/%Y
+time_pattern = %H:%M
+```
+
+Exemple :
+
+```python
+from sdk_entrepot_gpf.workflow.resolver.DateResolver import DateResolver
+from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
+from sdk_entrepot_gpf.io.Config import Config
+
+# configuration
+Config().read("config.ini")
+
+# initialisation
+date_resolver = DateResolver("date")
+GlobalResolver().add_resolver(date_resolver)
+
+# texte à résoudre
+text = """
+## Affichage date courante
+datetime courant > {date.now.datetime} <
+date courant > {date.now.date} <
+heure courant > {date.now.time} <
+date actuelle pattern différent > {date.now.strtime(%Y-%m-%dT%H:%M:%S)} <
+
+## Ajout de temps
+date +1an > {date.now.add(year=1).date} <
+date +1semaine > {date.now.add(week=1).date} <
+heure +4h > {date.now.add(hours=4).time} <
+datetime +1an 4h > {date.now.add(year=1, hours=4).datetime} <
+date +1an 4h pattern différent > {date.now.add(year=1, hours=4).strtime(%Y-%m-%dT%H:%M:%S)} <
+
+## différentes modification de date :
+Y+1 M+2 D+3 H+4 M+5 > {date.now.add(year=1,month=2,day=3,hour=4,minute=5).datetime} <
+Y-1 M+2 D+3 H-4 M+5 > {date.now.add(year=-1,month=2,day=3,hour=-4,minute=5).datetime} <
+Y-1 M+2 D+3 H-4 M+5 > {date.now.add(years=-1,months=2,days=3,hours=-4,minutes=5).datetime} <
+"""
+
+# resolution
+print(GlobalResolver().resolve(text))
+
+## affichage
+#    ## Affichage date courante
+#    datetime courant > 20/02/2024 11:08 <
+#    date courant > 20/02/2024 <
+#    heure courant > 11:08 <
+#    date actuelle pattern différent > 2024-02-20T11:08:03 <
+#
+#    ## Ajout de temps
+#    date +1an > 20/02/2025 <
+#    date +1semaine > 27/02/2024 <
+#    heure +4h > 15:08 <
+#    datetime +1an 4h > 20/02/2025 15:08 <
+#    date +1an 4h pattern différent > 2025-02-20T15:08:03 <
+#
+#    ## différentes modification de date :
+#    Y+1 M+2 D+3 H+4 M+5 > 23/04/2025 15:13 <
+#    Y-1 M+2 D+3 H-4 M+5 > 23/04/2023 07:13 <
+#    Y-1 M+2 D+3 H-4 M+5 > 23/04/2023 07:13 <
+```
+
 ## Créer son résolveur
 
 Pour créer votre résolveur, vous devez créer une classe qui hérite de la classe `AbstractResolver`.

--- a/docs/resolveurs.md
+++ b/docs/resolveurs.md
@@ -10,6 +10,7 @@ A l'utilisation du SDK comme un exécutable, il y a 2 résolveurs d’instancié
 
 * `user` : un [UserResolver](UserResolver)
 * `store_entity` : un [StoreEntityResolver](StoreEntityResolver)
+* `datetime`: un [DateResolver](#dateresolver)
 
 A l'utilisation comme module, il n'y a aucun résolveurs d’instancié de base. Il faut instancier des résolveurs dans le programme et les ajouter au `GlobalResolver`.
 
@@ -27,6 +28,7 @@ Il y a 4 résolveurs de base :
 * [FileResolver](FileResolver): insère les valeurs contenues dans un fichier ;
 * [StoreEntityResolver](StoreEntityResolver): récupère des informations sur les entités depuis la GPF ;
 * [UserResolver](UserResolver): récupère des informations de l'utilisateur courant depuis la GPF.
+* [DateResolver](#dateresolver): insertion d'une date au format désirer;
 
 ### DictResolver
 

--- a/docs/resolveurs.md
+++ b/docs/resolveurs.md
@@ -27,8 +27,8 @@ Il y a 4 résolveurs de base :
 * [DictResolver](DictResolver): permet d'insérer les valeurs contenues dans un dictionnaire ;
 * [FileResolver](FileResolver): insère les valeurs contenues dans un fichier ;
 * [StoreEntityResolver](StoreEntityResolver): récupère des informations sur les entités depuis la GPF ;
-* [UserResolver](UserResolver): récupère des informations de l'utilisateur courant depuis la GPF.
-* [DateResolver](#dateresolver): insertion d'une date au format désirer;
+* [UserResolver](UserResolver): récupère des informations de l'utilisateur courant depuis la GPF ;
+* [DateResolver](#dateresolver): insertion d'une date au format désiré.
 
 ### DictResolver
 
@@ -195,25 +195,25 @@ print(GlobalResolver().resolve(text))
 
 ### DateResolver
 
-Permet d'ajouté la date actuelle ou une date relative à la date actuelle dans le workflow.
+Permet d'insérer la date actuelle ou une date relative à la date actuelle dans le workflow.
 
-Utilisation, resolver nommé *my_date* et date actuelle `19/02/2024 14:01`:
+Utilisation, résolveur nommé *my_date* et date actuelle `19/02/2024 14:01`:
 
 * date actuelle : `my_date.now.date` => `19/02/2024`
 * heure actuelle : `my_date.now.time` => `14:01`
 * date et heure actuelle : `date.now.datetime`=> `19/02/2024 14:01`
-* changement de pattern de sortie : `date.now.strtime(%Y-%m-%dT%H:%M:%S)` => `2024-02-19T14:01:02`
+* changement du pattern de sortie : `date.now.strtime(%Y-%m-%dT%H:%M:%S)` => `2024-02-19T14:01:02`
 
-* date et heure actuelle + ajout/enlever temps :
+* date et heure actuelle + ajouter/enlever du temps :
   * `my_date.now.add(hour=4,year=1,month=2,day=3,minutes=5).datetime` => `22/04/2025 18:06`
   * `my_date.now.datetime.add(year=-1).datetime` => `19/02/2023 14:01`
   * `my_date.now.datetime.add(weak=-1).datetime` => `19/02/2023 14:01`
 
 donc `{nom_resolver}.now[.add\(year(s)=X,month(s)=X,day(s)=X,hour(s)=X,minute(s)=X,second(s)=X,week(s)=X\)].(date|time|datetime|strtime\({pattern}\))`
 
-Pour add on a les options : `year`,`month` ,`day`, `hour`, `minute`, `second`, `week` (ou avec des `s`) qui permettent d'ajouter (valeur positive) ou enlever (valeur négative) du temps à la date. Il n'y a pas d'ordre dans les paramètres et il ne sont pas tous obligatoires.
+Pour `add` on a les options : `year`,`month` ,`day`, `hour`, `minute`, `second`, `week` (ou avec des `s`) qui permettent d'ajouter (valeur positive) ou enlever (valeur négative) du temps à la date. Il n'y a pas d'ordre dans les paramètres et ils ne sont pas tous obligatoires.
 
-Les pattern pour les date (date, time, datetime, pattern donné avec strtime) suivent les [patterns de datetime](https://docs.python.org/fr/3/library/datetime.html#strftime-and-strptime-format-codes). Les pattern des sorties par défaut (date, time, datetime) sont dans la configuration.
+Les pattern pour les dates (date, time, datetime, pattern donné avec strtime) suivent les [patterns de datetime](https://docs.python.org/fr/3/library/datetime.html#strftime-and-strptime-format-codes). Les pattern des sorties par défaut (date, time, datetime) sont dans la configuration.
 
 ```ini
 datetime_pattern = %d/%m/%Y %H:%M
@@ -250,7 +250,7 @@ heure +4h > {date.now.add(hours=4).time} <
 datetime +1an 4h > {date.now.add(year=1, hours=4).datetime} <
 date +1an 4h pattern différent > {date.now.add(year=1, hours=4).strtime(%Y-%m-%dT%H:%M:%S)} <
 
-## différentes modification de date :
+## différentes modifications de date :
 Y+1 M+2 D+3 H+4 M+5 > {date.now.add(year=1,month=2,day=3,hour=4,minute=5).datetime} <
 Y-1 M+2 D+3 H-4 M+5 > {date.now.add(year=-1,month=2,day=3,hour=-4,minute=5).datetime} <
 Y-1 M+2 D+3 H-4 M+5 > {date.now.add(years=-1,months=2,days=3,hours=-4,minutes=5).datetime} <
@@ -273,7 +273,7 @@ print(GlobalResolver().resolve(text))
 #    datetime +1an 4h > 20/02/2025 15:08 <
 #    date +1an 4h pattern différent > 2025-02-20T15:08:03 <
 #
-#    ## différentes modification de date :
+#    ## différentes modifications de date :
 #    Y+1 M+2 D+3 H+4 M+5 > 23/04/2025 15:13 <
 #    Y-1 M+2 D+3 H-4 M+5 > 23/04/2023 07:13 <
 #    Y-1 M+2 D+3 H-4 M+5 > 23/04/2023 07:13 <

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -23,6 +23,7 @@ from sdk_entrepot_gpf.store.Metadata import Metadata
 from sdk_entrepot_gpf.store.Static import Static
 from sdk_entrepot_gpf.workflow.Workflow import Workflow
 from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
+from sdk_entrepot_gpf.workflow.resolver.DateResolver import DateResolver
 from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
 from sdk_entrepot_gpf.workflow.resolver.StoreEntityResolver import StoreEntityResolver
 from sdk_entrepot_gpf.workflow.action.UploadAction import UploadAction
@@ -614,6 +615,8 @@ class Main:
                 # Sinon, on définit des résolveurs
                 GlobalResolver().add_resolver(StoreEntityResolver("store_entity"))
                 GlobalResolver().add_resolver(UserResolver("user"))
+                GlobalResolver().add_resolver(DateResolver("datetime"))
+
                 # le comportement
                 s_behavior = str(self.o_args.behavior).upper() if self.o_args.behavior is not None else None
                 # on reset l'afficheur de log

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -247,6 +247,11 @@ store_entity_regex=(?P<entity_type>(upload|stored_data|processing_execution|offe
 global_regex=(?P<param>(\["_|{("_)?)(?P<resolver_name>[a-z_]+)(\.|_": *"|_", *")(?P<to_solve>[^"{}]*?({[^}]+}[^"{}]*?)*)("\]|"?}))
 file_regex=(?P<resolver_type>str|list|dict)\((?P<resolver_file>.*)\)
 
+# pattern pour le résolveur de date
+date_regex=(?P<date>now)\.?(add\((?P<add_param>(\w+=-?\d+,?\s*)+)\))?\.(?P<output>datetime|date|time|strtime\((?P<output_pattern>.+)\))
+datetime_pattern = %d/%m/%Y %H:%M
+date_pattern = %d/%m/%Y
+time_pattern = %H:%M
 
 [json_converter]
 # Pattern de convertion des types Python en str

--- a/sdk_entrepot_gpf/workflow/resolver/DateResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/DateResolver.py
@@ -23,9 +23,9 @@ class DateResolver(AbstractResolver):
         """
         super().__init__(name)
         self.__regex: Pattern[str] = re.compile(Config().get_str("workflow_resolution_regex", "date_regex"))
-        self.__datetime_pattern: Pattern[str] = Config().get_str("workflow_resolution_regex", "datetime_pattern")
-        self.__date_pattern: Pattern[str] = Config().get_str("workflow_resolution_regex", "date_pattern")
-        self.__time_pattern: Pattern[str] = Config().get_str("workflow_resolution_regex", "time_pattern")
+        self.__datetime_pattern: str = Config().get_str("workflow_resolution_regex", "datetime_pattern")
+        self.__date_pattern: str = Config().get_str("workflow_resolution_regex", "date_pattern")
+        self.__time_pattern: str = Config().get_str("workflow_resolution_regex", "time_pattern")
 
     def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
         """Résolution bête : on retourne la chaîne à résoudre.

--- a/sdk_entrepot_gpf/workflow/resolver/DateResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/DateResolver.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+import re
+from typing import Any, Pattern
+from dateutil.relativedelta import relativedelta
+
+from sdk_entrepot_gpf.workflow.resolver.AbstractResolver import AbstractResolver
+from sdk_entrepot_gpf.io.Config import Config
+from sdk_entrepot_gpf.workflow.resolver.Errors import ResolverError
+
+
+class DateResolver(AbstractResolver):
+    """Classe permettant de résoudre une date.
+
+    Attributes:
+        __name (str): nom de code du resolver
+    """
+
+    def __init__(self, name: str) -> None:
+        """À l'instanciation, le résolveur est nommé selon ce qui est indiqué dans la Config.
+
+        Args:
+            name (str): nom du résolveur
+        """
+        super().__init__(name)
+        self.__regex: Pattern[str] = re.compile(Config().get_str("workflow_resolution_regex", "date_regex"))
+        self.__datetime_pattern: Pattern[str] = Config().get_str("workflow_resolution_regex", "datetime_pattern")
+        self.__date_pattern: Pattern[str] = Config().get_str("workflow_resolution_regex", "date_pattern")
+        self.__time_pattern: Pattern[str] = Config().get_str("workflow_resolution_regex", "time_pattern")
+
+    def resolve(self, string_to_solve: str, **kwargs: Any) -> str:
+        """Résolution bête : on retourne la chaîne à résoudre.
+
+        Args:
+            string_to_solve (str): chaîne à résoudre.
+            kwargs (Any): paramètres supplémentaires.
+
+        Returns:
+            str: chaîne résolue
+        """
+
+        # On parse la chaîne à résoudre
+        o_result = self.__regex.search(string_to_solve)
+        if o_result is None:
+            raise ResolverError(self.name, string_to_solve)
+        d_groups = o_result.groupdict()
+
+        # date de référence
+        if d_groups["date"] == "now":
+            o_date = datetime.now()
+        else:
+            raise ResolverError(self.name, string_to_solve)
+        # print(string_to_solve, d_groups["add_param"])
+        # ajout si besoin (nom négatif accepté)
+        if "add_param" in d_groups and d_groups["add_param"]:
+            # récupération des valeur à ajouter
+            d_add_info = {s.split("=")[0].strip(): int(s.split("=")[1]) for s in d_groups["add_param"].split(",")}
+            # création et ajout du delta
+            o_date += relativedelta(
+                years=d_add_info.get("years", d_add_info.get("year", 0)),
+                months=d_add_info.get("months", d_add_info.get("month", 0)),
+                days=d_add_info.get("days", d_add_info.get("day", 0)),
+                hours=d_add_info.get("hours", d_add_info.get("hour", 0)),
+                minutes=d_add_info.get("minutes", d_add_info.get("minute", 0)),
+                weeks=d_add_info.get("weeks", d_add_info.get("week", 0)),
+                seconds=d_add_info.get("seconds", d_add_info.get("second", 0)),
+            )
+
+        # passage de la date en texte avec le bon pattern
+        if d_groups["output"] == "date":
+            return o_date.strftime(self.__date_pattern)
+        if d_groups["output"] == "time":
+            return o_date.strftime(self.__time_pattern)
+        if d_groups["output"] == "datetime":
+            return o_date.strftime(self.__datetime_pattern)
+        if d_groups["output"].startswith("strtime"):
+            return o_date.strftime(d_groups["output_pattern"])
+
+        # pattern de sortie non gérer
+        raise ResolverError(self.name, string_to_solve)

--- a/tests/workflow/resolver/DateResolverTestCase.py
+++ b/tests/workflow/resolver/DateResolverTestCase.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from unittest.mock import patch
+from dateutil.relativedelta import relativedelta
+
+from sdk_entrepot_gpf.workflow.resolver.DateResolver import DateResolver
+from sdk_entrepot_gpf.workflow.resolver.Errors import ResolverError
+from tests.GpfTestCase import GpfTestCase
+
+
+class DateResolverTestCase(GpfTestCase):
+    """Tests DateResolver class.
+
+    cmd : python3 -m unittest -b tests.workflow.resolver.DateResolverTestCase
+    """
+
+    def test_resolve(self) -> None:
+        """Vérifie le bon fonctionnement de la fonction resolve."""
+        # on force la configuration de la date
+        # TODO
+
+        # date actuelle que l'on utilisera
+        o_date = datetime.now()
+
+        # Instanciation du résolveur
+        o_resolver = DateResolver("4t")
+
+        d_data = {
+            # date actuel
+            "now.date": o_date.strftime("%d/%m/%Y"),
+            "now.time": o_date.strftime("%H:%M"),
+            "now.datetime": o_date.strftime("%d/%m/%Y %H:%M"),
+            "now.strtime(%Y-%m-%dT%H:%M:%S)": o_date.strftime("%Y-%m-%dT%H:%M:%S"),
+            # add/remove
+            "now.add(year=1,month=2,day=3,hour=4,minute=5).datetime": (o_date + relativedelta(years=1, months=2, days=3, hours=4, minutes=5)).strftime("%d/%m/%Y %H:%M"),
+            "now.add(year=-1,minute=-5,month=2,day=3,hour=4).datetime": (o_date + relativedelta(years=-1, months=2, days=3, hours=4, minutes=-5)).strftime("%d/%m/%Y %H:%M"),
+            "now.add(year=-1,month=2).datetime": (o_date + relativedelta(years=-1, months=2)).strftime("%d/%m/%Y %H:%M"),
+            "now.add(weeks=2).datetime": (o_date + relativedelta(weeks=2)).strftime("%d/%m/%Y %H:%M"),
+        }
+        # test en mode réussite (avec toutes les clefs/valeurs de notre dict)
+        ## on fixe la date
+        with patch("sdk_entrepot_gpf.workflow.resolver.DateResolver.datetime") as o_mock_now:
+            o_mock_now.now.return_value = o_date
+            ## test de la résolution
+            for k, v in d_data.items():
+                self.assertEqual(o_resolver.resolve(k), v)
+
+        # test en mode erreur (exception levée + message ok)
+        ## pattern faux
+        s_to_solve = "non_existant"
+        with self.assertRaises(ResolverError) as o_arc:
+            o_resolver.resolve(s_to_solve)
+        self.assertEqual(o_arc.exception.message, f"Erreur du résolveur '4t' avec la chaîne '{s_to_solve}'.")


### PR DESCRIPTION
Résolveur pour les date suite demande #86 

pattern pour le résolveur : `{nom_resolver}.now[.add\(year=X,month=X,day=X,hour=X,minutes=X\)].(date|time|datetime|strtime\({pattern}\))`

## [Added]

* DateResolver: ajout d'un résolveur pour les dates #86