### PR TITLE
Upload_descriptor_file ajout de "type_infos"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### [Fixed]
 
+* upload_descriptor_file.json: ajout de type_infos suite à l'ajout du paramètre dans la requête GPF. #117
+
 ## v0.1.26
 
 ### [Added]

--- a/sdk_entrepot_gpf/_conf/json_schemas/upload_descriptor_file.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/upload_descriptor_file.json
@@ -46,6 +46,9 @@
                             },
                             "type": {
                                 "type": "string"
+                            },
+                            "type_infos": {
+                                "type": "object"
                             }
                         }
                     },


### PR DESCRIPTION
Développement pour #117

## [Fixed]

* upload_descriptor_file.json: ajout de type_infos suite à l'ajout du paramètre dans la requête GPF. #117
