### PR TITLE
Conflict upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * workflow : ajout de EditUsedDataConfigurationAction #105
 * DeleteAction: meilleur gestion cas sans élément à supprimé #115
+* UploadAction: les conflits de livraisons ne bloquent pas la suite du traitement #119
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * ajout d'une `LogsInterface` pour gérer les logs (mutualisation de `api_logs`).
 * utilisation systématique de la fonction `JsonHelper.loads` (au lieu de `json.loads`) pour afficher un message d'erreur et le JSON posant problème en cas de besoin (sauf si raison particulière, à expliquer).
+* UploadAction: mise en commun fonctions__push_data_files et __push_md5_files
 
 ### [Fixed]
 


### PR DESCRIPTION
Développement pour #119

## [Added]

* UploadAction: les conflits de livraisons ne bloquent pas la suite du traitement #119

## [Changed]

* UploadAction: mise en commun fonctions__push_data_files et __push_md5_files