### PR TITLE
Version 0.1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGE LOG
 
+## v0.1.25
+
+### [Added]
+
+### [Changed]
+
+### [Fixed]
+
 ## v0.1.24
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # CHANGE LOG
 
+## v0.1.24
+
+### [Added]
+
+### [Changed]
+
+### [Fixed]
+
 ## v0.1.23
 
 ### [Added]
 
 * DateResolver: ajout d'un résolveur pour les dates #86
-
-### [Changed]
-
-### [Fixed]
 
 ## v0.1.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ### [Changed]
 
-* workflow: ajout de PermissionAction #94
+* workflow:
+  * ajout de PermissionAction #94
+  * possibilité d'utiliser un résolveur pour créer la liste de "Iter_vals" #106
+  * possibilité de définir un datastore au niveau de l'étape
 
 ### [Fixed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@
 
 ### [Added]
 
+* ajout classe Permission : gère les permissions sur les offres #93
+* ajout classe PermissionAction : gère les permissions sur les offres depuis le workflow #94
+
 ### [Changed]
 
+* workflow: ajout de PermissionAction #94
+
 ### [Fixed]
+
+* schema workflow: ajout du type "edit-entity"
 
 ## v0.1.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Added]
 
+* StoreEntityResolver: possibilité de récupérer une liste d'entités ou d’informations sur une entité #85
+
 ### [Changed]
 
 ### [Fixed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### [Fixed]
 
 * schema workflow: ajout du type "edit-entity"
+* Edit Configuration : correction de la gestion de `used_data` (#107)
 
 ## v0.1.23
 

--- a/sdk_entrepot_gpf/__init__.py
+++ b/sdk_entrepot_gpf/__init__.py
@@ -1,3 +1,3 @@
 """Python API to simplify the use of the GPF Warehouse HTTPS API."""
 
-__version__ = "0.1.22"
+__version__ = "0.1.23"

--- a/sdk_entrepot_gpf/__init__.py
+++ b/sdk_entrepot_gpf/__init__.py
@@ -1,3 +1,3 @@
 """Python API to simplify the use of the GPF Warehouse HTTPS API."""
 
-__version__ = "0.1.23"
+__version__ = "0.1.24"

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -167,6 +167,12 @@ metadata_download=${routing:metadata_get}/file
 metadata_publish=${routing:metadata_list}/publication
 metadata_unpublish=${routing:metadata_list}/unpublication
 
+# permission
+permission_list=${store_api:root_datastore}/permissions
+permission_get=${permission_list}/{permissions}
+permission_create=${permission_list}
+permission_delete=${permission_get}
+permission_partial_edit=${routing:permission_get}
 
 [upload]
 ############################### Contrainte d'unicité à la création d'une livraison ###############################

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -244,7 +244,7 @@ filter_infos = ((\s*)INFOS(\s*)\((?P<filter_infos>.*?)\)(\s*))?
 # Filtre de store_entity à partir des tags
 filter_tags = ((\s*)TAGS(\s*)\((?P<filter_tags>.*?)\)(\s*))?
 filter = ((\s*)\[${filter_infos},?${filter_tags}\])
-store_entity_regex=(?P<entity_type>(upload|stored_data|processing_execution|offering|processing|configuration|endpoint|static|datastore))\.(?P<selected_field_type>(tags|infos))\.(?P<selected_field>(\w|\.|\[\d+\])*)${filter}
+store_entity_regex=(?P<entity_type>(upload|stored_data|processing_execution|offering|processing|configuration|endpoint|static|datastore))\.(((?P<number_selected>ALL|ONE)\.)?(?P<selected_field_type>(tags|infos))\.(?P<selected_field>(\w|\.|\[\d+\])*)|(?P<number_dict>ALL|ONE))${filter}
 global_regex=(?P<param>(\["_|{("_)?)(?P<resolver_name>[a-z_0-9]+)(\.|_": *"|_", *")(?P<to_solve>[^"{}]*?({[^}]+}[^"{}]*?)*)("\]|"?}))
 file_regex=(?P<resolver_type>str|list|dict)\((?P<resolver_file>.*)\)
 

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -41,7 +41,9 @@
                                                 "configuration",
                                                 "copy-configuration",
                                                 "offering",
-                                                "synchronize-offering"
+                                                "synchronize-offering",
+                                                "edit-entity",
+                                                "permission"
                                             ]
                                         },
                                         "url_parameters": {

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -119,6 +119,9 @@
                             },
                             "iter_key": {
                                 "type": "string"
+                            },
+                            "datastore": {
+                                "type": "string"
                             }
                         }
                     }

--- a/sdk_entrepot_gpf/store/Configuration.py
+++ b/sdk_entrepot_gpf/store/Configuration.py
@@ -62,22 +62,25 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
 
     def edit(self, data_edit: Dict[str, Any]) -> None:
         """Mise à jour totale de l'entité en fusionnant le nouveau dictionnaire (prioritaire) et l'ancien.
-        Pour les configurations, il faut en plus fusionner la liste des used_data.
+        Pour les configurations, il faut en plus fusionner le sous dictionnaire "type_infos" et la liste "used_data" qu'il contient.
         Si la nouvelle liste et l'ancienne liste n'ont pas la même taille, une exception est levée.
 
         Args:
             data_edit (Dict[str, Any]): nouvelles valeurs de propriétés
         """
         d_origine_data = self.get_store_properties()
-        # fusion de used_data
-        l_used_data = []
-        if len(d_origine_data["used_data"]) != len(data_edit["used_data"]):
-            s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
-            raise StoreEntityError(s_message)
-        for i in range(len(d_origine_data["used_data"])):
-            l_used_data.append({**d_origine_data["used_data"][i], **data_edit["used_data"][i]})
 
-        # fusion des dictionnaires actuels et nouveaux (prioritaire)
-        d_data = {**self.get_store_properties(), **data_edit, **{"used_data": l_used_data}}
+        # fusion de type_infos et de type_infos.used_data
+        if "type_infos" in data_edit:  # il peut ne pas y avoir de "type_infos" dans data_edit
+            if "used_data" in data_edit["type_infos"]:  # il peut ne pas y avoir de "used_data" dans data_edit["type_infos"]
+                l_used_data = []
+                if len(d_origine_data["type_infos"]["used_data"]) != len(data_edit["type_infos"]["used_data"]):
+                    s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
+                    raise StoreEntityError(s_message)
+                for i in range(len(d_origine_data["type_infos"]["used_data"])):
+                    l_used_data.append({**d_origine_data["type_infos"]["used_data"][i], **data_edit["type_infos"]["used_data"][i]})
+                data_edit["type_infos"]["used_data"] = l_used_data
+            data_edit["type_infos"] = {**d_origine_data["type_infos"], **data_edit["type_infos"]}
 
-        self.api_full_edit(d_data)
+        # le reste est géré par la classe parente
+        FullEditInterface.edit(self, data_edit)

--- a/sdk_entrepot_gpf/store/Permission.py
+++ b/sdk_entrepot_gpf/store/Permission.py
@@ -3,7 +3,7 @@ from sdk_entrepot_gpf.store.interface.PartialEditInterface import PartialEditInt
 
 
 class Permission(PartialEditInterface, StoreEntity):
-    """Classe Python représentant les permissions."""
+    """Classe Python représentant l'entité des permissions."""
 
     _entity_name = "permission"
     _entity_title = "permission"

--- a/sdk_entrepot_gpf/store/Permissions.py
+++ b/sdk_entrepot_gpf/store/Permissions.py
@@ -1,0 +1,9 @@
+from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
+from sdk_entrepot_gpf.store.interface.PartialEditInterface import PartialEditInterface
+
+
+class Permission(PartialEditInterface, StoreEntity):
+    """Classe Python représentant les permissions."""
+
+    _entity_name = "permission"
+    _entity_title = "permission"

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -14,6 +14,7 @@ from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.workflow.action.CopyConfigurationAction import CopyConfigurationAction
 from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
 from sdk_entrepot_gpf.workflow.action.EditAction import EditAction
+from sdk_entrepot_gpf.workflow.action.PermissionAction import PermissionAction
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
 from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
@@ -277,6 +278,8 @@ class Workflow:
             return SynchronizeOfferingAction(workflow_context, definition_dict, parent_action)
         if definition_dict["type"] == "edit-entity":
             return EditAction(workflow_context, definition_dict, parent_action)
+        if definition_dict["type"] == "permission":
+            return PermissionAction(workflow_context, definition_dict, parent_action)
         raise WorkflowError(f"Aucune correspondance pour ce type d'action : {definition_dict['type']}")
 
     @staticmethod

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -97,14 +97,12 @@ class Workflow:
             # création de l'action
             o_action = Workflow.generate(step_name, d_action_raw, o_parent_action, behavior)
             # choix du datastore
-            ## par défaut datastore du workflow, si None il sera récupérer dans la configuration
-            s_use_datastore = self.__datastore
-            if datastore:
-                # datastore dans l'appel à la fonction on prend
-                s_use_datastore = datastore
-            elif "datastore" in o_action.definition_dict:
-                # datastore dans l'étape
-                s_use_datastore = o_action.definition_dict["datastore"]
+            ## datastore donné en paramètre
+            ## sinon datastore du workflow au niveau de l'action
+            ## sinon datastore du workflow au niveau de l'étape
+            ## sinon datastore du workflow au niveau global (self.__datastore)
+            # NB: si None il sera récupérer dans la configuration
+            s_use_datastore = datastore if datastore else o_action.definition_dict.get("datastore", d_step_definition.get("datastore", self.__datastore))
 
             # résolution
             o_action.resolve(datastore=s_use_datastore)

--- a/sdk_entrepot_gpf/workflow/action/PermissionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/PermissionAction.py
@@ -1,0 +1,21 @@
+import time
+from typing import Any, Dict, Optional
+
+from sdk_entrepot_gpf.Errors import GpfSdkError
+from sdk_entrepot_gpf.store.Offering import Offering
+from sdk_entrepot_gpf.store.Configuration import Configuration
+from sdk_entrepot_gpf.workflow.Errors import StepActionError
+from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
+from sdk_entrepot_gpf.io.Config import Config
+from sdk_entrepot_gpf.io.Errors import ConflictError
+
+
+class PermissionAction(ActionAbstract):
+    """Classe dédiée à la géstion des Permissions.
+
+    Attributes:
+        __workflow_context (str): nom du contexte du workflow
+        __definition_dict (Dict[str, Any]): définition de l'action
+        __parent_action (Optional["Action"]): action parente
+        __offering (Optional[Offering]): représentation Python de la Offering créée
+    """

--- a/sdk_entrepot_gpf/workflow/action/PermissionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/PermissionAction.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from sdk_entrepot_gpf.store.Offering import Offering
-from sdk_entrepot_gpf.store.Configuration import Configuration
+from sdk_entrepot_gpf.store.Permission import Permission
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.io.Config import Config
@@ -11,7 +11,7 @@ from sdk_entrepot_gpf.io.Errors import ConflictError
 
 
 class PermissionAction(ActionAbstract):
-    """Classe dédiée à la géstion des Permissions.
+    """Classe dédiée à la création des Permissions.
 
     Attributes:
         __workflow_context (str): nom du contexte du workflow
@@ -19,3 +19,31 @@ class PermissionAction(ActionAbstract):
         __parent_action (Optional["Action"]): action parente
         __offering (Optional[Offering]): représentation Python de la Offering créée
     """
+
+    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None) -> None:
+        super().__init__(workflow_context, definition_dict, parent_action)
+        # Autres attributs
+        self.__permission: Optional[Permission] = None
+
+    def run(self, datastore: Optional[str] = None) -> None:
+        Config().om.info("Création d'une permission...")
+        # Création de la permission
+        self.__create_permission(datastore)
+        Config().om.info(f"Permission créée  : {self.permission}")
+        Config().om.info("Création d'une permission : terminée")
+
+    def __create_permission(self, datastore: Optional[str]) -> None:
+        """Création de la permission sur l'API à partir des paramètres de définition de l'action.
+
+        Args:
+            datastore (Optional[str]): id du datastore à utiliser.
+        """
+        # Création en gérant une erreur de type ConflictError (si la Permission existe déjà selon les critères de l'API)
+        try:
+            self.__permission = Permission.api_create(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
+        except ConflictError as e:
+            raise StepActionError(f"Impossible de créer la permission il y a un conflict : \n{e.message}") from e
+
+    @property
+    def permission(self) -> Optional[Permission]:
+        return self.__permission

--- a/sdk_entrepot_gpf/workflow/action/PermissionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/PermissionAction.py
@@ -1,8 +1,5 @@
-import time
 from typing import Any, Dict, Optional
 
-from sdk_entrepot_gpf.Errors import GpfSdkError
-from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.Permission import Permission
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract

--- a/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
@@ -89,7 +89,7 @@ class StoreEntityResolver(AbstractResolver):
         # Sinon on regarde ce qu'on doit envoyer
 
         if d_groups["number_dict"] == "ONE":
-            # json de la première entité trouvé
+            # json de la première entité trouvée
             l_entities[0].api_update()
             return l_entities[0].to_json()
         if d_groups["number_dict"] == "ALL":
@@ -101,10 +101,10 @@ class StoreEntityResolver(AbstractResolver):
             return json.dumps(l_res1)
         try:
             if not d_groups["number_selected"] or d_groups["number_selected"] == "ONE":
-                # une seule entité à traité affichage d'une info ou d'un tag
+                # une seule entité à traiter, affichage d'une info ou d'un tag
                 return self._get_info_or_tag(l_entities[0], d_groups)
             if d_groups["number_selected"] == "ALL":
-                # affichage d'info ou d'tag pour tout les entités trouvées
+                # affichage d'une info ou d'un tag pour toutes les entités trouvées
                 l_res2 = [self._get_info_or_tag(o_entity, d_groups) for o_entity in l_entities]
                 if d_groups["selected_field_type"] == "tags":
                     l_res2 = list(set(l_res2))
@@ -112,7 +112,6 @@ class StoreEntityResolver(AbstractResolver):
         except KeyError as e:
             raise ResolverError(self.name, string_to_solve) from e
 
-        # print(d_groups)
         raise ResolverError(self.name, string_to_solve)
 
     def _get_info_or_tag(self, o_entity: StoreEntity, d_groups: Dict[str, Any]) -> str:

--- a/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/StoreEntityResolver.py
@@ -94,21 +94,21 @@ class StoreEntityResolver(AbstractResolver):
             return l_entities[0].to_json()
         if d_groups["number_dict"] == "ALL":
             # json de toutes les entités trouvées
-            l_res = []
+            l_res1 = []
             for o_entity in l_entities:
                 o_entity.api_update()
-                l_res.append(o_entity.get_store_properties())
-            return json.dumps(l_res)
+                l_res1.append(o_entity.get_store_properties())
+            return json.dumps(l_res1)
         try:
             if not d_groups["number_selected"] or d_groups["number_selected"] == "ONE":
                 # une seule entité à traité affichage d'une info ou d'un tag
                 return self._get_info_or_tag(l_entities[0], d_groups)
             if d_groups["number_selected"] == "ALL":
                 # affichage d'info ou d'tag pour tout les entités trouvées
-                l_res = [self._get_info_or_tag(o_entity, d_groups) for o_entity in l_entities]
+                l_res2 = [self._get_info_or_tag(o_entity, d_groups) for o_entity in l_entities]
                 if d_groups["selected_field_type"] == "tags":
-                    l_res = list(set(l_res))
-                return json.dumps(l_res)
+                    l_res2 = list(set(l_res2))
+                return json.dumps(l_res2)
         except KeyError as e:
             raise ResolverError(self.name, string_to_solve) from e
 

--- a/tests/workflow/WorkflowTestCase.py
+++ b/tests/workflow/WorkflowTestCase.py
@@ -18,6 +18,7 @@ from sdk_entrepot_gpf.workflow.action.CopyConfigurationAction import CopyConfigu
 from sdk_entrepot_gpf.workflow.action.DeleteAction import DeleteAction
 from sdk_entrepot_gpf.workflow.action.EditAction import EditAction
 from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
+from sdk_entrepot_gpf.workflow.action.PermissionAction import PermissionAction
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
 from sdk_entrepot_gpf.workflow.action.SynchronizeOfferingAction import SynchronizeOfferingAction
 
@@ -406,6 +407,8 @@ class WorkflowTestCase(GpfTestCase):
         self.run_generation(CopyConfigurationAction, "name", {"type": "copy-configuration"}, o_mock_parent, with_beavior=True)
         # test type edit-entity
         self.run_generation(EditAction, "name", {"type": "edit-entity"}, o_mock_parent, with_beavior=False)
+        # test type permission
+        self.run_generation(PermissionAction, "name", {"type": "permission"}, o_mock_parent, with_beavior=False)
 
     def test_open_workflow(self) -> None:
         """Test de la fonction open_workflow."""

--- a/tests/workflow/WorkflowTestCase.py
+++ b/tests/workflow/WorkflowTestCase.py
@@ -21,6 +21,7 @@ from sdk_entrepot_gpf.workflow.action.OfferingAction import OfferingAction
 from sdk_entrepot_gpf.workflow.action.PermissionAction import PermissionAction
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
 from sdk_entrepot_gpf.workflow.action.SynchronizeOfferingAction import SynchronizeOfferingAction
+from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
 
 from tests.GpfTestCase import GpfTestCase
 
@@ -145,45 +146,49 @@ class WorkflowTestCase(GpfTestCase):
         o_mock_action.run.return_value = None
 
         ## mock de la property definition_dict
-        d_effect = []
-        for d_el in l_actions:
-            d_effect += [d_el] * 2
-        type(o_mock_action).definition_dict = PropertyMock(side_effect=d_effect)
+        type(o_mock_action).definition_dict = PropertyMock(side_effect=l_actions)
 
         # initialisation de Workflow
         o_workflow = Workflow("nom", d_workflow)
 
         # on mock Workflow.generate
         with patch.object(Workflow, "generate", return_value=o_mock_action) as o_mock_action_generate:
-            if error_message is not None:
-                # si on attend une erreur
-                with self.assertRaises(WorkflowError) as o_arc:
-                    o_workflow.run_step(**d_args_run_step)
-                self.assertEqual(o_arc.exception.message, error_message.format(action=o_mock_action))
-            else:
-                # pas d'erreur attendu
-                l_entities = o_workflow.run_step(**d_args_run_step)
-                self.assertListEqual(l_entities, [f"Entity_{output_type}"] * len(l_run_args))
+            with patch.object(GlobalResolver, "resolve", side_effect=lambda x, **kwargs: x) as o_mock_resolve:
+                if error_message is not None:
+                    # si on attend une erreur
+                    with self.assertRaises(WorkflowError) as o_arc:
+                        o_workflow.run_step(**d_args_run_step)
+                    self.assertEqual(o_arc.exception.message, error_message.format(action=o_mock_action))
+                else:
+                    # pas d'erreur attendu
+                    l_entities = o_workflow.run_step(**d_args_run_step)
+                    self.assertListEqual(l_entities, [f"Entity_{output_type}"] * len(l_run_args))
 
-            # vérification des appels à generate
-            self.assertEqual(o_mock_action_generate.call_count, len(l_run_args))
-            o_parent = None
-            for d_action in l_actions:
-                o_mock_action_generate.assert_any_call(s_etape, d_action, o_parent, d_args_run_step["behavior"])
-                o_parent = o_mock_action
+                    # tests pour "iter_vals"
+                    d_step = d_workflow["workflow"]["steps"][s_etape]
+                    if "iter_vals" in d_step:
+                        # datastore argument du run_step, ou datastore de l'étape ou datastore du workflow
+                        o_mock_resolve.assert_called_once_with(json.dumps(d_step["iter_vals"]), datastore=d_args_run_step.get("datastore", d_step.get("datastore", d_workflow.get("datastore"))))
 
-            # vérification des appels à résolve
-            self.assertEqual(o_mock_action.resolve.call_count, len(l_run_args))
+                # vérification des appels à generate
+                self.assertEqual(o_mock_action_generate.call_count, len(l_run_args))
+                o_parent = None
+                for d_action in l_actions:
+                    o_mock_action_generate.assert_any_call(s_etape, d_action, o_parent, d_args_run_step["behavior"])
+                    o_parent = o_mock_action
 
-            # vérification des appels à run
-            self.assertEqual(o_mock_action.run.call_count, len(l_run_args))
-            for o_el in l_run_args:
-                o_mock_action.run.assert_any_call(o_el)
-
-            # si monitoring : vérification des appels à monitoring
-            if monitoring_until_end:
+                # vérification des appels à résolve
                 self.assertEqual(o_mock_action.resolve.call_count, len(l_run_args))
-                o_mock_action.monitoring_until_end.assert_any_call(callback=d_args_run_step["callback"], ctrl_c_action=None)
+
+                # vérification des appels à run
+                self.assertEqual(o_mock_action.run.call_count, len(l_run_args))
+                for o_el in l_run_args:
+                    o_mock_action.run.assert_any_call(o_el)
+
+                # si monitoring : vérification des appels à monitoring
+                if monitoring_until_end:
+                    self.assertEqual(o_mock_action.resolve.call_count, len(l_run_args))
+                    o_mock_action.monitoring_until_end.assert_any_call(callback=d_args_run_step["callback"], ctrl_c_action=None)
 
     def test_run_step(self) -> None:
         """test de run_step"""

--- a/tests/workflow/action/PermissionActionTestCase.py
+++ b/tests/workflow/action/PermissionActionTestCase.py
@@ -1,10 +1,7 @@
-from typing import Dict, Any, List
+from typing import Dict, Any
 from unittest.mock import patch, MagicMock
 
 from sdk_entrepot_gpf.store.Permission import Permission
-from sdk_entrepot_gpf.workflow.Errors import StepActionError
-from sdk_entrepot_gpf.workflow.action.CopieConfigurationAction import CopieConfigurationAction
-from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
 from sdk_entrepot_gpf.workflow.action.PermissionAction import PermissionAction
 
 from tests.GpfTestCase import GpfTestCase
@@ -34,9 +31,9 @@ class PermissionActionTestCase(GpfTestCase):
         self.assertIsNone(o_action.permission)
 
         # fonctionnement OK
-        permission = Permission({"_id": "permission_id"})
-        with patch.object(Permission, "api_create", return_value=permission) as o_mock_create:
+        o_permission = MagicMock()
+        with patch.object(Permission, "api_create", return_value=o_permission) as o_mock_create:
             o_action.run("datastore")
 
         o_mock_create.assert_called_once_with(d_action["body_parameters"], route_params={"datastore": "datastore"})
-        self.assertEqual(permission, o_action.permission)
+        self.assertEqual(o_permission, o_action.permission)

--- a/tests/workflow/action/PermissionActionTestCase.py
+++ b/tests/workflow/action/PermissionActionTestCase.py
@@ -28,12 +28,14 @@ class PermissionActionTestCase(GpfTestCase):
             },
         }
         o_action = PermissionAction("context", d_action)
+        # Permet de vérifier qu'il n'y a pas encore de permission
         self.assertIsNone(o_action.permission)
 
         # fonctionnement OK
         o_permission = MagicMock()
         with patch.object(Permission, "api_create", return_value=o_permission) as o_mock_create:
             o_action.run("datastore")
-
+        # Permet de moker l'appel à la création de la permission
         o_mock_create.assert_called_once_with(d_action["body_parameters"], route_params={"datastore": "datastore"})
+        # Permet de vérifier qu'aprés l'appel la permission ajoutée correspond à celle qui est demandée
         self.assertEqual(o_permission, o_action.permission)

--- a/tests/workflow/action/PermissionActionTestCase.py
+++ b/tests/workflow/action/PermissionActionTestCase.py
@@ -1,0 +1,42 @@
+from typing import Dict, Any, List
+from unittest.mock import patch, MagicMock
+
+from sdk_entrepot_gpf.store.Permission import Permission
+from sdk_entrepot_gpf.workflow.Errors import StepActionError
+from sdk_entrepot_gpf.workflow.action.CopieConfigurationAction import CopieConfigurationAction
+from sdk_entrepot_gpf.workflow.action.ConfigurationAction import ConfigurationAction
+from sdk_entrepot_gpf.workflow.action.PermissionAction import PermissionAction
+
+from tests.GpfTestCase import GpfTestCase
+
+
+# pylint:disable=too-many-arguments
+# pylint:disable=too-many-locals
+# pylint:disable=too-many-branches
+
+
+class PermissionActionTestCase(GpfTestCase):
+    """Tests CopieConfigurationAction class.
+
+    cmd : python3 -m unittest -b tests.workflow.action.PermissionActionTestCase
+    """
+
+    def test_run(self) -> None:
+        """test de run"""
+        d_action: Dict[str, Any] = {
+            "type": "permission",
+            "body_parameters": {
+                "name": "name_permission",
+                "layer_name": "layer_name_permission",
+            },
+        }
+        o_action = PermissionAction("context", d_action)
+        self.assertIsNone(o_action.permission)
+
+        # fonctionnement OK
+        permission = Permission({"_id": "permission_id"})
+        with patch.object(Permission, "api_create", return_value=permission) as o_mock_create:
+            o_action.run("datastore")
+
+        o_mock_create.assert_called_once_with(d_action["body_parameters"], route_params={"datastore": "datastore"})
+        self.assertEqual(permission, o_action.permission)

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -119,6 +119,7 @@ class StoreEntityResolverTestCase(GpfTestCase):
         l_uploads = [
             Upload({"_id": "upload_1", "name": "Name 1", "tags": {"k_tag": "v_tag"}}),
             Upload({"_id": "upload_2", "name": "Name 2", "tags": {"k_tag": "v_tag"}}),
+            Upload({"_id": "upload_2", "name": "Name 2", "tags": {"k_tag": "autre_tag"}}),
         ]
 
         l_param = [
@@ -128,21 +129,21 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
-                "expected_result": "upload_1",
+                "expected_result": l_uploads[0]["_id"],
             },
             {
                 "classe": Upload,
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "upload.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
-                "expected_result": "Name 1",
+                "expected_result": l_uploads[0]["name"],
             },
             {
                 "classe": Upload,
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "upload.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
-                "expected_result": "v_tag",
+                "expected_result": l_uploads[0]["tags"]["k_tag"],
             },
             # TEST 2 : avec on sens datastore, on vérifie qu'un datastore passé est bien transmis
             {
@@ -150,7 +151,7 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": "datastore_1"},
                 "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]", "datastore": "datastore_1"},
-                "expected_result": "upload_1",
+                "expected_result": l_uploads[0]["_id"],
             },
             # TEST 3 : utilisation de ONE
             {
@@ -158,14 +159,21 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": "datastore_1"},
                 "expression": {"string_to_solve": "upload.ONE.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]", "datastore": "datastore_1"},
-                "expected_result": "upload_1",
+                "expected_result": l_uploads[0]["_id"],
             },
             {
                 "classe": Upload,
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "upload.ONE.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
-                "expected_result": "Name 1",
+                "expected_result": l_uploads[0]["name"],
+            },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "upload.ONE.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
+                "expected_result": l_uploads[0]["tags"]["k_tag"],
             },
             {
                 "classe": Upload,
@@ -199,6 +207,14 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "expected_result": json.dumps([o_upload.get_store_properties() for o_upload in l_uploads]),
                 "nb_api_update": len(l_uploads),
             },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {}, "page": 1, "datastore": "datastore_1"},
+                "expression": {"string_to_solve": "upload.ALL.tags.k_tag [INFOS(name=start_%)]", "datastore": "datastore_1"},
+                "expected_result": json.dumps(list(set([o_upload["tags"]["k_tag"] for o_upload in l_uploads]))),
+                "nb_api_update": len(l_uploads),
+            },
         ]
         for d_param in l_param:
             self.run_resolve(d_param)
@@ -213,14 +229,14 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_endpoints,
                 "data_api_list": {"infos_filter": {"type": "ARCHIVE"}, "tags_filter": {}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "endpoint.infos._id [INFOS(type=ARCHIVE)]"},
-                "expected_result": "endpoint",
+                "expected_result": l_endpoints[0]["_id"],
             },
             {
                 "classe": Endpoint,
                 "return_api_list": l_endpoints,
                 "data_api_list": {"infos_filter": {"type": "ARCHIVE"}, "tags_filter": {}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "endpoint.infos.name [INFOS(type=ARCHIVE)]"},
-                "expected_result": "Name",
+                "expected_result": l_endpoints[0]["name"],
             },
         ]
         for d_param in l_param:
@@ -238,14 +254,14 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_entities,
                 "data_api_list": {"infos_filter": {"name": "ds1"}, "tags_filter": {}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "datastore.infos._id [INFOS(name=ds1)]"},
-                "expected_result": "1",
+                "expected_result": l_entities[0]["_id"],
             },
             {
                 "classe": Datastore,
                 "return_api_list": l_entities,
                 "data_api_list": {"infos_filter": {"name": "ds1"}, "tags_filter": {}, "page": 1, "datastore": None},
                 "expression": {"string_to_solve": "datastore.infos.technical_name [INFOS(name=ds1)]"},
-                "expected_result": "ds1",
+                "expected_result": l_entities[0]["technical_name"],
             },
         ]
         for d_param in l_param:

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import Any, Dict, List
 from unittest.mock import patch
 
 from sdk_entrepot_gpf.store.Endpoint import Endpoint
@@ -101,7 +101,12 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 # Vérification maj entité via appel de api_update
                 o_mock_api_update.assert_called_once_with()
 
-    def run_resolve(self, d_param) -> None:
+    def run_resolve(self, d_param: Dict[str, Any]) -> None:
+        """lancement des tests pour resolve() sans erreur
+
+        Args:
+            d_param (Dict[str,Any]): dictionnaire
+        """
         o_store_entity_resolver = StoreEntityResolver("store_entity")
         # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
         with patch.object(d_param["classe"], "api_list", return_value=d_param["return_api_list"]) as o_mock_api_list:
@@ -212,7 +217,7 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 "return_api_list": l_uploads,
                 "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {}, "page": 1, "datastore": "datastore_1"},
                 "expression": {"string_to_solve": "upload.ALL.tags.k_tag [INFOS(name=start_%)]", "datastore": "datastore_1"},
-                "expected_result": json.dumps(list(set([o_upload["tags"]["k_tag"] for o_upload in l_uploads]))),
+                "expected_result": json.dumps(list({o_upload["tags"]["k_tag"] for o_upload in l_uploads})),
                 "nb_api_update": len(l_uploads),
             },
         ]

--- a/tests/workflow/resolver/StoreEntityResolverTestCase.py
+++ b/tests/workflow/resolver/StoreEntityResolverTestCase.py
@@ -32,6 +32,24 @@ class StoreEntityResolverTestCase(GpfTestCase):
             o_store_entity_resolver.resolve("upload.infos._id [IFO(name=titi)]")
         self.assertEqual(o_arc_2.exception.message, "Erreur du résolveur 'store_entity' avec la chaîne 'upload.infos._id [IFO(name=titi)]'.")
 
+        # pas de possibilité de récupérer un tag pour une entité endpoint
+        l_endpoints = [Endpoint({"_id": "endpoint", "name": "Name", "type": "ARCHIVE"})]
+        o_store_entity_resolver = StoreEntityResolver("store_entity")
+        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
+        with patch.object(Endpoint, "api_list", return_value=l_endpoints) as o_mock_api_list:
+            s_to_solve = "endpoint.tags.k_tag [INFOS(type=ARCHIVE)]"
+            with self.assertRaises(ResolverError) as o_arc:
+                o_store_entity_resolver.resolve("endpoint.tags.k_tag [INFOS(type=ARCHIVE)]")
+            # Vérification erreur
+            self.assertEqual(o_arc.exception.message, f"Erreur du résolveur 'store_entity' avec la chaîne '{s_to_solve}'.")
+            # Vérifications o_mock_api_list
+            o_mock_api_list.assert_called_once_with(
+                infos_filter={"type": "ARCHIVE"},
+                tags_filter={},
+                page=1,
+                datastore=None,
+            )
+
     def test_resolve_no_result(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve si aucun résultat n'est trouvé."""
 
@@ -82,173 +100,112 @@ class StoreEntityResolverTestCase(GpfTestCase):
                 # Vérification maj entité via appel de api_update
                 o_mock_api_update.assert_called_once_with()
 
+    def run_resolve(self, d_param) -> None:
+        o_store_entity_resolver = StoreEntityResolver("store_entity")
+        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
+        with patch.object(d_param["classe"], "api_list", return_value=d_param["return_api_list"]) as o_mock_api_list:
+            with patch.object(d_param["classe"], "api_update", return_value=None) as o_mock_api_update:
+                s_result = o_store_entity_resolver.resolve(**d_param["expression"])
+                # Vérifications o_mock_api_list
+                o_mock_api_list.assert_called_once_with(**d_param["data_api_list"])
+                # Vérification id récupérée
+                self.assertEqual(s_result, d_param["expected_result"])
+                # Vérification maj entité via appel de api_update
+                o_mock_api_update.assert_called_once_with()
+
     def test_resolve_upload(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un upload."""
-
-        o_store_entity_resolver = StoreEntityResolver("store_entity")
         l_uploads = [
             Upload({"_id": "upload_1", "name": "Name 1", "tags": {"k_tag": "v_tag"}}),
             Upload({"_id": "upload_2", "name": "Name 2", "tags": {"k_tag": "v_tag"}}),
         ]
 
-        # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "start_%"},
-                    tags_filter={"k_tag": "v_tag"},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification id récupérée
-                self.assertEqual(s_result, "upload_1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("upload.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "start_%"},
-                    tags_filter={"k_tag": "v_tag"},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification name récupérée
-                self.assertEqual(s_result, "Name 1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("upload.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "start_%"},
-                    tags_filter={"k_tag": "v_tag"},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification name récupéré
-                self.assertEqual(s_result, "v_tag")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
-
-        # TEST 2 : avec on sens datastore, on vérifie qu'un datastore passé est bien transmis
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(StoreEntity, "api_list", return_value=l_uploads) as o_mock_api_list:
-            with patch.object(StoreEntity, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve(
-                    "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]",
-                    datastore="datastore_1",  # On précise un datastore
-                )
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "start_%"},
-                    tags_filter={"k_tag": "v_tag"},
-                    page=1,
-                    datastore="datastore_1",  # Il est bien transmis
-                )
-                # Vérification id récupérée
-                self.assertEqual(s_result, "upload_1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
+        l_param = [
+            # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
+                "expected_result": "upload_1",
+            },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "upload.infos.name [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
+                "expected_result": "Name 1",
+            },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "upload.tags.k_tag [INFOS(name=start_%), TAGS(k_tag=v_tag)]"},
+                "expected_result": "v_tag",
+            },
+            # TEST 2 : avec on sens datastore, on vérifie qu'un datastore passé est bien transmis
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": "datastore_1"},
+                "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]", "datastore": "datastore_1"},
+                "expected_result": "upload_1",
+            },
+            {
+                "classe": Upload,
+                "return_api_list": l_uploads,
+                "data_api_list": {"infos_filter": {"name": "start_%"}, "tags_filter": {"k_tag": "v_tag"}, "page": 1, "datastore": "datastore_1"},
+                "expression": {"string_to_solve": "upload.infos._id [INFOS(name=start_%), TAGS(k_tag=v_tag)]", "datastore": "datastore_1"},
+                "expected_result": "upload_1",
+            },
+        ]
+        for d_param in l_param:
+            self.run_resolve(d_param)
 
     def test_resolve_endpoint(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un endpoint."""
-
-        o_store_entity_resolver = StoreEntityResolver("store_entity")
-        l_uploads = [
-            Endpoint({"_id": "endpoint", "name": "Name", "type": "ARCHIVE"}),
+        l_endpoints = [Endpoint({"_id": "endpoint", "name": "Name", "type": "ARCHIVE"})]
+        l_param = [
+            # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
+            {
+                "classe": Endpoint,
+                "return_api_list": l_endpoints,
+                "data_api_list": {"infos_filter": {"type": "ARCHIVE"}, "tags_filter": {}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "endpoint.infos._id [INFOS(type=ARCHIVE)]"},
+                "expected_result": "endpoint",
+            },
+            {
+                "classe": Endpoint,
+                "return_api_list": l_endpoints,
+                "data_api_list": {"infos_filter": {"type": "ARCHIVE"}, "tags_filter": {}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "endpoint.infos.name [INFOS(type=ARCHIVE)]"},
+                "expected_result": "Name",
+            },
         ]
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Endpoint, "api_list", return_value=l_uploads) as o_mock_api_list:
-            s_result = o_store_entity_resolver.resolve("endpoint.infos._id [INFOS(type=ARCHIVE)]")
-            # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(
-                infos_filter={"type": "ARCHIVE"},
-                tags_filter={},
-                page=1,
-                datastore=None,
-            )
-            # Vérification id récupérée
-            self.assertEqual(s_result, "endpoint")
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Endpoint, "api_list", return_value=l_uploads) as o_mock_api_list:
-            s_result = o_store_entity_resolver.resolve("endpoint.infos.name [INFOS(type=ARCHIVE)]")
-            # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(
-                infos_filter={"type": "ARCHIVE"},
-                tags_filter={},
-                page=1,
-                datastore=None,
-            )
-            # Vérification name récupérée
-            self.assertEqual(s_result, "Name")
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Endpoint, "api_list", return_value=l_uploads) as o_mock_api_list:
-            s_to_solve = "endpoint.tags.k_tag [INFOS(type=ARCHIVE)]"
-            with self.assertRaises(ResolverError) as o_arc:
-                o_store_entity_resolver.resolve("endpoint.tags.k_tag [INFOS(type=ARCHIVE)]")
-            # Vérification erreur
-            self.assertEqual(o_arc.exception.message, f"Erreur du résolveur 'store_entity' avec la chaîne '{s_to_solve}'.")
-            # Vérifications o_mock_api_list
-            o_mock_api_list.assert_called_once_with(
-                infos_filter={"type": "ARCHIVE"},
-                tags_filter={},
-                page=1,
-                datastore=None,
-            )
+        for d_param in l_param:
+            self.run_resolve(d_param)
 
     def test_resolve_datastore(self) -> None:
         """Vérifie le bon fonctionnement de la fonction resolve pour un store.
         On peut utiliser `name` pour filter sur le `name` et sur le `technical_name`.
         """
-
-        o_store_entity_resolver = StoreEntityResolver("store_entity")
-        l_entities = [
-            Datastore({"_id": "1", "name": "Datastore 1", "technical_name": "ds1"}),
+        l_entities = [Datastore({"_id": "1", "name": "Datastore 1", "technical_name": "ds1"})]
+        l_param = [
+            # TEST 1 : attributs, on tente de récupérer différents attributs du 1er élément
+            {
+                "classe": Datastore,
+                "return_api_list": l_entities,
+                "data_api_list": {"infos_filter": {"name": "ds1"}, "tags_filter": {}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "datastore.infos._id [INFOS(name=ds1)]"},
+                "expected_result": "1",
+            },
+            {
+                "classe": Datastore,
+                "return_api_list": l_entities,
+                "data_api_list": {"infos_filter": {"name": "ds1"}, "tags_filter": {}, "page": 1, "datastore": None},
+                "expression": {"string_to_solve": "datastore.infos.technical_name [INFOS(name=ds1)]"},
+                "expected_result": "ds1",
+            },
         ]
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Datastore, "api_list", return_value=l_entities) as o_mock_api_list:
-            with patch.object(Datastore, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("datastore.infos._id [INFOS(name=ds1)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "ds1"},
-                    tags_filter={},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification id récupérée
-                self.assertEqual(s_result, "1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
-
-        # On mock la fonction api_list, on veut vérifier qu'elle est appelée avec les bons param
-        with patch.object(Datastore, "api_list", return_value=l_entities) as o_mock_api_list:
-            with patch.object(Datastore, "api_update", return_value=None) as o_mock_api_update:
-                s_result = o_store_entity_resolver.resolve("datastore.infos._id [INFOS(name=Datastore 1)]")
-                # Vérifications o_mock_api_list
-                o_mock_api_list.assert_called_once_with(
-                    infos_filter={"name": "Datastore 1"},
-                    tags_filter={},
-                    page=1,
-                    datastore=None,
-                )
-                # Vérification id récupérée
-                self.assertEqual(s_result, "1")
-                # Vérification maj entité via appel de api_update
-                o_mock_api_update.assert_called_once_with()
+        for d_param in l_param:
+            self.run_resolve(d_param)


### PR DESCRIPTION
## v0.1.24

### [Added]

* StoreEntityResolver: possibilité de récupérer une liste d'entités ou d’informations sur une entité #85
* ajout classe Permission : gère les permissions sur les offres #93
* ajout classe PermissionAction : gère les permissions sur les offres depuis le workflow #94

### [Changed]

* workflow:
  * ajout de PermissionAction #94
  * possibilité d'utiliser un résolveur pour créer la liste de "Iter_vals" #106
  * possibilité de définir un datastore au niveau de l'étape

### [Fixed]

* schema workflow: ajout du type "edit-entity"
* Edit Configuration : correction de la gestion de `used_data` (#107)