### PR TITLE
PermissionAction : création d'une liste de permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
 * Annexe, Metadata: amélioration de l'affichage des entités
+* PermissionAction: il faut utiliser `api_create` et non `api_create_list` pour créer les permissions.
 
 ## v0.1.28
 

--- a/sdk_entrepot_gpf/workflow/action/PermissionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/PermissionAction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from sdk_entrepot_gpf.store.Permission import Permission
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
@@ -20,27 +20,27 @@ class PermissionAction(ActionAbstract):
     def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None) -> None:
         super().__init__(workflow_context, definition_dict, parent_action)
         # Autres attributs
-        self.__permission: Optional[Permission] = None
+        self.__permissions: List[Permission] = []
 
     def run(self, datastore: Optional[str] = None) -> None:
-        Config().om.info("Création d'une permission...", force_flush=True)
+        Config().om.info("Création des permissions...", force_flush=True)
         # Création de la permission
-        self.__create_permission(datastore)
-        Config().om.info(f"Permissions créées : {self.permission}")
-        Config().om.info("Création d'une permission : terminée")
+        self.__create_permissions(datastore)
+        Config().om.info(f"Permissions créées : {self.permissions}")
+        Config().om.info("Création des permissions : terminée")
 
-    def __create_permission(self, datastore: Optional[str]) -> None:
-        """Création de la permission sur l'API à partir des paramètres de définition de l'action.
+    def __create_permissions(self, datastore: Optional[str]) -> None:
+        """Création des permissions sur l'API à partir des paramètres de définition de l'action.
 
         Args:
             datastore (Optional[str]): id du datastore à utiliser.
         """
         # Création en gérant une erreur de type ConflictError (si la Permission existe déjà selon les critères de l'API)
         try:
-            self.__permission = Permission.api_create(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
+            self.__permissions = Permission.api_create_list(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
         except ConflictError as e:
-            raise StepActionError(f"Impossible de créer la permission il y a un conflict : \n{e.message}") from e
+            raise StepActionError(f"Impossible de créer les permissions il y a un conflict : \n{e.message}") from e
 
     @property
-    def permission(self) -> Optional[Permission]:
-        return self.__permission
+    def permissions(self) -> List[Permission]:
+        return self.__permissions

--- a/tests/workflow/action/PermissionActionTestCase.py
+++ b/tests/workflow/action/PermissionActionTestCase.py
@@ -7,11 +7,6 @@ from sdk_entrepot_gpf.workflow.action.PermissionAction import PermissionAction
 from tests.GpfTestCase import GpfTestCase
 
 
-# pylint:disable=too-many-arguments
-# pylint:disable=too-many-locals
-# pylint:disable=too-many-branches
-
-
 class PermissionActionTestCase(GpfTestCase):
     """Tests PermissionAction class.
 
@@ -29,13 +24,13 @@ class PermissionActionTestCase(GpfTestCase):
         }
         o_action = PermissionAction("context", d_action)
         # Permet de vérifier qu'il n'y a pas encore de permission
-        self.assertIsNone(o_action.permission)
+        self.assertListEqual(o_action.permissions, [])
 
         # fonctionnement OK
-        o_permission = MagicMock()
-        with patch.object(Permission, "api_create", return_value=o_permission) as o_mock_create:
+        l_permissions = [MagicMock()]
+        with patch.object(Permission, "api_create_list", return_value=l_permissions) as o_mock_create:
             o_action.run("datastore")
         # Permet de mocker l'appel à la création de la permission
         o_mock_create.assert_called_once_with(d_action["body_parameters"], route_params={"datastore": "datastore"})
         # Permet de vérifier qu'après l'appel la permission ajoutée correspond à celle qui est demandée
-        self.assertEqual(o_permission, o_action.permission)
+        self.assertEqual(l_permissions, o_action.permissions)


### PR DESCRIPTION
Correction d'un bug : on crée une liste de permissions et il faut donc utiliser `api_create_list`.