### PR TITLE
Plus de limitation sur le type de l'upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### [Changed]
 
+* Plus de limitation sur le type de l'upload dans le fichier upload_descriptor, permet la livraison des nouveaux types sans mise à jour du SDK. #117
+
 ### [Fixed]
 
 ## v0.1.25

--- a/sdk_entrepot_gpf/_conf/json_schemas/upload_descriptor_file.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/upload_descriptor_file.json
@@ -45,12 +45,7 @@
                                 "type": "string"
                             },
                             "type": {
-                                "type": "string",
-                                "enum": [
-                                    "RASTER",
-                                    "VECTOR",
-                                    "ARCHIVE"
-                                ]
+                                "type": "string"
                             }
                         }
                     },


### PR DESCRIPTION
Développement pour #117 

## [Changed]

* Plus de limitation sur le type de l'upload dans le fichier upload_descriptor, permet la livraison des nouveaux types sans mise à jour du SDK. #117