### PR TITLE
StoreEntityResolver: récupérer une liste d'entité. Close #85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Added]
 
+* StoreEntityResolver: possibilité de récupérer une liste d'entités ou d’informations sur une entité #85
+
 ### [Changed]
 
 ### [Fixed]

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -244,7 +244,7 @@ filter_infos = ((\s*)INFOS(\s*)\((?P<filter_infos>.*?)\)(\s*))?
 # Filtre de store_entity à partir des tags
 filter_tags = ((\s*)TAGS(\s*)\((?P<filter_tags>.*?)\)(\s*))?
 filter = ((\s*)\[${filter_infos},?${filter_tags}\])
-store_entity_regex=(?P<entity_type>(upload|stored_data|processing_execution|offering|processing|configuration|endpoint|static|datastore))\.(?P<selected_field_type>(tags|infos))\.(?P<selected_field>(\w|\.|\[\d+\])*)${filter}
+store_entity_regex=(?P<entity_type>(upload|stored_data|processing_execution|offering|processing|configuration|endpoint|static|datastore))\.(((?P<number_selected>ALL|ONE)\.)?(?P<selected_field_type>(tags|infos))\.(?P<selected_field>(\w|\.|\[\d+\])*)|(?P<number_dict>ALL|ONE))${filter}
 global_regex=(?P<param>(\["_|{("_)?)(?P<resolver_name>[a-z_0-9]+)(\.|_": *"|_", *")(?P<to_solve>[^"{}]*?({[^}]+}[^"{}]*?)*)("\]|"?}))
 file_regex=(?P<resolver_type>str|list|dict)\((?P<resolver_file>.*)\)
 

--- a/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
@@ -89,7 +89,7 @@ class StoreEntityResolver(AbstractResolver):
         # Sinon on regarde ce qu'on doit envoyer
 
         if d_groups["number_dict"] == "ONE":
-            # json de la première entité trouvé
+            # json de la première entité trouvée
             l_entities[0].api_update()
             return l_entities[0].to_json()
         if d_groups["number_dict"] == "ALL":
@@ -101,10 +101,10 @@ class StoreEntityResolver(AbstractResolver):
             return json.dumps(l_res1)
         try:
             if not d_groups["number_selected"] or d_groups["number_selected"] == "ONE":
-                # une seule entité à traité affichage d'une info ou d'un tag
+                # une seule entité à traiter, affichage d'une info ou d'un tag
                 return self._get_info_or_tag(l_entities[0], d_groups)
             if d_groups["number_selected"] == "ALL":
-                # affichage d'info ou d'tag pour tout les entités trouvées
+                # affichage d'une info ou d'un tag pour toutes les entités trouvées
                 l_res2 = [self._get_info_or_tag(o_entity, d_groups) for o_entity in l_entities]
                 if d_groups["selected_field_type"] == "tags":
                     l_res2 = list(set(l_res2))
@@ -112,7 +112,6 @@ class StoreEntityResolver(AbstractResolver):
         except KeyError as e:
             raise ResolverError(self.name, string_to_solve) from e
 
-        # print(d_groups)
         raise ResolverError(self.name, string_to_solve)
 
     def _get_info_or_tag(self, o_entity: StoreEntity, d_groups: Dict[str, Any]) -> str:

--- a/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
@@ -94,21 +94,21 @@ class StoreEntityResolver(AbstractResolver):
             return l_entities[0].to_json()
         if d_groups["number_dict"] == "ALL":
             # json de toutes les entités trouvées
-            l_res = []
+            l_res1 = []
             for o_entity in l_entities:
                 o_entity.api_update()
-                l_res.append(o_entity.get_store_properties())
-            return json.dumps(l_res)
+                l_res1.append(o_entity.get_store_properties())
+            return json.dumps(l_res1)
         try:
             if not d_groups["number_selected"] or d_groups["number_selected"] == "ONE":
                 # une seule entité à traité affichage d'une info ou d'un tag
                 return self._get_info_or_tag(l_entities[0], d_groups)
             if d_groups["number_selected"] == "ALL":
                 # affichage d'info ou d'tag pour tout les entités trouvées
-                l_res = [self._get_info_or_tag(o_entity, d_groups) for o_entity in l_entities]
+                l_res2 = [self._get_info_or_tag(o_entity, d_groups) for o_entity in l_entities]
                 if d_groups["selected_field_type"] == "tags":
-                    l_res = list(set(l_res))
-                return json.dumps(l_res)
+                    l_res2 = list(set(l_res2))
+                return json.dumps(l_res2)
         except KeyError as e:
             raise ResolverError(self.name, string_to_solve) from e
 

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -119,6 +119,7 @@ class StoreEntityResolverTestCase(GpfTestCase):
         l_uploads = [
             Upload({"_id": "upload_1", "name": "Name 1", "tags": {"k_tag": "v_tag"}}),
             Upload({"_id": "upload_2", "name": "Name 2", "tags": {"k_tag": "v_tag"}}),
+            Upload({"_id": "upload_2", "name": "Name 2", "tags": {"k_tag": "autre_tag"}}),
         ]
 
         l_param = [
@@ -128,21 +129,21 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
-                "expected_result": "upload_1",
+                "expected_result": l_uploads[0]["_id"],
             },
             {
                 "classe": Upload,
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "upload.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
-                "expected_result": "Name 1",
+                "expected_result": l_uploads[0]["name"],
             },
             {
                 "classe": Upload,
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "upload.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
-                "expected_result": "v_tag",
+                "expected_result": l_uploads[0]["tags"]["k_tag"],
             },
             # TEST 2 : avec on sens datastore, on vérifie qu'un datastore passé est bien transmis
             {
@@ -150,7 +151,7 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": "datastore_1"},
                 "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]", "datastore": "datastore_1"},
-                "expected_result": "upload_1",
+                "expected_result": l_uploads[0]["_id"],
             },
             # TEST 3 : utilisation de ONE
             {
@@ -158,14 +159,21 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": "datastore_1"},
                 "expression": {"string_to_solve": "upload.ONE.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]", "datastore": "datastore_1"},
-                "expected_result": "upload_1",
+                "expected_result": l_uploads[0]["_id"],
             },
             {
                 "classe": Upload,
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "upload.ONE.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
-                "expected_result": "Name 1",
+                "expected_result": l_uploads[0]["name"],
+            },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "upload.ONE.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
+                "expected_result": l_uploads[0]["tags"]["k_tag"],
             },
             {
                 "classe": Upload,
@@ -199,6 +207,14 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "expected_result": json.dumps([o_upload.get_store_properties() for o_upload in l_uploads]),
                 "nb_api_update": len(l_uploads),
             },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {}, "page": 1, "datastore": "datastore_1"},
+                "expression": {"string_to_solve": "upload.ALL.tags.k_tag [INFOS(name=start_%)]", "datastore": "datastore_1"},
+                "expected_result": json.dumps(list(set([o_upload["tags"]["k_tag"] for o_upload in l_uploads]))),
+                "nb_api_update": len(l_uploads),
+            },
         ]
         for d_param in l_param:
             self.run_resolve(d_param)
@@ -213,14 +229,14 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_endpoints,
                 "data_api_list": {"infos_filter": {"type": "ARCHIVE"}, "tags_filter": {}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "endpoint.infos._id [INFOS(type=ARCHIVE)]"},
-                "expected_result": "endpoint",
+                "expected_result": l_endpoints[0]["_id"],
             },
             {
                 "classe": Endpoint,
                 "return_api_list": l_endpoints,
                 "data_api_list": {"infos_filter": {"type": "ARCHIVE"}, "tags_filter": {}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "endpoint.infos.name [INFOS(type=ARCHIVE)]"},
-                "expected_result": "Name",
+                "expected_result": l_endpoints[0]["name"],
             },
         ]
         for d_param in l_param:
@@ -238,14 +254,14 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_entities,
                 "data_api_list": {"infos_filter": {"name": "ds1"}, "tags_filter": {}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "datastore.infos._id [INFOS(name=ds1)]"},
-                "expected_result": "1",
+                "expected_result": l_entities[0]["_id"],
             },
             {
                 "classe": Datastore,
                 "return_api_list": l_entities,
                 "data_api_list": {"infos_filter": {"name": "ds1"}, "tags_filter": {}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "datastore.infos.technical_name [INFOS(name=ds1)]"},
-                "expected_result": "ds1",
+                "expected_result": l_entities[0]["technical_name"],
             },
         ]
         for d_param in l_param:

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import Any, Dict, List
 from unittest.mock import patch
 
 from sdk_entrepot_gpf.store.Endpoint import Endpoint
@@ -101,7 +101,12 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 # Vérification maj entité via appel de api_update
                 o_mock_api_update.assert_called_once_with()
 
-    def run_resolve(self, d_param) -> None:
+    def run_resolve(self, d_param: Dict[str, Any]) -> None:
+        """lancement des tests pour resolve() sans erreur
+
+        Args:
+            d_param (Dict[str,Any]): dictionnaire
+        """
         o_store_entity_resolver = StoreEntityResolver("store_entity")
         # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
         with patch.object(d_param["classe"], "api_list", return_value=d_param["return_api_list"]) as o_mock_api_list:
@@ -212,7 +217,7 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {}, "page": 1, "datastore": "datastore_1"},
                 "expression": {"string_to_solve": "upload.ALL.tags.k_tag [INFOS(name=start_%)]", "datastore": "datastore_1"},
-                "expected_result": json.dumps(list(set([o_upload["tags"]["k_tag"] for o_upload in l_uploads]))),
+                "expected_result": json.dumps(list({o_upload["tags"]["k_tag"] for o_upload in l_uploads})),
                 "nb_api_update": len(l_uploads),
             },
         ]

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -32,6 +32,24 @@ class StoreEntityResolverTestCase(GpfTestCase):
             o_store_entity_resolver.resolve("upload.infos._id [IFO(name=titi)]")
         self.assertEqual(o_arc_2.exception.message, "Erreur du résolveur 'store_entity' avec la chaîne 'upload.infos._id [IFO(name=titi)]'.")
 
+        # pas de possibilité de récupérer un tag pour une entité endpoint
+        l_endpoints = [Endpoint({"_id": "endpoint", "name": "Name", "type": "ARCHIVE"})]
+        o_store_entity_resolver = StoreEntityResolver("store_entity")
+        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
+        with patch.object(Endpoint, "api_list", return_value=l_endpoints) as o_mock_api_list:
+            s_to_solve = "endpoint.tags.k_tag [INFOS(type=ARCHIVE)]"
+            with self.assertRaises(ResolverError) as o_arc:
+                o_store_entity_resolver.resolve("endpoint.tags.k_tag [INFOS(type=ARCHIVE)]")
+            # Vérification erreur
+            self.assertEqual(o_arc.exception.message, f"Erreur du résolveur 'store_entity' avec la chaîne '{s_to_solve}'.")
+            # Vérifications o_mock_api_list
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"type": "ARCHIVE"},
+                tags_filter={},
+                page=1,
+                datastore=None,
+            )
+
     def test_resolve_no_result(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve si aucun résultat n'est trouvé."""
 
@@ -82,173 +100,112 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 # Vérification maj entité via appel de api_update
                 o_mock_api_update.assert_called_once_with()
 
+    def run_resolve(self, d_param) -> None:
+        o_store_entity_resolver = StoreEntityResolver("store_entity")
+        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
+        with patch.object(d_param["classe"], "api_list", return_value=d_param["return_api_list"]) as o_mock_api_list:
+            with patch.object(d_param["classe"], "api_update", return_value=None) as o_mock_api_update:
+                s_result = o_store_entity_resolver.resolve(**d_param["expression"])
+                # Vérifications o_mock_api_list
+                o_mock_api_list.assert_called_once_with(**d_param["data_api_list"])
+                # Vérification id récupérée
+                self.assertEqual(s_result, d_param["expected_result"])
+                # Vérification maj entité via appel de api_update
+                o_mock_api_update.assert_called_once_with()
+
     def test_resolve_upload(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un upload."""
-
-        o_store_entity_resolver = StoreEntityResolver("store_entity")
         l_uploads = [
             Upload({"_id": "upload_1", "name": "Name 1", "tags": {"k_tag": "v_tag"}}),
             Upload({"_id": "upload_2", "name": "Name 2", "tags": {"k_tag": "v_tag"}}),
         ]
 
-        # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "start_%"},
-                    tags_filter={"k_tag": "v_tag"},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification id récupérée
-                self.assertEqual(s_result, "upload_1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("upload.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "start_%"},
-                    tags_filter={"k_tag": "v_tag"},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification name récupérée
-                self.assertEqual(s_result, "Name 1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("upload.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "start_%"},
-                    tags_filter={"k_tag": "v_tag"},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification name récupéré
-                self.assertEqual(s_result, "v_tag")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
-
-        # TEST 2 : avec on sens datastore, on vérifie qu'un datastore passé est bien transmis
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve(
-                    "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]",
-                    datastore="datastore_1",  # On précise un datastore
-                )
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "start_%"},
-                    tags_filter={"k_tag": "v_tag"},
-                    page=1,
-                    datastore="datastore_1",  # Il est bien transmis
-                )
-                # Vérification id récupérée
-                self.assertEqual(s_result, "upload_1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
+        l_param = [
+            # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
+                "expected_result": "upload_1",
+            },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "upload.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
+                "expected_result": "Name 1",
+            },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "upload.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
+                "expected_result": "v_tag",
+            },
+            # TEST 2 : avec on sens datastore, on vérifie qu'un datastore passé est bien transmis
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": "datastore_1"},
+                "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]", "datastore": "datastore_1"},
+                "expected_result": "upload_1",
+            },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": "datastore_1"},
+                "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]", "datastore": "datastore_1"},
+                "expected_result": "upload_1",
+            },
+        ]
+        for d_param in l_param:
+            self.run_resolve(d_param)
 
     def test_resolve_endpoint(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un endpoint."""
-
-        o_store_entity_resolver = StoreEntityResolver("store_entity")
-        l_uploads = [
-            Endpoint({"_id": "endpoint", "name": "Name", "type": "ARCHIVE"}),
+        l_endpoints = [Endpoint({"_id": "endpoint", "name": "Name", "type": "ARCHIVE"})]
+        l_param = [
+            # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
+            {
+                "classe": Endpoint,
+                "return_api_list": l_endpoints,
+                "data_api_list": {"infos_filter": {"type": "ARCHIVE"}, "tags_filter": {}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "endpoint.infos._id [INFOS(type=ARCHIVE)]"},
+                "expected_result": "endpoint",
+            },
+            {
+                "classe": Endpoint,
+                "return_api_list": l_endpoints,
+                "data_api_list": {"infos_filter": {"type": "ARCHIVE"}, "tags_filter": {}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "endpoint.infos.name [INFOS(type=ARCHIVE)]"},
+                "expected_result": "Name",
+            },
         ]
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Endpoint, "api_list", return_value=l_uploads) as o_mock_api_list:
-            s_result = o_store_entity_resolver.resolve("endpoint.infos._id [INFOS(type=ARCHIVE)]")
-            # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(
-                infos_filter={"type": "ARCHIVE"},
-                tags_filter={},
-                page=1,
-                datastore=None,
-            )
-            # Vérification id récupérée
-            self.assertEqual(s_result, "endpoint")
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Endpoint, "api_list", return_value=l_uploads) as o_mock_api_list:
-            s_result = o_store_entity_resolver.resolve("endpoint.infos.name [INFOS(type=ARCHIVE)]")
-            # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(
-                infos_filter={"type": "ARCHIVE"},
-                tags_filter={},
-                page=1,
-                datastore=None,
-            )
-            # Vérification name récupérée
-            self.assertEqual(s_result, "Name")
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Endpoint, "api_list", return_value=l_uploads) as o_mock_api_list:
-            s_to_solve = "endpoint.tags.k_tag [INFOS(type=ARCHIVE)]"
-            with self.assertRaises(ResolverError) as o_arc:
-                o_store_entity_resolver.resolve("endpoint.tags.k_tag [INFOS(type=ARCHIVE)]")
-            # Vérification erreur
-            self.assertEqual(o_arc.exception.message, f"Erreur du résolveur 'store_entity' avec la chaîne '{s_to_solve}'.")
-            # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(
-                infos_filter={"type": "ARCHIVE"},
-                tags_filter={},
-                page=1,
-                datastore=None,
-            )
+        for d_param in l_param:
+            self.run_resolve(d_param)
 
     def test_resolve_datastore(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un store.
         On peut utiliser `name` pour filter sur le `name` et sur le `technical_name`.
         """
-
-        o_store_entity_resolver = StoreEntityResolver("store_entity")
-        l_entities = [
-            Datastore({"_id": "1", "name": "Datastore 1", "technical_name": "ds1"}),
+        l_entities = [Datastore({"_id": "1", "name": "Datastore 1", "technical_name": "ds1"})]
+        l_param = [
+            # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
+            {
+                "classe": Datastore,
+                "return_api_list": l_entities,
+                "data_api_list": {"infos_filter": {"name": "ds1"}, "tags_filter": {}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "datastore.infos._id [INFOS(name=ds1)]"},
+                "expected_result": "1",
+            },
+            {
+                "classe": Datastore,
+                "return_api_list": l_entities,
+                "data_api_list": {"infos_filter": {"name": "ds1"}, "tags_filter": {}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "datastore.infos.technical_name [INFOS(name=ds1)]"},
+                "expected_result": "ds1",
+            },
         ]
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Datastore, "api_list", return_value=l_entities) as o_mock_api_list:
-            with patch.object(Datastore, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("datastore.infos._id [INFOS(name=ds1)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "ds1"},
-                    tags_filter={},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification id récupérée
-                self.assertEqual(s_result, "1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Datastore, "api_list", return_value=l_entities) as o_mock_api_list:
-            with patch.object(Datastore, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("datastore.infos._id [INFOS(name=Datastore 1)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "Datastore 1"},
-                    tags_filter={},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification id récupérée
-                self.assertEqual(s_result, "1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
+        for d_param in l_param:
+            self.run_resolve(d_param)


### PR DESCRIPTION
Développement pour #85 : pouvoir récupérer une liste d'entités que d'avoir la première entité.

## Format pour récupérer la liste :

`{entity_type}.ALL` => liste des "entité.to_json()" pour chaque entité sélectionné
`{entity_type}.ALL.info.Y `=> liste des valeurs de Y pour chaque entité sélectionné
`{entity_type}.ALL.tags.X` => liste des tags X sans doublons

##  Format pour récupérer l'info du premier élément

`{entity_type}.info.Y` => valeur de Y
`{entity_type}.tags.X` => valeur du tags X
`{entity_type}.ONE` => "entité.to_json()"
`{entity_type}.ONE.info.Y` => valeur de Y
`{entity_type}.ONE.tags.X` => valeur du tags X

## [Added]

* StoreEntityResolver: possibilité de récupérer une liste d'entités ou d’informations sur une entité
