### PR TITLE
Debug processing execution. Close #98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * #80 : Upload.api_delete_data_file(): suppression exception pour répertoire "data"
 * #78 : ajout route `upload_delete_data` dans la configuration
 * Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
+* Bug #98: problème de datastore lors de la création d'une ProcessingExecution
 
 ## v0.1.21
 

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -108,7 +108,7 @@ class ProcessingExecutionAction(ActionAbstract):
         # A ce niveau là, si on a encore self.__processing_execution qui est None, c'est qu'on peut créer l'Exécution de Traitement sans problème
         if self.__processing_execution is None:
             # création de la ProcessingExecution
-            self.__processing_execution = ProcessingExecution.api_create({**self.definition_dict["body_parameters"], "datastore": datastore})
+            self.__processing_execution = ProcessingExecution.api_create(self.definition_dict["body_parameters"], {"datastore": datastore})
             d_info = self.__processing_execution.get_store_properties()["output"]
 
         if d_info is None:

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -167,7 +167,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                 o_mock_pea_find_stored_data.assert_not_called()
 
             # test de l'appel à ProcessingExecution.api_create
-            o_mock_pe_api_create.assert_called_once_with({**d_action['body_parameters'], "datastore":datastore})
+            o_mock_pe_api_create.assert_called_once_with(d_action['body_parameters'], {"datastore":datastore})
             # un appel à ProcessingExecution().get_store_properties
             o_mock_processing_execution.get_store_properties.assert_called_once_with()
 


### PR DESCRIPTION
Développement pour #98 

## [Fixed]

* Bug #98: problème de datastore lors de la création d'une ProcessingExecution