### PR TITLE
v0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### [Fixed]
 
+* #80 : Upload.api_delete_data_file(): suppression exception pour répertoire "data"
+
 ## v0.1.21
 
 ### [Added]
@@ -16,7 +18,6 @@
 
 ### [Fixed]
 
-* #80 : Upload.api_delete_data_file(): suppression exception pour répertoire "data"
 * Upload: modification de la requête suite modification de l'API GPF #54
 
 ## v0.1.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### [Changed]
 
+* Renommage de `CopieConfigurationAction` en `CopyConfigurationAction`
+
 ### [Fixed]
 
 * Upload: modification de la requête suite modification de l'API GPF #54
@@ -15,8 +17,6 @@
 ### [Added]
 
 ### [Changed]
-
-* Renommage de `CopieConfigurationAction` en `CopyConfigurationAction`
 
 ### [Fixed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Added]
 
+* Résolveurs: possibilité de descendre dans les tests et les listes #87
+
 ### [Changed]
 
 ### [Fixed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Added]
 
+* Dans une étape d'un workflow, itération possible sur les actions. (V0, sera améliorer suite à la modification des résolveurs #87, #85)
+
 ### [Changed]
 
 ### [Fixed]
@@ -11,8 +13,6 @@
 ## v0.1.21
 
 ### [Added]
-
-* Dans une étape d'un workflow, itération possible sur les actions. (V0, sera améliorer suite à la modification des résolveurs #87, #85)
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### [Fixed]
 
+* #80 : Upload.api_delete_data_file(): suppression exception pour répertoire "data"
+
 ## v0.1.20
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### [Fixed]
 
+* #78 : ajout route `upload_delete_data` dans la configuration
+
 ## v0.1.20
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### [Changed]
 
+* Renommage de `CopieConfigurationAction` en `CopyConfigurationAction`
+
 ### [Fixed]
+
+* Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
 
 ## v0.1.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * #80 : Upload.api_delete_data_file(): suppression exception pour répertoire "data"
 * #78 : ajout route `upload_delete_data` dans la configuration
 * Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
+* Bug #98: problème de datastore lors de la création d'une ProcessingExecution
 
 ## v0.1.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * #80 : Upload.api_delete_data_file(): suppression exception pour répertoire "data"
 * #78 : ajout route `upload_delete_data` dans la configuration
 * Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
-* Bug #98: problème de datastore lors de la création d'une ProcessingExecution
+* Bug #98 : problème de datastore lors de la création d'une ProcessingExecution
 
 ## v0.1.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGE LOG
 
+## v0.1.22
+
+### [Added]
+
+### [Changed]
+
+### [Fixed]
+
 ## v0.1.21
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### [Fixed]
 
-* Upload: modification de la requête suite modification de l'API GPF #54
+* Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
 
 ## v0.1.21
 
@@ -20,7 +20,7 @@
 
 ### [Fixed]
 
-* Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
+* Upload: modification de la requête suite modification de l'API GPF #54
 
 ## v0.1.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### [Fixed]
 
 * #80 : Upload.api_delete_data_file(): suppression exception pour répertoire "data"
+* Upload: modification de la requête suite modification de l'API GPF #54
 
 ## v0.1.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Added]
 
+* Dans une étape d'un workflow, itération possible sur les actions. (V0, sera améliorer suite à la modification des résolveurs #87, #85)
+
 ### [Changed]
 
 ### [Fixed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # CHANGE LOG
 
+## v0.1.23
+
+### [Added]
+
+### [Changed]
+
+### [Fixed]
+
 ## v0.1.22
 
 ### [Added]
 
-* Dans une étape d'un workflow, itération possible sur les actions. (V0, sera améliorer suite à la modification des résolveurs #87, #85)
+* Dans une étape d'un workflow, itération possible sur les actions. (V0, sera amélioré suite à la modification des résolveurs #87, #85)
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### [Fixed]
 
+* #83 : fusion de la liste des used_data en gardant l'ordre de la liste lors de édition de configuration
+
 ## v0.1.20
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### [Fixed]
 
-* #83 : fusion de la liste des used_data en gardant l'ordre de la liste lors de édition de configuration
+* #83 : fusion de la liste des used_data en gardant l'ordre de la liste lors de l'édition de configurations
 
 ## v0.1.20
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Installez le module via pip :
 pip install sdk_entrepot_gpf
 ```
 
-Vous pouvez ensuite l'[utiliser comme exécutable](docs/comme-executable.md) ou l'[importer dans vos scripts Python](docs/comme-module.md).
+Vous pouvez ensuite l'[utiliser comme exécutable](https://geoplateforme.github.io/sdk-entrepot/comme-executable/) ou l'[importer dans vos scripts Python](https://geoplateforme.github.io/sdk-entrepot/comme-module/).
 
 ## Développement
 
-Si vous souhaitez participer au développement du projet, consultez le [document détaillant comment procéder](docs/development.md).
+Si vous souhaitez participer au développement du projet, consultez le [document détaillant comment procéder](https://geoplateforme.github.io/sdk-entrepot/development/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ doc = [
 
 [project.urls]
 Source = "https://github.com/Geoplateforme/sdk_entrepot"
-Documentation = "https://github.com/Geoplateforme/sdk_entrepot/blob/prod/docs/index.md"
+Documentation = "https://geoplateforme.github.io/sdk-entrepot/"
 
 [project.scripts]
 realpython = "sdk_entrepot_gpf.__main__:main"

--- a/sdk_entrepot_gpf/__init__.py
+++ b/sdk_entrepot_gpf/__init__.py
@@ -1,3 +1,3 @@
 """Python API to simplify the use of the GPF Warehouse HTTPS API."""
 
-__version__ = "0.1.21"
+__version__ = "0.1.22"

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -244,7 +244,7 @@ filter_infos = ((\s*)INFOS(\s*)\((?P<filter_infos>.*?)\)(\s*))?
 filter_tags = ((\s*)TAGS(\s*)\((?P<filter_tags>.*?)\)(\s*))?
 filter = ((\s*)\[${filter_infos},?${filter_tags}\])
 store_entity_regex=(?P<entity_type>(upload|stored_data|processing_execution|offering|processing|configuration|endpoint|static|datastore))\.(?P<selected_field_type>(tags|infos))\.(?P<selected_field>\w*)${filter}
-global_regex=(?P<param>(\["_|{("_)?)(?P<resolver_name>[a-z_]+)(\.|_": *"|_", *")(?P<to_solve>[^"{}]*?({[^}]+}[^"{}]*?)*)("\]|"?}))
+global_regex=(?P<param>(\["_|{("_)?)(?P<resolver_name>[a-z_0-9]+)(\.|_": *"|_", *")(?P<to_solve>[^"{}]*?({[^}]+}[^"{}]*?)*)("\]|"?}))
 file_regex=(?P<resolver_type>str|list|dict)\((?P<resolver_file>.*)\)
 
 

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -243,7 +243,7 @@ filter_infos = ((\s*)INFOS(\s*)\((?P<filter_infos>.*?)\)(\s*))?
 # Filtre de store_entity à partir des tags
 filter_tags = ((\s*)TAGS(\s*)\((?P<filter_tags>.*?)\)(\s*))?
 filter = ((\s*)\[${filter_infos},?${filter_tags}\])
-store_entity_regex=(?P<entity_type>(upload|stored_data|processing_execution|offering|processing|configuration|endpoint|static|datastore))\.(?P<selected_field_type>(tags|infos))\.(?P<selected_field>\w*)${filter}
+store_entity_regex=(?P<entity_type>(upload|stored_data|processing_execution|offering|processing|configuration|endpoint|static|datastore))\.(?P<selected_field_type>(tags|infos))\.(?P<selected_field>(\w|\.|\[\d+\])*)${filter}
 global_regex=(?P<param>(\["_|{("_)?)(?P<resolver_name>[a-z_]+)(\.|_": *"|_", *")(?P<to_solve>[^"{}]*?({[^}]+}[^"{}]*?)*)("\]|"?}))
 file_regex=(?P<resolver_type>str|list|dict)\((?P<resolver_file>.*)\)
 

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -55,6 +55,7 @@ upload_delete=${routing:upload_list}/{upload}
 upload_add_tags=${upload_get}/tags
 upload_delete_tags=${upload_get}/tags
 upload_push_data=${upload_get}/data
+upload_delete_data=${upload_get}/data
 upload_push_md5=${upload_get}/md5
 upload_delete_md5=${upload_push_md5}
 upload_close=${upload_get}/close

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -39,7 +39,7 @@
                                                 "delete-entity",
                                                 "processing-execution",
                                                 "configuration",
-                                                "copie-configuration",
+                                                "copy-configuration",
                                                 "offering",
                                                 "synchronize-offering"
                                             ]

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -108,6 +108,15 @@
                             },
                             "tags": {
                                 "type": "object"
+                            },
+                            "iter_vals" : {
+                                "type": "array",
+                                "items": {
+                                    "type": ["string",  "object"]
+                                }
+                            },
+                            "iter_key": {
+                                "type": "string"
                             }
                         }
                     }

--- a/sdk_entrepot_gpf/store/Configuration.py
+++ b/sdk_entrepot_gpf/store/Configuration.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List
+from sdk_entrepot_gpf.store.Errors import StoreEntityError
 
 from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
@@ -58,3 +59,24 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
         l_entities += l_offering
         l_entities.append(self)
         return l_entities
+
+    def edit(self, data_edit: Dict[str, Any]) -> None:
+        """Mise à jour totale de l'entité en fusionnant le nouveau dictionnaire (prioritaire) et l'ancien.
+        configuration fusion de la liste des used_data
+
+        Args:
+            data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
+        """
+        d_origine_data = self.get_store_properties()
+        # fusion de used_data
+        l_used_data = []
+        if len(d_origine_data["used_data"]) != len(data_edit["used_data"]):
+            s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
+            raise StoreEntityError(s_message)
+        for i in range(len(d_origine_data["used_data"])):
+            l_used_data.append({**d_origine_data["used_data"][i], **data_edit["used_data"][i]})
+
+        # fusion des dictionnaires actuel et nouveau (prioritaire)
+        d_data = {**self.get_store_properties(), **data_edit, **{"used_data": l_used_data}}
+
+        self.api_full_edit(d_data)

--- a/sdk_entrepot_gpf/store/Configuration.py
+++ b/sdk_entrepot_gpf/store/Configuration.py
@@ -62,7 +62,8 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
 
     def edit(self, data_edit: Dict[str, Any]) -> None:
         """Mise à jour totale de l'entité en fusionnant le nouveau dictionnaire (prioritaire) et l'ancien.
-        configuration fusion de la liste des used_data
+        Pour les configurations, il faut en plus fusionner la liste des used_data.
+        Si la nouvelle liste et l'ancienne liste n'ont pas la même taille, une exception est levée.
 
         Args:
             data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
@@ -76,7 +77,7 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
         for i in range(len(d_origine_data["used_data"])):
             l_used_data.append({**d_origine_data["used_data"][i], **data_edit["used_data"][i]})
 
-        # fusion des dictionnaires actuel et nouveau (prioritaire)
+        # fusion des dictionnaires actuels et nouveaux (prioritaire)
         d_data = {**self.get_store_properties(), **data_edit, **{"used_data": l_used_data}}
 
         self.api_full_edit(d_data)

--- a/sdk_entrepot_gpf/store/Upload.py
+++ b/sdk_entrepot_gpf/store/Upload.py
@@ -49,7 +49,7 @@ class Upload(TagInterface, CommentInterface, SharingInterface, EventInterface, P
             file_path,
             s_file_key,
             route_params={"datastore": self.datastore, self._entity_name: self.id},
-            params={"path": api_path},
+            params={"path": api_path + "/" + file_path.name},
             method=ApiRequester.POST,
         )
 

--- a/sdk_entrepot_gpf/store/Upload.py
+++ b/sdk_entrepot_gpf/store/Upload.py
@@ -56,15 +56,9 @@ class Upload(TagInterface, CommentInterface, SharingInterface, EventInterface, P
     def api_delete_data_file(self, api_path: str) -> None:
         """Supprime un fichier de donnée de la Livraison.
 
-        Retire `data/` de devant le chemin distant si jamais il le contient.
-
         Args:
             api_path: chemin distant vers le fichier à supprimer
         """
-        # On retire data/ de devant le chemin si jamais il le contient
-        if api_path.startswith("data/"):
-            api_path = api_path[5:]
-
         # Génération du nom de la route
         s_route = f"{self._entity_name}_delete_data"
 

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -253,7 +253,7 @@ class Workflow:
             return ProcessingExecutionAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "configuration":
             return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
-        if definition_dict["type"] == "copie-configuration":
+        if definition_dict["type"] == "copy-configuration":
             return CopyConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "offering":
             return OfferingAction(workflow_context, definition_dict, parent_action, behavior=behavior)

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -10,7 +10,7 @@ from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.workflow.Errors import WorkflowError
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
-from sdk_entrepot_gpf.workflow.action.CopieConfigurationAction import CopieConfigurationAction
+from sdk_entrepot_gpf.workflow.action.CopyConfigurationAction import CopyConfigurationAction
 from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
 from sdk_entrepot_gpf.workflow.action.EditAction import EditAction
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
@@ -254,7 +254,7 @@ class Workflow:
         if definition_dict["type"] == "configuration":
             return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "copie-configuration":
-            return CopieConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
+            return CopyConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "offering":
             return OfferingAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "synchronize-offering":

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -170,7 +170,7 @@ class Workflow:
             l_actions = []
             s_actions = str(json.dumps(d_step["actions"], ensure_ascii=False))
 
-            if isinstance(d_step["iter_vals"][0], str) or isinstance(d_step["iter_vals"][0], float) or isinstance(d_step["iter_vals"][0], int):
+            if isinstance(d_step["iter_vals"][0], (str, float, int)):
                 # si la liste est une liste de string, un int ou flat : on remplace directement
                 for s_val in d_step["iter_vals"]:
                     l_actions += json.loads(s_actions.replace("{" + d_step["iter_key"] + "}", s_val))
@@ -181,7 +181,6 @@ class Workflow:
                     GlobalResolver().add_resolver(DictResolver(f"iter_resolve_{i}", s_val))
 
             d_step["actions"] = l_actions
-            print(l_actions)
         elif "iter_vals" in d_step or "iter_key" in d_step:
             # on a une seule des deux clef
             s_error_message = f"Une seule des clefs iter_vals ou iter_key est trouvée: il faut mettre les deux valeurs ou aucune. Étape {step_name} workflow {self.__name}"
@@ -189,27 +188,17 @@ class Workflow:
             raise WorkflowError(s_error_message)
 
         # on récupère les commentaires commun au workflow et à l'étape
-        if "comments" in self.__raw_definition_dict:
-            comments.extend(self.__raw_definition_dict["comments"])
-        if "comments" in d_step:
-            comments.extend(d_step["comments"])
+        comments.extend(self.__raw_definition_dict.get("comments", []))
+        comments.extend(d_step.get("comments", []))
 
         # on récupère les tags commun au workflow et à l'étape
-        if "tags" in self.__raw_definition_dict:
-            tags.update(self.__raw_definition_dict["tags"])
-        if "tags" in d_step:
-            tags.update(d_step["tags"])
+        tags.update(self.__raw_definition_dict.get("tags", {}))
+        tags.update(d_step.get("tags", {}))
 
-        # Ajout des commentaire et des tags à chaque actions
+        # Ajout des commentaires et des tags à chaque actions
         for d_action in d_step["actions"]:
-            if "comments" in d_action:
-                d_action["comments"] = [*comments, *d_action["comments"]]
-            else:
-                d_action["comments"] = comments
-            if "tags" in d_action:
-                d_action["tags"] = {**tags, **d_action["tags"]}
-            else:
-                d_action["tags"] = tags
+            d_action["comments"] = [*comments, *d_action.get("comments", [])]
+            d_action["tags"] = {**tags, **d_action.get("tags", {})}
 
         return d_step
 

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -17,6 +18,8 @@ from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import Processin
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
 from sdk_entrepot_gpf.workflow.action.SynchronizeOfferingAction import SynchronizeOfferingAction
+from sdk_entrepot_gpf.workflow.resolver.DictResolver import DictResolver
+from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
 
 
 class Workflow:
@@ -152,39 +155,63 @@ class Workflow:
             Dict[str, Any]: dictionnaire de l'étape
         """
         # Recherche de l'étape correspondante
-        if step_name in self.__raw_definition_dict["workflow"]["steps"]:
-            # récupération e l'étape :
-            d_step = dict(self.__raw_definition_dict["workflow"]["steps"][step_name])
+        if step_name not in self.__raw_definition_dict["workflow"]["steps"]:
+            # Si on passe le if, c'est que l'étape n'existe pas dans la définition du workflow
+            s_error_message = f"L'étape {step_name} n'est pas définie dans le workflow {self.__name}"
+            Config().om.error(s_error_message)
+            raise WorkflowError(s_error_message)
 
-            # on récupère les commentaires commun au workflow et à l'étape
-            if "comments" in self.__raw_definition_dict:
-                comments.extend(self.__raw_definition_dict["comments"])
-            if "comments" in d_step:
-                comments.extend(d_step["comments"])
+        # récupération e l'étape :
+        d_step = dict(self.__raw_definition_dict["workflow"]["steps"][step_name])
 
-            # on récupère les tags commun au workflow et à l'étape
-            if "tags" in self.__raw_definition_dict:
-                tags.update(self.__raw_definition_dict["tags"])
-            if "tags" in d_step:
-                tags.update(d_step["tags"])
+        # Gestion des itérations
+        if "iter_vals" in d_step and "iter_key" in d_step:
+            # on itère sur les clefs
+            l_actions = []
+            s_actions = str(json.dumps(d_step["actions"], ensure_ascii=False))
 
-            # Ajout des commentaire et des tags à chaque actions
-            for d_action in d_step["actions"]:
-                if "comments" in d_action:
-                    d_action["comments"] = [*comments, *d_action["comments"]]
-                else:
-                    d_action["comments"] = comments
-                if "tags" in d_action:
-                    d_action["tags"] = {**tags, **d_action["tags"]}
-                else:
-                    d_action["tags"] = tags
+            if isinstance(d_step["iter_vals"][0], str) or isinstance(d_step["iter_vals"][0], float) or isinstance(d_step["iter_vals"][0], int):
+                # si la liste est une liste de string, un int ou flat : on remplace directement
+                for s_val in d_step["iter_vals"]:
+                    l_actions += json.loads(s_actions.replace("{" + d_step["iter_key"] + "}", s_val))
+            else:
+                # on a une liste de sous dict ou apparenté on utilise un résolveur
+                for i, s_val in enumerate(d_step["iter_vals"]):
+                    l_actions += json.loads(s_actions.replace(d_step["iter_key"], f"iter_resolve_{i}"))
+                    GlobalResolver().add_resolver(DictResolver(f"iter_resolve_{i}", s_val))
 
-            return d_step
+            d_step["actions"] = l_actions
+            print(l_actions)
+        elif "iter_vals" in d_step or "iter_key" in d_step:
+            # on a une seule des deux clef
+            s_error_message = f"Une seule des clefs iter_vals ou iter_key est trouvée: il faut mettre les deux valeurs ou aucune. Étape {step_name} workflow {self.__name}"
+            Config().om.error(s_error_message)
+            raise WorkflowError(s_error_message)
 
-        # Si on passe le if, c'est que l'étape n'existe pas dans la définition du workflow
-        s_error_message = f"L'étape {step_name} n'est pas définie dans le workflow {self.__name}"
-        Config().om.error(s_error_message)
-        raise WorkflowError(s_error_message)
+        # on récupère les commentaires commun au workflow et à l'étape
+        if "comments" in self.__raw_definition_dict:
+            comments.extend(self.__raw_definition_dict["comments"])
+        if "comments" in d_step:
+            comments.extend(d_step["comments"])
+
+        # on récupère les tags commun au workflow et à l'étape
+        if "tags" in self.__raw_definition_dict:
+            tags.update(self.__raw_definition_dict["tags"])
+        if "tags" in d_step:
+            tags.update(d_step["tags"])
+
+        # Ajout des commentaire et des tags à chaque actions
+        for d_action in d_step["actions"]:
+            if "comments" in d_action:
+                d_action["comments"] = [*comments, *d_action["comments"]]
+            else:
+                d_action["comments"] = comments
+            if "tags" in d_action:
+                d_action["tags"] = {**tags, **d_action["tags"]}
+            else:
+                d_action["tags"] = tags
+
+        return d_step
 
     def get_actions(self, step_name: str) -> List[ActionAbstract]:
         """Instancie les actions de l'étape demandée et en renvoie la liste.

--- a/sdk_entrepot_gpf/workflow/action/CopyConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/CopyConfigurationAction.py
@@ -5,7 +5,7 @@ from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 
 
-class CopieConfigurationAction(ConfigurationAction):
+class CopyConfigurationAction(ConfigurationAction):
     """Classe dédiée à la copie des Configuration.
 
     Attributes:

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -108,7 +108,7 @@ class ProcessingExecutionAction(ActionAbstract):
         # A ce niveau là, si on a encore self.__processing_execution qui est None, c'est qu'on peut créer l'Exécution de Traitement sans problème
         if self.__processing_execution is None:
             # création de la ProcessingExecution
-            self.__processing_execution = ProcessingExecution.api_create({**self.definition_dict["body_parameters"], "datastore": datastore})
+            self.__processing_execution = ProcessingExecution.api_create(self.definition_dict["body_parameters"], {"datastore": datastore})
             d_info = self.__processing_execution.get_store_properties()["output"]
 
         if d_info is None:

--- a/sdk_entrepot_gpf/workflow/resolver/AbstractResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/AbstractResolver.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Any
+import re
+from typing import Any, Dict
 
 
 class AbstractResolver(ABC):
@@ -31,3 +32,26 @@ class AbstractResolver(ABC):
     @property
     def name(self) -> str:
         return self.__name
+
+    @staticmethod
+    def get(key_value: Dict[str, Any], js_key: str) -> Any:
+        """fonction permettant de récupérer une valeur dans un dictionnaire complexe avec une récupération de style JS
+
+        Args:
+            key_value (Dict[str, Any]): dictionnaire dont on veut récupérer l'info
+            string (str): pattern type JS pour récupérer la valeur du dictionnaire
+
+        Returns:
+            Any: valeur demandée
+        """
+        o_val = key_value
+        l_keys = js_key.split(".")
+        # On itère selon les morceaux
+        for s_key in l_keys:
+            # traitement du cas des array (cle[0], cle[1], cle[-1], ...)
+            o_match = re.search(r"(.*)\[(-?\d*)\]$", s_key)
+            if o_match:
+                o_val = o_val[o_match.group(1)][int(o_match.group(2))]
+            else:
+                o_val = o_val[s_key]
+        return o_val

--- a/sdk_entrepot_gpf/workflow/resolver/DictResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/DictResolver.py
@@ -40,7 +40,8 @@ class DictResolver(AbstractResolver):
             str: chaîne résolue
         """
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
-        if string_to_solve in self.__key_value:
-            return str(self.__key_value[string_to_solve])
-        # Sinon on lève une exception
-        raise ResolverError(self.name, string_to_solve)
+        try:
+            return str(self.get(self.__key_value, string_to_solve))
+        except KeyError as e:
+            # Sinon on lève une exception
+            raise ResolverError(self.name, string_to_solve) from e

--- a/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
@@ -92,7 +92,10 @@ class StoreEntityResolver(AbstractResolver):
         # On doit envoyer une info ?
         if d_groups["selected_field_type"] == "infos":
             # On doit renvoyer une info
-            return str(o_entity[s_selected_field])
+            try:
+                return str(self.get(o_entity.get_store_properties(), s_selected_field))
+            except KeyError as e:
+                raise ResolverError(self.name, string_to_solve) from e
         # On doit renvoyer un tag, possible que si ça implémente TagInterface
         if isinstance(o_entity, TagInterface):
             return o_entity.get_tag(s_selected_field)

--- a/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
@@ -41,7 +41,8 @@ class UserResolver(AbstractResolver):
             valeur de l'attribut
         """
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
-        if string_to_solve in self.__user_data:
-            return str(self.__user_data[string_to_solve])
-        # Sinon on lève une exception
-        raise ResolveUserError(self.name, string_to_solve)
+        try:
+            return str(self.get(self.__user_data, string_to_solve))
+        except KeyError as e:
+            # Sinon on lève une exception
+            raise ResolveUserError(self.name, string_to_solve) from e

--- a/tests/store/UploadTestCase.py
+++ b/tests/store/UploadTestCase.py
@@ -37,7 +37,7 @@ class UploadTestCase(GpfTestCase):
                 p_file_path,
                 s_key_file,
                 route_params={"datastore": "id_datastore", "upload": "id_de_test"},
-                params={"path": s_api_path},
+                params={"path": s_api_path + "/" + p_file_path.name},
                 method=ApiRequester.POST,
             )
 

--- a/tests/store/UploadTestCase.py
+++ b/tests/store/UploadTestCase.py
@@ -88,29 +88,6 @@ class UploadTestCase(GpfTestCase):
                 params={"path": s_api_path},
             )
 
-    def test_api_delete_data_file_2(self) -> None:
-        """Vérifie le bon fonctionnement de api_delete_data_file si le chemin contient data/.
-        Dans ce test, le datastore n'est pas défini (cf. route_params).
-        """
-        # On instancie une livraison pour laquelle on veut supprimer des fichiers
-        # peu importe si la livraison comporte ou pas des fichiers
-        o_upload = Upload({"_id": "id_de_test"})
-        # on prend un chemin coté api
-        s_api_path = "data/path/cote/api"
-
-        # On mock la fonction route_request, on veut vérifier qu'elle est appelée avec les bons params
-        with patch.object(ApiRequester, "route_request", return_value=None) as o_mock_request:
-            # On appelle la fonction que l'on veut tester
-            o_upload.api_delete_data_file(s_api_path)
-
-            # Vérification sur o_mock_request
-            o_mock_request.assert_called_once_with(
-                "upload_delete_data",
-                method=ApiRequester.DELETE,
-                route_params={"datastore": None, "upload": "id_de_test"},
-                params={"path": s_api_path[5:]},  # le data/ a dû être retiré
-            )
-
     def test_api_delete_md5_file(self) -> None:
         """Vérifie le bon fonctionnement de api_delete_md5_file.
         Dans ce test, le datastore n'est pas défini (cf. route_params).

--- a/tests/store/interface/FullEditInterfaceTestCase.py
+++ b/tests/store/interface/FullEditInterfaceTestCase.py
@@ -54,7 +54,7 @@ class FullEditInterfaceTestCase(GpfTestCase):
 
         print(d_fusion)
 
-        o_entity = FullEditInterface({"_id": "1"})
+        o_entity = FullEditInterface(d_entity)
         with patch.object(FullEditInterface, "api_full_edit", return_value=None) as o_mock_api_edit:
             o_entity.edit(d_edit)
             o_mock_api_edit.assert_called_once_with(d_fusion)

--- a/tests/workflow/WorkflowTestCase.py
+++ b/tests/workflow/WorkflowTestCase.py
@@ -14,7 +14,7 @@ from sdk_entrepot_gpf.workflow.Errors import WorkflowError
 from sdk_entrepot_gpf.workflow.Workflow import Workflow
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
-from sdk_entrepot_gpf.workflow.action.CopieConfigurationAction import CopieConfigurationAction
+from sdk_entrepot_gpf.workflow.action.CopyConfigurationAction import CopyConfigurationAction
 from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
 from sdk_entrepot_gpf.workflow.action.EditAction import EditAction
 from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
@@ -366,7 +366,7 @@ class WorkflowTestCase(GpfTestCase):
         patch.object(ConfigurationAction, "__init__", wraps=new_init) as d_mock["ConfigurationAction"], \
         patch.object(OfferingAction, "__init__", wraps=new_init) as d_mock["OfferingAction"], \
         patch.object(SynchronizeOfferingAction, "__init__", wraps=new_init) as d_mock["SynchronizeOfferingAction"], \
-        patch.object(CopieConfigurationAction, "__init__", wraps=new_init) as d_mock["CopieConfigurationAction"], \
+        patch.object(CopyConfigurationAction, "__init__", wraps=new_init) as d_mock["CopyConfigurationAction"], \
         patch.object(EditAction, "__init__", wraps=new_init) as d_mock["EditAction"]:
             # fmt: on
             # exécution
@@ -403,7 +403,7 @@ class WorkflowTestCase(GpfTestCase):
         # test type synchronize-offering
         self.run_generation(SynchronizeOfferingAction, "name", {"type": "synchronize-offering"}, o_mock_parent, with_beavior=False)
         # test type copie-configuration
-        self.run_generation(CopieConfigurationAction, "name", {"type": "copie-configuration"}, o_mock_parent, with_beavior=True)
+        self.run_generation(CopyConfigurationAction, "name", {"type": "copy-configuration"}, o_mock_parent, with_beavior=True)
         # test type edit-entity
         self.run_generation(EditAction, "name", {"type": "edit-entity"}, o_mock_parent, with_beavior=False)
 

--- a/tests/workflow/WorkflowTestCase.py
+++ b/tests/workflow/WorkflowTestCase.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Any, Dict, Optional, Type, List
 from unittest.mock import PropertyMock, patch, MagicMock
@@ -13,6 +14,7 @@ from sdk_entrepot_gpf.workflow.Errors import WorkflowError
 from sdk_entrepot_gpf.workflow.Workflow import Workflow
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
+from sdk_entrepot_gpf.workflow.action.CopieConfigurationAction import CopieConfigurationAction
 from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
 from sdk_entrepot_gpf.workflow.action.EditAction import EditAction
 from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
@@ -38,7 +40,7 @@ class WorkflowTestCase(GpfTestCase):
         o_workflow = Workflow("nom", d_workflow)
         self.assertDictEqual(d_workflow, o_workflow.get_raw_dict())
 
-    def __list_action_run_step(self, s_etape: str, d_args_run_step: Dict[str, Any], d_workflow: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def __list_action_run_step(self, s_etape: str, d_args_run_step: Dict[str, Any], d_workflow: Dict[str, Any]) -> List[Dict[str, Any]]:  # pylint:disable=too-many-branches
         """création de la liste des actions pour run_run_step()
 
         Args:
@@ -51,6 +53,7 @@ class WorkflowTestCase(GpfTestCase):
         """
         if s_etape not in d_workflow["workflow"]["steps"]:
             return []
+        d_etape = d_workflow["workflow"]["steps"][s_etape]
         l_comments: List[str] = d_args_run_step["comments"]
         d_tags: Dict[str, str] = d_args_run_step["tags"]
         l_actions = []
@@ -61,11 +64,11 @@ class WorkflowTestCase(GpfTestCase):
         if "tags" in d_workflow:
             d_tags = {**d_tags, **d_workflow["tags"]}
         # dans l'étape
-        if "comments" in d_workflow["workflow"]["steps"][s_etape]:
-            l_comments = [*l_comments, *d_workflow["workflow"]["steps"][s_etape]["comments"]]
-        if "tags" in d_workflow["workflow"]["steps"][s_etape]:
-            d_tags = {**d_tags, **d_workflow["workflow"]["steps"][s_etape]["tags"]}
-        for d_action in d_workflow["workflow"]["steps"][s_etape]["actions"]:
+        if "comments" in d_etape:
+            l_comments = [*l_comments, *d_etape["comments"]]
+        if "tags" in d_etape:
+            d_tags = {**d_tags, **d_etape["tags"]}
+        for d_action in d_etape["actions"]:
             d_action = d_action.copy()
             if "comments" in d_action:
                 d_action["comments"] = [*l_comments, *d_action["comments"]]
@@ -76,6 +79,20 @@ class WorkflowTestCase(GpfTestCase):
             else:
                 d_action["tags"] = d_tags
             l_actions.append(d_action)
+
+        # les iterations
+        if "iter_vals" in d_etape and "iter_key" in d_etape:
+            # on itère sur les clefs
+            s_actions = str(json.dumps(l_actions, ensure_ascii=False))
+            l_actions = []
+            if isinstance(d_etape["iter_vals"][0], (str, float, int)):
+                # si la liste est une liste de string, un int ou flat : on remplace directement
+                for s_val in d_etape["iter_vals"]:
+                    l_actions += json.loads(s_actions.replace("{" + d_etape["iter_key"] + "}", s_val))
+            else:
+                # on a une liste de sous dict ou apparenté on utilise un résolveur
+                for i, s_val in enumerate(d_etape["iter_vals"]):
+                    l_actions += json.loads(s_actions.replace(d_etape["iter_key"], f"iter_resolve_{i}"))
         return l_actions
 
     def run_run_step(
@@ -287,6 +304,38 @@ class WorkflowTestCase(GpfTestCase):
             {**d_args, "step_name": "mise-en-base", "callback": callback, "behavior": "DELETE"}, d_workflow, [None], monitoring_until_end=["SUCCESS", "SUCCESS"], output_type="stored_data"
         )
 
+        # itérations
+        d_workflow_4: Dict[str, Any] = {
+            "workflow": {
+                "steps": {
+                    "mise-en-base": {
+                        "actions": [{"type": "action4-{ma_clef}", "datastore": "datastore_4-1"}, {"type": "action4-{ma_clef}"}],
+                        "iter_vals": ["a", "b", "c"],
+                        "iter_key": "ma_clef",
+                    },
+                    "mise-en-base-2": {
+                        "actions": [{"type": "action4-{ma_clef}", "datastore": "datastore_4-1"}, {"type": "action4-{ma_clef.nom}"}],
+                        "iter_vals": [{"nom": "a"}, {"nom": "b"}, {"nom": "c"}],
+                        "iter_key": "ma_clef",
+                    },
+                    "mise-en-base-3": {
+                        "actions": [],
+                        "iter_key": "ma_clef",
+                    },
+                    "mise-en-base-4": {
+                        "actions": [],
+                        "iter_vals": [{"nom": "a"}, {"nom": "b"}, {"nom": "c"}],
+                    },
+                }
+            }
+        }
+        self.run_run_step({**d_args, "step_name": "mise-en-base", "datastore": s_datastore}, d_workflow_4, [s_datastore] * 6)
+        self.run_run_step({**d_args, "step_name": "mise-en-base-2", "datastore": s_datastore}, d_workflow_4, [s_datastore] * 6)
+        s_message = "Une seule des clefs iter_vals ou iter_key est trouvée: il faut mettre les deux valeurs ou aucune. Étape mise-en-base-3 workflow nom"
+        self.run_run_step({**d_args, "step_name": "mise-en-base-3", "datastore": s_datastore}, d_workflow_4, [], error_message=s_message)
+        s_message = "Une seule des clefs iter_vals ou iter_key est trouvée: il faut mettre les deux valeurs ou aucune. Étape mise-en-base-4 workflow nom"
+        self.run_run_step({**d_args, "step_name": "mise-en-base-4", "datastore": s_datastore}, d_workflow_4, [], error_message=s_message)
+
     def run_generation(
         self,
         expected_type: Type[ActionAbstract],
@@ -317,6 +366,7 @@ class WorkflowTestCase(GpfTestCase):
         patch.object(ConfigurationAction, "__init__", wraps=new_init) as d_mock["ConfigurationAction"], \
         patch.object(OfferingAction, "__init__", wraps=new_init) as d_mock["OfferingAction"], \
         patch.object(SynchronizeOfferingAction, "__init__", wraps=new_init) as d_mock["SynchronizeOfferingAction"], \
+        patch.object(CopieConfigurationAction, "__init__", wraps=new_init) as d_mock["CopieConfigurationAction"], \
         patch.object(EditAction, "__init__", wraps=new_init) as d_mock["EditAction"]:
             # fmt: on
             # exécution
@@ -352,6 +402,8 @@ class WorkflowTestCase(GpfTestCase):
         self.run_generation(DeleteAction, "name", {"type": "delete-entity"}, o_mock_parent, with_beavior=False)
         # test type synchronize-offering
         self.run_generation(SynchronizeOfferingAction, "name", {"type": "synchronize-offering"}, o_mock_parent, with_beavior=False)
+        # test type copie-configuration
+        self.run_generation(CopieConfigurationAction, "name", {"type": "copie-configuration"}, o_mock_parent, with_beavior=True)
         # test type edit-entity
         self.run_generation(EditAction, "name", {"type": "edit-entity"}, o_mock_parent, with_beavior=False)
 

--- a/tests/workflow/action/CopyConfigurationActionTestCase.py
+++ b/tests/workflow/action/CopyConfigurationActionTestCase.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 
 from sdk_entrepot_gpf.store.Configuration import Configuration
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
-from sdk_entrepot_gpf.workflow.action.CopieConfigurationAction import CopieConfigurationAction
+from sdk_entrepot_gpf.workflow.action.CopyConfigurationAction import CopyConfigurationAction
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 
 from tests.GpfTestCase import GpfTestCase
@@ -14,10 +14,10 @@ from tests.GpfTestCase import GpfTestCase
 # pylint:disable=too-many-branches
 
 
-class CopieConfigurationActionTestCase(GpfTestCase):
-    """Tests CopieConfigurationAction class.
+class CopyConfigurationActionTestCase(GpfTestCase):
+    """Tests CopyConfigurationAction class.
 
-    cmd : python3 -m unittest -b tests.workflow.action.CopieConfigurationActionTestCase
+    cmd : python3 -m unittest -b tests.workflow.action.CopyConfigurationActionTestCase
     """
 
     def test_run(self) -> None:
@@ -25,13 +25,13 @@ class CopieConfigurationActionTestCase(GpfTestCase):
         # manque des paramétres
         l_dict_definition: List[Dict[str, Any]] = [{}, {"body_parameters": {}}, {"body_parameters": {"name": "nouveau name"}}, {"body_parameters": {"layer_name": "nouveau layer_name"}}]
         for d_definition in l_dict_definition:
-            o_action = CopieConfigurationAction("contexte", d_definition, None, "CONTINUE")
+            o_action = CopyConfigurationAction("contexte", d_definition, None, "CONTINUE")
             with self.assertRaises(StepActionError) as o_mock_err:
                 o_action.run("datastore")
             self.assertEqual('Les clefs "name" et "layer_name" sont obligatoires dans "body_parameters"', o_mock_err.exception.message)
 
         d_definition = {"url_parameters": {"configuration": "123"}, "body_parameters": {"layer_name": "nouveau layer_name", "name": "nouveau name"}}
-        o_action = CopieConfigurationAction("contexte", d_definition, None, "CONTINUE")
+        o_action = CopyConfigurationAction("contexte", d_definition, None, "CONTINUE")
 
         # fonctionnement OK
         o_mock_base_config = MagicMock()

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -167,7 +167,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                 o_mock_pea_find_stored_data.assert_not_called()
 
             # test de l'appel à ProcessingExecution.api_create
-            o_mock_pe_api_create.assert_called_once_with({**d_action['body_parameters'], "datastore":datastore})
+            o_mock_pe_api_create.assert_called_once_with(d_action['body_parameters'], {"datastore":datastore})
             # un appel à ProcessingExecution().get_store_properties
             o_mock_processing_execution.get_store_properties.assert_called_once_with()
 

--- a/tests/workflow/resolver/AbstractResolverTestCase.py
+++ b/tests/workflow/resolver/AbstractResolverTestCase.py
@@ -1,0 +1,23 @@
+from sdk_entrepot_gpf.workflow.resolver.AbstractResolver import AbstractResolver
+
+from tests.GpfTestCase import GpfTestCase
+
+
+class AbstractResolverTestCase(GpfTestCase):
+    """Tests AbstractResolver class.
+
+    cmd : python3 -m unittest -b tests.workflow.resolver.AbstractResolverTestCase
+    """
+
+    def test_get(self) -> None:
+        """test unitaire pour get()"""
+
+        d_data = {"key": "val", "dict": {"key": "val_dict"}, "list": ["val_list", {"key": "val_list_dict"}]}
+        l_res = [
+            ("key", "val"),
+            ("dict.key", "val_dict"),
+            ("list[0]", "val_list"),
+            ("list[1].key", "val_list_dict"),
+        ]
+        for s_js_key, s_res in l_res:
+            self.assertEqual(s_res, AbstractResolver.get(d_data, s_js_key))

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -53,6 +53,35 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 datastore=None,
             )
 
+    def test_no_key(self) -> None:
+        """vérifie l'erreur retournée quand la kef n'ai n'ai pas trouvée"""
+
+        o_store_entity_resolver = StoreEntityResolver("store_entity")
+        l_uploads = [
+            Upload({"_id": "upload_1", "name": "Name 1", "tags": {"k_tag": "v_tag"}}),
+            Upload({"_id": "upload_2", "name": "Name 2", "tags": {"k_tag": "v_tag"}}),
+        ]
+
+        # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
+
+        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
+        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
+            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
+                s_to_solve = "upload.infos.not_in_dict [INFOS(name=start_%), TAGS(k_tag=v_tag)]"
+                with self.assertRaises(ResolverError) as o_arc:
+                    o_store_entity_resolver.resolve(s_to_solve)
+                # message d'erreur :
+                self.assertEqual(o_arc.exception.message, f"Erreur du résolveur 'store_entity' avec la chaîne '{s_to_solve}'.")
+                # Vérifications o_mock_api_list
+                o_mock_api_list.assert_called_once_with(
+                    infos_filter={"name": "start_%"},
+                    tags_filter={"k_tag": "v_tag"},
+                    page=1,
+                    datastore=None,
+                )
+                # Vérification maj entité via appel de api_update
+                o_mock_api_update.assert_called_once_with()
+
     def test_resolve_upload(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un upload."""
 

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -54,7 +54,7 @@ class StoreEntityResolverTestCase(GpfTestCase):
             )
 
     def test_no_key(self) -> None:
-        """vérifie l'erreur retournée quand la kef n'ai n'ai pas trouvée"""
+        """vérifie l'erreur retournée quand la clef n'est pas trouvée"""
 
         o_store_entity_resolver = StoreEntityResolver("store_entity")
         l_uploads = [


### PR DESCRIPTION
## v0.1.22

### [Added]

* Dans une étape d'un workflow, itération possible sur les actions. (V0, sera amélioré suite à la modification des résolveurs #87, #85)

### [Changed]

* Renommage de `CopieConfigurationAction` en `CopyConfigurationAction`

### [Fixed]

* #83 : fusion de la liste des used_data en gardant l'ordre de la liste lors de l'édition de configurations
* #80 : Upload.api_delete_data_file(): suppression exception pour répertoire "data"
* #78 : ajout route `upload_delete_data` dans la configuration
* Bug #77 : problème de nommage de l'action de copie de configuration entre le code est la doc : utilisation de `copy-configuration`
* Bug #98 : problème de datastore lors de la création d'une ProcessingExecution