### PR TITLE
v0.1.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
 * ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
-* OutputManager: ajout option force_flush pour info, warning, error et critical. Permet de forcé le remonté des logs. Utilisation dans les différentes actions
+* OutputManager: ajout option force_flush pour info, warning, error et critical. Permet de forcer la remontée des logs. Utilisation dans les différentes actions où cela est pertinent.
+* Mode Compatibilité avec cartes.gouv : ce mode permet au SDK de manipuler les entités de l'API en ajoutant les tags qui permettent d'assurer la compatibilité avec l'interface d'alimentation en ligne cartes.gouv.
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Création/consultation des clefs depuis la ligne de commande #96
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
+* ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGE LOG
 
+## v0.1.29
+
+### [Fixed]
+
+* `ReUploadFileInterface` : ajout de `route_params` pour modifier l'entité. (fix #178)
+
 ## v0.1.28
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### [Added]
 
 * Création/consultation des clefs depuis la ligne de commande #96
+* doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
 * ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
+* OutputManager: ajout option force_flush pour info, warning, error et critical. Permet de forcer la remontée des logs. Utilisation dans les différentes actions où cela est pertinent.
+* Mode Compatibilité avec cartes.gouv : ce mode permet au SDK de manipuler les entités de l'API en ajoutant les tags qui permettent d'assurer la compatibilité avec l'interface d'alimentation en ligne cartes.gouv.
 * EditAction: possibilité de supprimer les tags et les commentaires #180
 
 ### [Changed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### [Fixed]
 
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
+* Annexe, Metadata: amélioration de l'affichage des entités
 
 ## v0.1.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Création/consultation des clefs depuis la ligne de commande #96
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
+* ApiRequester, Authentifier: gestion de l'erreur ConnectionError # 168
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
 * ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
+* EditAction: possibilité de supprimer les tags et les commentaires #180
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
 * ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
-* EditAction: possibilité de supprimé les tags et commentaires #180
+* EditAction: possibilité de supprimer les tags et les commentaires #180
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
 * Annexe, Metadata: amélioration de l'affichage des entités
+* `ReUploadFileInterface` : ajout de `route_params` pour modifier l'entité. (fix #178)
 * PermissionAction: il faut utiliser `api_create` et non `api_create_list` pour créer les permissions.
 
 ## v0.1.28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,22 @@
 
 ### [Added]
 
+* Création/consultation des clefs depuis la ligne de commande #96
+* doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
+* ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
+* ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
+
 ### [Changed]
+
+* Config :
+  * gestion des fichiers `toml` ;
+  * suppression de la fonction `get_parser` remplacée par `get_config` ;
+  * les fonctions de récupération typées (`get_str`, `get_int`, `get_float`, `get_bool`) renvoient une valeur valide ou lèvent une exception.
 
 ### [Fixed]
 
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
+* Annexe, Metadata: amélioration de l'affichage des entités
 
 ## v0.1.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Création/consultation des clefs depuis la ligne de commande #96
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
+* ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
 
 ### [Changed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### [Changed]
 
+* Config :
+  * gestion des fichiers `toml` ;
+  * suppression de la fonction `get_parser` remplacée par `get_config` ;
+  * les fonctions de récupération typées (`get_str`, `get_int`, `get_float`, `get_bool`) renvoient une valeur valide ou lèvent une exception.
+
 ### [Fixed]
 
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,24 @@
 
 ## v0.1.29
 
+### [Added]
+
+* Création/consultation des clefs depuis la ligne de commande #96
+* doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
+* ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
+* ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
+
+### [Changed]
+
+* Config :
+  * gestion des fichiers `toml` ;
+  * suppression de la fonction `get_parser` remplacée par `get_config` ;
+  * les fonctions de récupération typées (`get_str`, `get_int`, `get_float`, `get_bool`) renvoient une valeur valide ou lèvent une exception.
+
 ### [Fixed]
 
+* ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
+* Annexe, Metadata: amélioration de l'affichage des entités
 * `ReUploadFileInterface` : ajout de `route_params` pour modifier l'entité. (fix #178)
 
 ## v0.1.28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
 * Annexe, Metadata: amélioration de l'affichage des entités
 * `ReUploadFileInterface` : ajout de `route_params` pour modifier l'entité. (fix #178)
+* PermissionAction: il faut utiliser `api_create` et non `api_create_list` pour créer les permissions.
 
 ## v0.1.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 ### [Changed]
 
+* Config :
+  * gestion des fichiers `toml` ;
+  * suppression de la fonction `get_parser` remplacée par `get_config` ;
+  * les fonctions de récupération typées (`get_str`, `get_int`, `get_float`, `get_bool`) renvoient une valeur valide ou lèvent une exception.
+
 ### [Fixed]
 
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Added]
 
+* Création/consultation des clefs depuis la ligne de commande #96
+
 ### [Changed]
 
 ### [Fixed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
 * ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
+* OutputManager: ajout option force_flush pour info, warning, error et critical. Permet de forcé le remonté des logs. Utilisation dans les différentes actions
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### [Added]
 
+* Création/consultation des clefs depuis la ligne de commande #96
+* doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
+
 ### [Changed]
 
 ### [Fixed]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
 * ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
+* EditAction: possibilité de supprimé les tags et commentaires #180
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
 * Annexe, Metadata: amélioration de l'affichage des entités
+* PermissionAction: il faut utiliser `api_create` et non `api_create_list` pour créer les permissions.
 
 ## v0.1.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
 * OutputManager: ajout option force_flush pour info, warning, error et critical. Permet de forcer la remontée des logs. Utilisation dans les différentes actions où cela est pertinent.
 * Mode Compatibilité avec cartes.gouv : ce mode permet au SDK de manipuler les entités de l'API en ajoutant les tags qui permettent d'assurer la compatibilité avec l'interface d'alimentation en ligne cartes.gouv.
+* EditAction: possibilité de supprimer les tags et les commentaires #180
 
 ### [Changed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### [Fixed]
 
 * ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
+* Annexe, Metadata: amélioration de l'affichage des entités
 
 ## v0.1.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGE LOG
 
+## v0.1.29
+
+### [Added]
+
+### [Changed]
+
+### [Fixed]
+
 ## v0.1.28
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@
 
 * Création/consultation des clefs depuis la ligne de commande #96
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
-* ApiRequester, Authentifier: gestion de l'erreur ConnectionError # 168
+* ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
+* ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
 
 ### [Changed]
+
+* Config :
+  * gestion des fichiers `toml` ;
+  * suppression de la fonction `get_parser` remplacée par `get_config` ;
+  * les fonctions de récupération typées (`get_str`, `get_int`, `get_float`, `get_bool`) renvoient une valeur valide ou lèvent une exception.
 
 ### [Fixed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### [Fixed]
 
+* ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
+
 ## v0.1.28
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@
 
 * Création/consultation des clefs depuis la ligne de commande #96
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
+* ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
+* ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
 
 ### [Changed]
+
+* Config :
+  * gestion des fichiers `toml` ;
+  * suppression de la fonction `get_parser` remplacée par `get_config` ;
+  * les fonctions de récupération typées (`get_str`, `get_int`, `get_float`, `get_bool`) renvoient une valeur valide ou lèvent une exception.
 
 ### [Fixed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
 * ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
 * ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
+* OutputManager: ajout option force_flush pour info, warning, error et critical. Permet de forcer la remontée des logs. Utilisation dans les différentes actions où cela est pertinent.
+* Mode Compatibilité avec cartes.gouv : ce mode permet au SDK de manipuler les entités de l'API en ajoutant les tags qui permettent d'assurer la compatibilité avec l'interface d'alimentation en ligne cartes.gouv.
+* EditAction: possibilité de supprimer les tags et les commentaires #180
 
 ### [Changed]
 

--- a/docs/comme-executable.md
+++ b/docs/comme-executable.md
@@ -140,6 +140,140 @@ Permet d'avoir un workflow avec une gestion dynamique de l'édition traitée gr�
 {store_entity.stored_data.infos._id [INFOS(name=MES_DONNÉES_{params.edition})]}
 ```
 
+## Suppression d'entités
+
+Le programme permet de supprimer des entités de type `upload`, `stored_data`, `configuration`, `offering`, `permission` et `key`.
+
+Avant la suppression la liste des entités supprimées sera affichée et l'utilisateur devra valider la suppression (sauf si utilisation de `--force`).
+
+Commande générale :
+
+```sh
+python -m sdk_entrepot_gpf delete --type {upload,stored_data,configuration,offering,permission,key} --id UUID
+```
+
+Avec comme options supplémentaires :
+
+* `--force` : aucune question ne sera posée avant la suppression
+* `--cascade` : suppression des éléments liés en aval, fonctionne uniquement pour :
+  * `stored_data` : suppression des configuration et offres liées
+  * `configuration` : suppression des offres liées
+
+NB : s'il y a des des éléments liés en aval et que vous ne demandez pas la suppression il sera impossible de supprimer l'élément ciblé.
+
+Exemples :
+
+```sh
+# Suppression d'une livraison
+python -m sdk_entrepot_gpf delete --type upload --id UUID
+# Suppression d'une donnée stockée (sans demander confirmation, sans supprimer les éléments liés)
+python -m sdk_entrepot_gpf delete --type stored_data --id UUID --force
+# Suppression d'une configuration (et d'une éventuelle offre liée)
+python -m sdk_entrepot_gpf delete --type configuration --id UUID --cascade
+```
+
+## Fichiers annexes
+
+Base : `python -m sdk_entrepot_gpf annexe`
+
+Quatre types de lancement :
+
+* livraison d'annexes : `-f FICHIER`
+* liste des annexes, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
+* afficher des détails d'une annexe, avec option publication / dépublication : `--id ID [--publish|--unpublish]`
+* publication / dépublication par label : `--publish-by-label label1,label2` et `--unpublish-by-label label1,label2`
+
+Exemple de fichier pour la livraison :
+
+```json
+{
+  "annexe" : [
+    {
+      "file": "/chemin/du/fichier.pdf",
+      "paths": ["test2.xml"],
+      "labels": ["label1", "label2"],
+      "published": false
+    }
+  ]
+}
+```
+
+## Fichiers statiques
+
+Base : `python -m sdk_entrepot_gpf static`
+
+Trois types de lancement :
+
+* livraison de fichiers statics : `-f FICHIER`
+* liste des fichiers statics, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
+* afficher des détails d'un ficher statique : `--id ID`
+
+Exemple de fichier pour la livraison :
+
+```json
+{
+  "static" : [
+    {
+      "file": "mon_style.sld",
+      "name": "mon_style",
+      "type": "GEOSERVER-STYLE",
+      "description": "description"
+    }
+  ]
+}
+```
+
+## Fichiers de métadonnées
+
+Base : `python -m sdk_entrepot_gpf metadata`
+
+Quatre types de lancement :
+
+* livraison d'une métadonnée : `-f FICHIER`
+* liste des métadonnées, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
+* afficher les détails d'une métadonnée : `--id ID`
+* publication / dépublication : `--publish NOM_FICHIER [NOM_FICHIER] --id-endpoint ID_ENDPOINT` et `--unpublish NOM_FICHIER [NOM_FICHIER] --id-endpoint ID_ENDPOINT`
+
+Exemple de fichier pour la livraison :
+
+```json
+{
+  "metadata": [
+    {
+      "file": "metadata.xml",
+      "type": "INSPIRE"
+    }
+  ]
+}
+```
+
+## Gestion des clefs de l'utilisateur
+
+Base : `python -m sdk_entrepot_gpf key`
+
+Trois types de lancement :
+
+* liste des clefs : `` (aucun paramètres)
+* afficher les détails d'une clef : `--id ID`
+* création de clefs : `--f FICHIER`
+
+Exemple de fichier pour la création :
+
+```json
+{
+  "key": [
+    {
+      "name": "nom",
+      "type": "HASH",
+      "type_infos": {
+        "hash": "hash"
+      }
+    }
+  ]
+}
+
+```
+
 ## Tutoriels
 
 Vous pouvez maintenant livrer et publier vos données en utilisant le module comme un exécutable. Voici quelques exemples :

--- a/docs/comme-executable.md
+++ b/docs/comme-executable.md
@@ -140,6 +140,123 @@ Permet d'avoir un workflow avec une gestion dynamique de l'édition traitée gr�
 {store_entity.stored_data.infos._id [INFOS(name=MES_DONNÉES_{params.edition})]}
 ```
 
+## suppression d'entité
+
+Il est possible de supprimer des entité de type `upload`, `stored_data`, `configuration`, `offering`, `permission` et `key`. Avant la suppression la liste sera affiché et l'utilisateur devra validé la suppression (sauf si utilisation de `--force`)
+
+```sh
+python -m sdk_entrepot_gpf delete --type {upload,stored_data,configuration,offering,permission,key} --id UUID
+```
+
+Avec comme option supplémentaire :
+
+* `--force` : aucune question sera posé avant la suppression
+* `-- cascade` : supprimer ses éléments lié, fonctionne uniquement pour :
+  * `stored_data` : suppression des configuration et offres lié
+  * `configuration` : suppression des offres lié
+
+## Fichiers annexes
+
+Base : `python -m sdk_entrepot_gpf annexe`
+
+Quatre types de lancement :
+
+* livraison d'annexes : `-f FICHIER`
+* liste des annexes, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
+* détail d'une annexe, avec option publication / dépublication : `--id ID [--publish|--unpublish]`
+* publication / dépublication par label : `--publish-by-label label1,label2` et `--unpublish-by-label label1,label2`
+
+Exemple de fichier pour la livraison :
+
+```json
+{
+  "annexe" : [
+    {
+      "file": "/chemin/du/fichier.pdf",
+      "paths": ["test2.xml"],
+      "labels": ["label1", "label2"],
+      "published": false
+    }
+  ]
+}
+```
+
+## Fichiers statics
+
+Base : `python -m sdk_entrepot_gpf static`
+
+Trois types de lancement :
+
+* livraison de fichiers statics : `-f FICHIER`
+* liste des fichiers statics, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
+* détail d'un ficher static : `--id ID`
+
+Exemple de fichier pour la livraison :
+
+```json
+{
+  "static" : [
+    {
+      "file": "mon_style.sld",
+      "name": "mon_style",
+      "type": "GEOSERVER-STYLE",
+      "description": "description"
+    }
+  ]
+}
+```
+
+## Fichiers de métadonnées
+
+Base : `python -m sdk_entrepot_gpf metadata`
+
+Quatre types de lancement :
+
+* livraison d'une métadonnée : `-f FICHIER`
+* liste des métadonnées, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
+* détail d'une métadonnée : `--id ID`
+* publication / dépublication : `--publish NOM_FICHIER [NOM_FICHIER] --id-endpoint ID_ENDPOINT` et `--unpublish NOM_FICHIER [NOM_FICHIER] --id-endpoint ID_ENDPOINT`
+
+Exemple de fichier pour la livraison :
+
+```json
+{
+  "metadata": [
+    {
+      "file": "metadata.xml",
+      "type": "INSPIRE"
+    }
+  ]
+}
+```
+
+## gestion des clefs de l'utilisateur
+
+Base : `python -m sdk_entrepot_gpf key`
+
+Trois type de lancement:
+
+* liste des clefs : `` (aucun paramètres)
+* détail d'une clef : `--id ID`
+* création de clefs : `--f FICHIER`
+
+Exemple de fichier pour la création :
+
+```json
+{
+  "key": [
+    {
+      "name": "nom",
+      "type": "HASH",
+      "type_infos": {
+        "hash": "hash"
+      }
+    }
+  ]
+}
+
+```
+
 ## Tutoriels
 
 Vous pouvez maintenant livrer et publier vos données en utilisant le module comme un exécutable. Voici quelques exemples :

--- a/docs/comme-executable.md
+++ b/docs/comme-executable.md
@@ -140,20 +140,37 @@ Permet d'avoir un workflow avec une gestion dynamique de l'édition traitée gr�
 {store_entity.stored_data.infos._id [INFOS(name=MES_DONNÉES_{params.edition})]}
 ```
 
-## suppression d'entité
+## Suppression d'entités
 
-Il est possible de supprimer des entité de type `upload`, `stored_data`, `configuration`, `offering`, `permission` et `key`. Avant la suppression la liste sera affiché et l'utilisateur devra validé la suppression (sauf si utilisation de `--force`)
+Le programme permet de supprimer des entités de type `upload`, `stored_data`, `configuration`, `offering`, `permission` et `key`.
+
+Avant la suppression la liste des entités supprimées sera affichée et l'utilisateur devra valider la suppression (sauf si utilisation de `--force`).
+
+Commande générale :
 
 ```sh
 python -m sdk_entrepot_gpf delete --type {upload,stored_data,configuration,offering,permission,key} --id UUID
 ```
 
-Avec comme option supplémentaire :
+Avec comme options supplémentaires :
 
-* `--force` : aucune question sera posé avant la suppression
-* `-- cascade` : supprimer ses éléments lié, fonctionne uniquement pour :
-  * `stored_data` : suppression des configuration et offres lié
-  * `configuration` : suppression des offres lié
+* `--force` : aucune question ne sera posée avant la suppression
+* `--cascade` : suppression des éléments liés en aval, fonctionne uniquement pour :
+  * `stored_data` : suppression des configuration et offres liées
+  * `configuration` : suppression des offres liées
+
+NB : s'il y a des des éléments liés en aval et que vous ne demandez pas la suppression il sera impossible de supprimer l'élément ciblé.
+
+Exemples :
+
+```sh
+# Suppression d'une livraison
+python -m sdk_entrepot_gpf delete --type upload --id UUID
+# Suppression d'une donnée stockée (sans demander confirmation, sans supprimer les éléments liés)
+python -m sdk_entrepot_gpf delete --type stored_data --id UUID --force
+# Suppression d'une configuration (et d'une éventuelle offre liée)
+python -m sdk_entrepot_gpf delete --type configuration --id UUID --cascade
+```
 
 ## Fichiers annexes
 
@@ -163,7 +180,7 @@ Quatre types de lancement :
 
 * livraison d'annexes : `-f FICHIER`
 * liste des annexes, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
-* détail d'une annexe, avec option publication / dépublication : `--id ID [--publish|--unpublish]`
+* afficher des détails d'une annexe, avec option publication / dépublication : `--id ID [--publish|--unpublish]`
 * publication / dépublication par label : `--publish-by-label label1,label2` et `--unpublish-by-label label1,label2`
 
 Exemple de fichier pour la livraison :
@@ -181,7 +198,7 @@ Exemple de fichier pour la livraison :
 }
 ```
 
-## Fichiers statics
+## Fichiers statiques
 
 Base : `python -m sdk_entrepot_gpf static`
 
@@ -189,7 +206,7 @@ Trois types de lancement :
 
 * livraison de fichiers statics : `-f FICHIER`
 * liste des fichiers statics, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
-* détail d'un ficher static : `--id ID`
+* afficher des détails d'un ficher statique : `--id ID`
 
 Exemple de fichier pour la livraison :
 
@@ -214,7 +231,7 @@ Quatre types de lancement :
 
 * livraison d'une métadonnée : `-f FICHIER`
 * liste des métadonnées, avec filtre en option : `[--info filtre1=valeur1,filtre2=valeur2]`
-* détail d'une métadonnée : `--id ID`
+* afficher les détails d'une métadonnée : `--id ID`
 * publication / dépublication : `--publish NOM_FICHIER [NOM_FICHIER] --id-endpoint ID_ENDPOINT` et `--unpublish NOM_FICHIER [NOM_FICHIER] --id-endpoint ID_ENDPOINT`
 
 Exemple de fichier pour la livraison :
@@ -230,14 +247,14 @@ Exemple de fichier pour la livraison :
 }
 ```
 
-## gestion des clefs de l'utilisateur
+## Gestion des clefs de l'utilisateur
 
 Base : `python -m sdk_entrepot_gpf key`
 
-Trois type de lancement:
+Trois types de lancement :
 
 * liste des clefs : `` (aucun paramètres)
-* détail d'une clef : `--id ID`
+* afficher les détails d'une clef : `--id ID`
 * création de clefs : `--f FICHIER`
 
 Exemple de fichier pour la création :

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -392,8 +392,6 @@ Possibilité de modifier une entité de type : `upload`, `stored_data`, `configu
 
 Correspond aux requêtes de type `PUT` et `PATCH` de l'[API Entrepôt](https://data.geopf.fr/api/swagger-ui/index.html)
 
-La suppression des tags et des commentaires est faite avant l'ajout.
-
 ```jsonc
 {
     "type": "edit-entity",
@@ -403,10 +401,6 @@ La suppression des tags et des commentaires est faite avant l'ajout.
     "entity_id": "{uuid}",
     // Optionnel si non présent requête n'ai pas lancée ( => mise à jour des tags et commentaires uniquement), si l'entité hérite de FullEditInterface (mise à jour totale) => fusion des informations récupérées sur l'API (GET) et de celle fournies, sinon on envoie que celles fournies
     "body_parameters": { ... },
-    // Optionnel :  tags à supprimé
-    "remove_tags": ["clef1", "clef2"],
-    // Optionnel :  commentaire à supprimé
-    "remove_comments": ["commentaire 1", "commentaire 2"],
     // Optionnel : Liste des tags ajoutés à l'entité (uniquement si la classe hérite de TagInterface)
     "tags": {},
     // Optionnel : Liste des commentaires à ajouter (uniquement si la classe hérite de CommentInterface)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -392,6 +392,8 @@ Possibilité de modifier une entité de type : `upload`, `stored_data`, `configu
 
 Correspond aux requêtes de type `PUT` et `PATCH` de l'[API Entrepôt](https://data.geopf.fr/api/swagger-ui/index.html)
 
+La suppression des tags et des commentaires est faite avant l'ajout.
+
 ```jsonc
 {
     "type": "edit-entity",
@@ -401,6 +403,10 @@ Correspond aux requêtes de type `PUT` et `PATCH` de l'[API Entrepôt](https://d
     "entity_id": "{uuid}",
     // Optionnel si non présent requête n'ai pas lancée ( => mise à jour des tags et commentaires uniquement), si l'entité hérite de FullEditInterface (mise à jour totale) => fusion des informations récupérées sur l'API (GET) et de celle fournies, sinon on envoie que celles fournies
     "body_parameters": { ... },
+    // Optionnel :  tags à supprimer
+    "remove_tags": ["clef1", "clef2"],
+    // Optionnel :  commentaire à supprimer
+    "remove_comments": ["commentaire 1", "commentaire 2"],
     // Optionnel : Liste des tags ajoutés à l'entité (uniquement si la classe hérite de TagInterface)
     "tags": {},
     // Optionnel : Liste des commentaires à ajouter (uniquement si la classe hérite de CommentInterface)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -392,6 +392,8 @@ Possibilité de modifier une entité de type : `upload`, `stored_data`, `configu
 
 Correspond aux requêtes de type `PUT` et `PATCH` de l'[API Entrepôt](https://data.geopf.fr/api/swagger-ui/index.html)
 
+La suppression des tags et des commentaires est faite avant l'ajout.
+
 ```jsonc
 {
     "type": "edit-entity",
@@ -401,6 +403,10 @@ Correspond aux requêtes de type `PUT` et `PATCH` de l'[API Entrepôt](https://d
     "entity_id": "{uuid}",
     // Optionnel si non présent requête n'ai pas lancée ( => mise à jour des tags et commentaires uniquement), si l'entité hérite de FullEditInterface (mise à jour totale) => fusion des informations récupérées sur l'API (GET) et de celle fournies, sinon on envoie que celles fournies
     "body_parameters": { ... },
+    // Optionnel :  tags à supprimé
+    "remove_tags": ["clef1", "clef2"],
+    // Optionnel :  commentaire à supprimé
+    "remove_comments": ["commentaire 1", "commentaire 2"],
     // Optionnel : Liste des tags ajoutés à l'entité (uniquement si la classe hérite de TagInterface)
     "tags": {},
     // Optionnel : Liste des commentaires à ajouter (uniquement si la classe hérite de CommentInterface)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -403,9 +403,9 @@ La suppression des tags et des commentaires est faite avant l'ajout.
     "entity_id": "{uuid}",
     // Optionnel si non présent requête n'ai pas lancée ( => mise à jour des tags et commentaires uniquement), si l'entité hérite de FullEditInterface (mise à jour totale) => fusion des informations récupérées sur l'API (GET) et de celle fournies, sinon on envoie que celles fournies
     "body_parameters": { ... },
-    // Optionnel :  tags à supprimé
+    // Optionnel :  tags à supprimer
     "remove_tags": ["clef1", "clef2"],
-    // Optionnel :  commentaire à supprimé
+    // Optionnel :  commentaire à supprimer
     "remove_comments": ["commentaire 1", "commentaire 2"],
     // Optionnel : Liste des tags ajoutés à l'entité (uniquement si la classe hérite de TagInterface)
     "tags": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 test = [
     "black<23",
     "pylint==2.17",
-    "mypy==0.950",
+    "mypy==0.981",
     "requests_mock",
     "coverage",
 ]

--- a/sdk_entrepot_gpf/__init__.py
+++ b/sdk_entrepot_gpf/__init__.py
@@ -1,3 +1,3 @@
 """Python API to simplify the use of the GPF Warehouse HTTPS API."""
 
-__version__ = "0.1.28"
+__version__ = "0.1.29"

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -217,9 +217,9 @@ class Main:
         )
 
         # parseur pour les key
-        s_epilog_key = """Trois type de lancement:
-        * liste des clefs : `` (aucun paramètres)
-        * détail d'une clef : `--id ID`
+        s_epilog_key = """Trois types de lancement :
+        * liste les clefs : `` (aucun paramètres)
+        * affiche les détails d'une clef : `--id ID`
         * création de clefs : `--f FICHIER`\nExemple du contenu du fichier : `{"key": [{"name": "nom","type": "HASH","type_infos": {"hash": "mon_hash"}}]}`
         """
         o_sub_parser = o_sub_parsers.add_parser("key", help="Gestion des clefs de l'utilisateur", epilog=s_epilog_key, formatter_class=argparse.RawTextHelpFormatter)
@@ -360,7 +360,7 @@ class Main:
 
     @staticmethod
     def upload_from_descriptor_file(file: Union[Path, str], behavior: Optional[str] = None, datastore: Optional[str] = None, check_before_close: bool = False) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons décrites par le fichier indiqué
 
         Args:
             file (Union[Path, str]): chemin du fichier descripteur de livraison
@@ -370,9 +370,9 @@ class Main:
 
         Returns:
             Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
-                "check_fail": liste des livraisons dont les vérification ont échouée
+                "ok" : liste des livraisons sans problèmes
+                "upload_fail": dictionnaire {nom livraison : erreur remontée lors de la livraison}
+                "check_fail": liste des livraisons dont les vérifications ont échoué
         """
         o_dfu = UploadDescriptorFileReader(Path(file))
         s_behavior = str(behavior).upper() if behavior is not None else None
@@ -738,17 +738,16 @@ class Main:
 
     @staticmethod
     def upload_annexe_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons  d'annexe décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
-            datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
+            file (Union[Path, str]): chemin du fichier descripteur de livraison d'annexes
+            datastore (Optional[str]): datastore à utiliser, datastore par défaut si None
 
         Returns:
-            Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
-                "check_fail": liste des livraisons dont les vérification ont échouée
+            Dict[str, Any]: dictionnaire avec le résultat de la livraison des annexes :
+                "ok" : liste des annexes livrées sans problèmes
+                "upload_fail": dictionnaire {nom annexe : erreur remontée lors de la livraison de l'annexe}
         """
         o_dfu = DescriptorFileReader(Path(file), "annexe")
 
@@ -756,7 +755,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier archive" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES ARCHIVES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES ARCHIVES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -791,16 +790,16 @@ class Main:
 
     @staticmethod
     def upload_static_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons de fichier statique décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
+            file (Union[Path, str]): chemin du fichier descripteur de livraisons de fichier statique
             datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
 
         Returns:
             Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
+                "ok" : liste des livraisons sans problèmes
+                "upload_fail": dictionnaire {nom fichier statique : erreur remontée lors de la livraison du fichier statique}
         """
         o_dfu = DescriptorFileReader(Path(file), "static")
 
@@ -808,7 +807,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier statique" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES FICHIERS STATIQUES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES FICHIERS STATIQUES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -851,16 +850,16 @@ class Main:
 
     @staticmethod
     def upload_metadata_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons de métadonnée décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
-            datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
+            file (Union[Path, str]): chemin du fichier descripteur de livraisons de métadonnée
+            datastore (Optional[str]): datastore à utiliser, datastore par défaut si None
 
         Returns:
-            Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
+            Dict[str, Any]: dictionnaire avec le résultat des livraisons des fichiers de métadonnée :
+                "ok" : liste des livraisons de métadonnées réussies,
+                "upload_fail": dictionnaire {nom métadonnée : erreur remontée lors de la livraison de la métadonnée}
         """
         o_dfu = DescriptorFileReader(Path(file), "metadata")
 
@@ -868,7 +867,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier statique" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES FICHIERS MÉTADONNÉES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES FICHIERS DE MÉTADONNÉES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -897,24 +896,24 @@ class Main:
             # affichage
             self._display_bilan_creation(d_res)
         else:
-            Config().om.info("Liste des clef de l'utilisateur", green_colored=True)
+            Config().om.info("Liste des clefs de l'utilisateur courant...", green_colored=True)
             l_key = Key.api_list()
             if l_key:
-                Config().om.info(f"{len(l_key)} clef de l'utilisateur :\n" + "\n".join([f" * {o_key['name']} [{o_key['type']}] -- {o_key['_id']}" for o_key in l_key]))
+                Config().om.info(f"{len(l_key)} clef(s) de l'utilisateur courant :\n" + "\n".join([f" * {o_key['name']} [{o_key['type']}] -- {o_key['_id']}" for o_key in l_key]))
             else:
-                Config().om.info("Aucune clef")
+                Config().om.info("Aucune clef.")
 
     @staticmethod
     def create_key_from_file(file: Union[str, Path]) -> Dict[str, Any]:
-        """création des clefs décrite par le fichier
+        """création des clefs décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur des celf
+            file (Union[Path, str]): chemin du fichier descripteur des clefs
 
         Returns:
-            Dict[str, Any]: dictionnaire avec le résultat des creations :
-                "ok" : liste des creations sans problèmes,
-                "fail": dictionnaire nom creations : erreur remonté lors de la livraison
+            Dict[str, Any]: dictionnaire avec le résultat des créations de clefs :
+                "ok" : liste des clefs créées sans problèmes
+                "fail": dictionnaire {nom clef : erreur remontée lors de la création}
         """
 
         l_data = JsonHelper.load(Path(file), file_not_found_pattern="Fichier descripteur de création {json_path} non trouvé.")["key"]
@@ -923,7 +922,7 @@ class Main:
         d_fail: Dict[str, Exception] = {}
 
         # on fait toutes les livraisons
-        Config().om.info(f"CREATION DES CLEFS : ({len(l_data)})", green_colored=True)
+        Config().om.info(f"CRÉATION DES CLEFS : ({len(l_data)})", green_colored=True)
         for d_data in l_data:
             s_nom = d_data["name"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -933,10 +932,10 @@ class Main:
             except Exception as e:
                 d_fail[s_nom] = e
                 Config().om.debug(traceback.format_exc())
-                Config().om.error(f"livraison {s_nom} : {e}")
+                Config().om.error(f"clef {s_nom} : {e}")
 
         # vérification des livraisons
-        Config().om.info("Fin des livraisons.", green_colored=True)
+        Config().om.info("Fin de la création.", green_colored=True)
         return {"ok": l_keys, "fail": d_fail}
 
     @staticmethod

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -2,7 +2,6 @@
 
 import configparser
 import io
-import json
 import sys
 import argparse
 import traceback
@@ -45,7 +44,7 @@ from sdk_entrepot_gpf.workflow.resolver.UserResolver import UserResolver
 class Main:
     """Classe d'entrée pour utiliser la lib comme binaire."""
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # pylint: disable=too-many-branches
         """Constructeur."""
         # Résolution des paramètres utilisateurs
         self.o_args = Main.parse_args()
@@ -885,7 +884,8 @@ class Main:
         Config().om.info("Fin des livraisons.", green_colored=True)
         return {"ok": l_uploads, "upload_fail": d_upload_fail}
 
-    def key(self):
+    def key(self) -> None:
+        """Gestion des clefs"""
         if self.o_args.id is not None:
             Config().om.info(f"détail pour la clef {self.o_args.id}", green_colored=True)
             o_key = Key.api_get(self.o_args.id)
@@ -919,7 +919,7 @@ class Main:
 
         l_data = JsonHelper.load(Path(file), file_not_found_pattern="Fichier descripteur de création {json_path} non trouvé.")["key"]
 
-        l_keys: List[Metadata] = []
+        l_keys: List[Key] = []
         d_fail: Dict[str, Exception] = {}
 
         # on fait toutes les livraisons

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -385,7 +385,7 @@ class Main:
             s_nom = o_dataset.upload_infos["name"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
             try:
-                o_ua = UploadAction(o_dataset, mode_cartes=mode_cartes, behavior=s_behavior)
+                o_ua = UploadAction(o_dataset, compatibility_cartes=mode_cartes, behavior=s_behavior)
                 o_upload = o_ua.run(datastore, check_before_close=check_before_close)
                 l_uploads.append(o_upload)
             except Exception as e:

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -21,6 +21,7 @@ from sdk_entrepot_gpf.io.DescriptorFileReader import DescriptorFileReader
 from sdk_entrepot_gpf.io.Errors import ConflictError, NotFoundError
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
 from sdk_entrepot_gpf.store.Annexe import Annexe
+from sdk_entrepot_gpf.store.Key import Key
 from sdk_entrepot_gpf.store.Metadata import Metadata
 from sdk_entrepot_gpf.store.Static import Static
 from sdk_entrepot_gpf.workflow.Workflow import Workflow
@@ -43,7 +44,7 @@ from sdk_entrepot_gpf.workflow.resolver.UserResolver import UserResolver
 class Main:
     """Classe d'entrée pour utiliser la lib comme binaire."""
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # pylint: disable=too-many-branches
         """Constructeur."""
         # Résolution des paramètres utilisateurs
         self.o_args = Main.parse_args()
@@ -82,6 +83,8 @@ class Main:
             self.static()
         elif self.o_args.task == "metadata":
             self.metadata()
+        elif self.o_args.task == "key":
+            self.key()
 
     @staticmethod
     def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:  # pylint:disable=too-many-statements
@@ -212,6 +215,16 @@ class Main:
         o_sub_parser.add_argument(
             "--unpublish", type=str, action="extend", nargs="+", default=None, metavar=("NOM_FICHIER"), help="Dé-publie les métadonnées listées sur le point d'accès donné par --id-endpoint"
         )
+
+        # parseur pour les key
+        s_epilog_key = """Trois types de lancement :
+        * liste les clefs : `` (aucun paramètres)
+        * affiche les détails d'une clef : `--id ID`
+        * création de clefs : `--f FICHIER`\nExemple du contenu du fichier : `{"key": [{"name": "nom","type": "HASH","type_infos": {"hash": "mon_hash"}}]}`
+        """
+        o_sub_parser = o_sub_parsers.add_parser("key", help="Gestion des clefs de l'utilisateur", epilog=s_epilog_key, formatter_class=argparse.RawTextHelpFormatter)
+        o_sub_parser.add_argument("--id", type=str, default=None, help="Affiche la clef demandée")
+        o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier décrivant les clefs à créer")
 
         return o_parser.parse_args(args)
 
@@ -347,7 +360,7 @@ class Main:
 
     @staticmethod
     def upload_from_descriptor_file(file: Union[Path, str], behavior: Optional[str] = None, datastore: Optional[str] = None, check_before_close: bool = False) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons décrites par le fichier indiqué
 
         Args:
             file (Union[Path, str]): chemin du fichier descripteur de livraison
@@ -357,9 +370,9 @@ class Main:
 
         Returns:
             Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
-                "check_fail": liste des livraisons dont les vérification ont échouée
+                "ok" : liste des livraisons sans problèmes
+                "upload_fail": dictionnaire {nom livraison : erreur remontée lors de la livraison}
+                "check_fail": liste des livraisons dont les vérifications ont échoué
         """
         o_dfu = UploadDescriptorFileReader(Path(file))
         s_behavior = str(behavior).upper() if behavior is not None else None
@@ -725,17 +738,16 @@ class Main:
 
     @staticmethod
     def upload_annexe_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons  d'annexe décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
-            datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
+            file (Union[Path, str]): chemin du fichier descripteur de livraison d'annexes
+            datastore (Optional[str]): datastore à utiliser, datastore par défaut si None
 
         Returns:
-            Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
-                "check_fail": liste des livraisons dont les vérification ont échouée
+            Dict[str, Any]: dictionnaire avec le résultat de la livraison des annexes :
+                "ok" : liste des annexes livrées sans problèmes
+                "upload_fail": dictionnaire {nom annexe : erreur remontée lors de la livraison de l'annexe}
         """
         o_dfu = DescriptorFileReader(Path(file), "annexe")
 
@@ -743,7 +755,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier archive" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES ARCHIVES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES ARCHIVES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -778,16 +790,16 @@ class Main:
 
     @staticmethod
     def upload_static_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons de fichier statique décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
+            file (Union[Path, str]): chemin du fichier descripteur de livraisons de fichier statique
             datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
 
         Returns:
             Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
+                "ok" : liste des livraisons sans problèmes
+                "upload_fail": dictionnaire {nom fichier statique : erreur remontée lors de la livraison du fichier statique}
         """
         o_dfu = DescriptorFileReader(Path(file), "static")
 
@@ -795,7 +807,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier statique" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES FICHIERS STATIQUES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES FICHIERS STATIQUES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -838,16 +850,16 @@ class Main:
 
     @staticmethod
     def upload_metadata_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons de métadonnée décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
-            datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
+            file (Union[Path, str]): chemin du fichier descripteur de livraisons de métadonnée
+            datastore (Optional[str]): datastore à utiliser, datastore par défaut si None
 
         Returns:
-            Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
+            Dict[str, Any]: dictionnaire avec le résultat des livraisons des fichiers de métadonnée :
+                "ok" : liste des livraisons de métadonnées réussies,
+                "upload_fail": dictionnaire {nom métadonnée : erreur remontée lors de la livraison de la métadonnée}
         """
         o_dfu = DescriptorFileReader(Path(file), "metadata")
 
@@ -855,7 +867,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier statique" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES FICHIERS MÉTADONNÉES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES FICHIERS DE MÉTADONNÉES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -870,6 +882,76 @@ class Main:
         # vérification des livraisons
         Config().om.info("Fin des livraisons.", green_colored=True)
         return {"ok": l_uploads, "upload_fail": d_upload_fail}
+
+    def key(self) -> None:
+        """Gestion des clefs"""
+        if self.o_args.id is not None:
+            Config().om.info(f"détail pour la clef {self.o_args.id}", green_colored=True)
+            o_key = Key.api_get(self.o_args.id)
+            # affichage
+            Config().om.info(o_key.to_json(indent=3))
+        elif self.o_args.file is not None:
+            Config().om.info("Création de clefs ...", green_colored=True)
+            d_res = self.create_key_from_file(self.o_args.file)
+            # affichage
+            self._display_bilan_creation(d_res)
+        else:
+            Config().om.info("Liste des clefs de l'utilisateur courant...", green_colored=True)
+            l_key = Key.api_list()
+            if l_key:
+                Config().om.info(f"{len(l_key)} clef(s) de l'utilisateur courant :\n" + "\n".join([f" * {o_key['name']} [{o_key['type']}] -- {o_key['_id']}" for o_key in l_key]))
+            else:
+                Config().om.info("Aucune clef.")
+
+    @staticmethod
+    def create_key_from_file(file: Union[str, Path]) -> Dict[str, Any]:
+        """création des clefs décrites par le fichier indiqué
+
+        Args:
+            file (Union[Path, str]): chemin du fichier descripteur des clefs
+
+        Returns:
+            Dict[str, Any]: dictionnaire avec le résultat des créations de clefs :
+                "ok" : liste des clefs créées sans problèmes
+                "fail": dictionnaire {nom clef : erreur remontée lors de la création}
+        """
+
+        l_data = JsonHelper.load(Path(file), file_not_found_pattern="Fichier descripteur de création {json_path} non trouvé.")["key"]
+
+        l_keys: List[Key] = []
+        d_fail: Dict[str, Exception] = {}
+
+        # on fait toutes les livraisons
+        Config().om.info(f"CRÉATION DES CLEFS : ({len(l_data)})", green_colored=True)
+        for d_data in l_data:
+            s_nom = d_data["name"]
+            Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
+            try:
+                o_upload = Key.api_create(d_data)
+                l_keys.append(o_upload)
+            except Exception as e:
+                d_fail[s_nom] = e
+                Config().om.debug(traceback.format_exc())
+                Config().om.error(f"clef {s_nom} : {e}")
+
+        # vérification des livraisons
+        Config().om.info("Fin de la création.", green_colored=True)
+        return {"ok": l_keys, "fail": d_fail}
+
+    @staticmethod
+    def _display_bilan_creation(d_res: Dict[str, Any]) -> None:
+        """Affichage du bilan pour la création d'entité (key)
+
+        Args:
+            d_res (Dict[str, Any]): dictionnaire de résultat {'ok': liste des creation ok, 'fail': dictionnaire 'fichier': erreur}
+        """
+        if d_res["fail"]:
+            Config().om.info("RÉCAPITULATIF DES PROBLÈMES :", green_colored=True)
+            Config().om.error(f"{len(d_res['fail'])} création échouées :\n" + "\n".join([f" * {s_nom} : {e_error}" for s_nom, e_error in d_res["fail"].items()]))
+            Config().om.error(f"BILAN : {len(d_res['ok'])} creation effectués sans erreur, {len(d_res['fail'])} creation échouées")
+            sys.exit(1)
+        else:
+            Config().om.info(f"BILAN : les {len(d_res['ok'])} créations se sont bien passées", green_colored=True)
 
 
 if __name__ == "__main__":

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -1,7 +1,5 @@
 """SDK Python pour simplifier l'utilisation de l'API Entrepôt Géoplateforme."""
 
-import configparser
-import io
 import sys
 import argparse
 import traceback
@@ -9,7 +7,7 @@ from pathlib import Path
 import shutil
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 import requests
-
+import toml
 
 import sdk_entrepot_gpf
 from sdk_entrepot_gpf.Errors import GpfSdkError
@@ -21,6 +19,7 @@ from sdk_entrepot_gpf.io.DescriptorFileReader import DescriptorFileReader
 from sdk_entrepot_gpf.io.Errors import ConflictError, NotFoundError
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
 from sdk_entrepot_gpf.store.Annexe import Annexe
+from sdk_entrepot_gpf.store.Key import Key
 from sdk_entrepot_gpf.store.Metadata import Metadata
 from sdk_entrepot_gpf.store.Static import Static
 from sdk_entrepot_gpf.workflow.Workflow import Workflow
@@ -43,7 +42,7 @@ from sdk_entrepot_gpf.workflow.resolver.UserResolver import UserResolver
 class Main:
     """Classe d'entrée pour utiliser la lib comme binaire."""
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # pylint: disable=too-many-branches
         """Constructeur."""
         # Résolution des paramètres utilisateurs
         self.o_args = Main.parse_args()
@@ -82,6 +81,8 @@ class Main:
             self.static()
         elif self.o_args.task == "metadata":
             self.metadata()
+        elif self.o_args.task == "key":
+            self.key()
 
     @staticmethod
     def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:  # pylint:disable=too-many-statements
@@ -214,6 +215,16 @@ class Main:
             "--unpublish", type=str, action="extend", nargs="+", default=None, metavar=("NOM_FICHIER"), help="Dé-publie les métadonnées listées sur le point d'accès donné par --id-endpoint"
         )
 
+        # parseur pour les key
+        s_epilog_key = """Trois types de lancement :
+        * liste les clefs : `` (aucun paramètres)
+        * affiche les détails d'une clef : `--id ID`
+        * création de clefs : `--f FICHIER`\nExemple du contenu du fichier : `{"key": [{"name": "nom","type": "HASH","type_infos": {"hash": "mon_hash"}}]}`
+        """
+        o_sub_parser = o_sub_parsers.add_parser("key", help="Gestion des clefs de l'utilisateur", epilog=s_epilog_key, formatter_class=argparse.RawTextHelpFormatter)
+        o_sub_parser.add_argument("--id", type=str, default=None, help="Affiche la clef demandée")
+        o_sub_parser.add_argument("--file", "-f", type=str, default=None, help="Chemin vers le fichier décrivant les clefs à créer")
+
         return o_parser.parse_args(args)
 
     def __datastore(self) -> Optional[str]:
@@ -283,48 +294,34 @@ class Main:
             * si un fichier est précisé on y enregistre toute la config
             * sinon on affiche toute la config
         """
-        o_parser = Config().get_parser()
+        d_config = Config().get_config()
 
         # Juste une section ou toute la config ?
         if self.o_args.section is not None:
             # Juste une section
+            d_section = d_config.get(self.o_args.section)
+            if d_section is None:
+                raise GpfSdkError(f"La section '{self.o_args.section}' n'existe pas dans la configuration.")
             if self.o_args.option is not None:
                 # On nous demande une section.option
-                try:
-                    print(o_parser.get(self.o_args.section, self.o_args.option))
-                except configparser.NoSectionError as e_no_section_error:
-                    raise GpfSdkError(f"La section '{self.o_args.section}' n'existe pas dans la configuration.") from e_no_section_error
-                except configparser.NoOptionError as e_no_option_error:
-                    raise GpfSdkError(f"L'option '{self.o_args.option}' n'existe pas dans la section '{self.o_args.section}'.") from e_no_option_error
+                if not str(self.o_args.option) in d_section:
+                    raise GpfSdkError(f"L'option '{self.o_args.option}' n'existe pas dans la section '{self.o_args.section}'.")
+                print(Config().get(self.o_args.section, self.o_args.option))
             else:
                 # On nous demande toute une section
-                try:
-                    # On crée un nouveau parser
-                    o_parser2 = configparser.ConfigParser()
-                    # On y met la section demandée
-                    o_parser2[self.o_args.section] = o_parser[self.o_args.section]
-                    # On affiche tout ça
-                    with io.StringIO() as o_string_io:
-                        o_parser2.write(o_string_io)
-                        o_string_io.seek(0)
-                        print(o_string_io.read()[:-1])
-                except KeyError as e_key_error:
-                    raise GpfSdkError(f"La section '{self.o_args.section}' n'existe pas dans la configuration.") from e_key_error
+                print(toml.dumps({self.o_args.section: d_section}))
         else:
             # On nous demande toute la config
             if self.o_args.file is not None:
                 # On sauvegarde la donnée
                 try:
-                    with open(self.o_args.file, mode="w", encoding="UTF-8") as f_ini:
-                        o_parser.write(f_ini)
+                    with open(self.o_args.file, mode="w", encoding="UTF-8") as f_config:
+                        toml.dump(d_config, f_config)
                 except PermissionError as e_permission_error:
                     raise GpfSdkError(f"Impossible d'écrire le fichier {self.o_args.file} : non autorisé") from e_permission_error
             else:
                 # Sinon on l'affiche
-                with io.StringIO() as o_string_io:
-                    o_parser.write(o_string_io)
-                    o_string_io.seek(0)
-                    print(o_string_io.read()[:-1])
+                print(toml.dumps(d_config))
 
     @staticmethod
     def __monitoring_upload(upload: Upload, message_ok: str, message_ko: str, callback: Optional[Callable[[str], None]] = None, ctrl_c_action: Optional[Callable[[], bool]] = None) -> bool:
@@ -348,7 +345,7 @@ class Main:
 
     @staticmethod
     def upload_from_descriptor_file(file: Union[Path, str], behavior: Optional[str] = None, datastore: Optional[str] = None, check_before_close: bool = False) -> Dict[str, Any]:
-        """réalisation des livraisons décrites par le fichier
+        """réalisation des livraisons décrites par le fichier indiqué
 
         Args:
             file (Union[Path, str]): chemin du fichier descripteur de livraison
@@ -358,9 +355,9 @@ class Main:
 
         Returns:
             Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
-                "check_fail": liste des livraisons dont les vérification ont échouée
+                "ok" : liste des livraisons sans problèmes
+                "upload_fail": dictionnaire {nom livraison : erreur remontée lors de la livraison}
+                "check_fail": liste des livraisons dont les vérifications ont échoué
         """
         o_dfu = UploadDescriptorFileReader(Path(file))
         s_behavior = str(behavior).upper() if behavior is not None else None
@@ -375,7 +372,7 @@ class Main:
             s_nom = o_dataset.upload_infos["name"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
             try:
-                o_ua = UploadAction(o_dataset, cartabilite = False, behavior=s_behavior)
+                o_ua = UploadAction(o_dataset, cartabilite=False, behavior=s_behavior)
                 o_upload = o_ua.run(datastore, check_before_close=check_before_close)
                 l_uploads.append(o_upload)
             except Exception as e:
@@ -726,17 +723,16 @@ class Main:
 
     @staticmethod
     def upload_annexe_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons  d'annexe décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
-            datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
+            file (Union[Path, str]): chemin du fichier descripteur de livraison d'annexes
+            datastore (Optional[str]): datastore à utiliser, datastore par défaut si None
 
         Returns:
-            Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
-                "check_fail": liste des livraisons dont les vérification ont échouée
+            Dict[str, Any]: dictionnaire avec le résultat de la livraison des annexes :
+                "ok" : liste des annexes livrées sans problèmes
+                "upload_fail": dictionnaire {nom annexe : erreur remontée lors de la livraison de l'annexe}
         """
         o_dfu = DescriptorFileReader(Path(file), "annexe")
 
@@ -744,7 +740,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier archive" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES ARCHIVES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES ARCHIVES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -779,16 +775,16 @@ class Main:
 
     @staticmethod
     def upload_static_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons de fichier statique décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
+            file (Union[Path, str]): chemin du fichier descripteur de livraisons de fichier statique
             datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
 
         Returns:
             Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
+                "ok" : liste des livraisons sans problèmes
+                "upload_fail": dictionnaire {nom fichier statique : erreur remontée lors de la livraison du fichier statique}
         """
         o_dfu = DescriptorFileReader(Path(file), "static")
 
@@ -796,7 +792,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier statique" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES FICHIERS STATIQUES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES FICHIERS STATIQUES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -839,16 +835,16 @@ class Main:
 
     @staticmethod
     def upload_metadata_from_descriptor_file(file: Union[Path, str], datastore: Optional[str] = None) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons de métadonnée décrites par le fichier indiqué
 
         Args:
-            file (Union[Path, str]): chemin du fichier descripteur de livraison
-            datastore (Optional[str]): datastore à utilisé, datastore par défaut si None
+            file (Union[Path, str]): chemin du fichier descripteur de livraisons de métadonnée
+            datastore (Optional[str]): datastore à utiliser, datastore par défaut si None
 
         Returns:
-            Dict[str, Any]: dictionnaire avec le résultat des livraisons :
-                "ok" : liste des livraisons sans problèmes,
-                "upload_fail": dictionnaire nom livraison : erreur remonté lors de la livraison
+            Dict[str, Any]: dictionnaire avec le résultat des livraisons des fichiers de métadonnée :
+                "ok" : liste des livraisons de métadonnées réussies,
+                "upload_fail": dictionnaire {nom métadonnée : erreur remontée lors de la livraison de la métadonnée}
         """
         o_dfu = DescriptorFileReader(Path(file), "metadata")
 
@@ -856,7 +852,7 @@ class Main:
         d_upload_fail: Dict[str, Exception] = {}  # dictionnaire "fichier statique" : erreur des uploads qui ont fail
 
         # on fait toutes les livraisons
-        Config().om.info(f"LIVRAISONS DES FICHIERS MÉTADONNÉES : ({len(o_dfu.data)})", green_colored=True)
+        Config().om.info(f"LIVRAISON DES FICHIERS DE MÉTADONNÉES : ({len(o_dfu.data)})", green_colored=True)
         for d_data in o_dfu.data:
             s_nom = d_data["file"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
@@ -871,6 +867,76 @@ class Main:
         # vérification des livraisons
         Config().om.info("Fin des livraisons.", green_colored=True)
         return {"ok": l_uploads, "upload_fail": d_upload_fail}
+
+    def key(self) -> None:
+        """Gestion des clefs"""
+        if self.o_args.id is not None:
+            Config().om.info(f"détail pour la clef {self.o_args.id}", green_colored=True)
+            o_key = Key.api_get(self.o_args.id)
+            # affichage
+            Config().om.info(o_key.to_json(indent=3))
+        elif self.o_args.file is not None:
+            Config().om.info("Création de clefs ...", green_colored=True)
+            d_res = self.create_key_from_file(self.o_args.file)
+            # affichage
+            self._display_bilan_creation(d_res)
+        else:
+            Config().om.info("Liste des clefs de l'utilisateur courant...", green_colored=True)
+            l_key = Key.api_list()
+            if l_key:
+                Config().om.info(f"{len(l_key)} clef(s) de l'utilisateur courant :\n" + "\n".join([f" * {o_key['name']} [{o_key['type']}] -- {o_key['_id']}" for o_key in l_key]))
+            else:
+                Config().om.info("Aucune clef.")
+
+    @staticmethod
+    def create_key_from_file(file: Union[str, Path]) -> Dict[str, Any]:
+        """création des clefs décrites par le fichier indiqué
+
+        Args:
+            file (Union[Path, str]): chemin du fichier descripteur des clefs
+
+        Returns:
+            Dict[str, Any]: dictionnaire avec le résultat des créations de clefs :
+                "ok" : liste des clefs créées sans problèmes
+                "fail": dictionnaire {nom clef : erreur remontée lors de la création}
+        """
+
+        l_data = JsonHelper.load(Path(file), file_not_found_pattern="Fichier descripteur de création {json_path} non trouvé.")["key"]
+
+        l_keys: List[Key] = []
+        d_fail: Dict[str, Exception] = {}
+
+        # on fait toutes les livraisons
+        Config().om.info(f"CRÉATION DES CLEFS : ({len(l_data)})", green_colored=True)
+        for d_data in l_data:
+            s_nom = d_data["name"]
+            Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
+            try:
+                o_upload = Key.api_create(d_data)
+                l_keys.append(o_upload)
+            except Exception as e:
+                d_fail[s_nom] = e
+                Config().om.debug(traceback.format_exc())
+                Config().om.error(f"clef {s_nom} : {e}")
+
+        # vérification des livraisons
+        Config().om.info("Fin de la création.", green_colored=True)
+        return {"ok": l_keys, "fail": d_fail}
+
+    @staticmethod
+    def _display_bilan_creation(d_res: Dict[str, Any]) -> None:
+        """Affichage du bilan pour la création d'entité (key)
+
+        Args:
+            d_res (Dict[str, Any]): dictionnaire de résultat {'ok': liste des creation ok, 'fail': dictionnaire 'fichier': erreur}
+        """
+        if d_res["fail"]:
+            Config().om.info("RÉCAPITULATIF DES PROBLÈMES :", green_colored=True)
+            Config().om.error(f"{len(d_res['fail'])} création échouées :\n" + "\n".join([f" * {s_nom} : {e_error}" for s_nom, e_error in d_res["fail"].items()]))
+            Config().om.error(f"BILAN : {len(d_res['ok'])} creation effectués sans erreur, {len(d_res['fail'])} creation échouées")
+            sys.exit(1)
+        else:
+            Config().om.info(f"BILAN : les {len(d_res['ok'])} créations se sont bien passées", green_colored=True)
 
 
 if __name__ == "__main__":

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -1,7 +1,5 @@
 """SDK Python pour simplifier l'utilisation de l'API Entrepôt Géoplateforme."""
 
-import configparser
-import io
 import sys
 import argparse
 import traceback
@@ -9,7 +7,7 @@ from pathlib import Path
 import shutil
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 import requests
-
+import toml
 
 import sdk_entrepot_gpf
 from sdk_entrepot_gpf.Errors import GpfSdkError
@@ -295,48 +293,34 @@ class Main:
             * si un fichier est précisé on y enregistre toute la config
             * sinon on affiche toute la config
         """
-        o_parser = Config().get_parser()
+        d_config = Config().get_config()
 
         # Juste une section ou toute la config ?
         if self.o_args.section is not None:
             # Juste une section
+            d_section = d_config.get(self.o_args.section)
+            if d_section is None:
+                raise GpfSdkError(f"La section '{self.o_args.section}' n'existe pas dans la configuration.")
             if self.o_args.option is not None:
                 # On nous demande une section.option
-                try:
-                    print(o_parser.get(self.o_args.section, self.o_args.option))
-                except configparser.NoSectionError as e_no_section_error:
-                    raise GpfSdkError(f"La section '{self.o_args.section}' n'existe pas dans la configuration.") from e_no_section_error
-                except configparser.NoOptionError as e_no_option_error:
-                    raise GpfSdkError(f"L'option '{self.o_args.option}' n'existe pas dans la section '{self.o_args.section}'.") from e_no_option_error
+                if not str(self.o_args.option) in d_section:
+                    raise GpfSdkError(f"L'option '{self.o_args.option}' n'existe pas dans la section '{self.o_args.section}'.")
+                print(Config().get(self.o_args.section, self.o_args.option))
             else:
                 # On nous demande toute une section
-                try:
-                    # On crée un nouveau parser
-                    o_parser2 = configparser.ConfigParser()
-                    # On y met la section demandée
-                    o_parser2[self.o_args.section] = o_parser[self.o_args.section]
-                    # On affiche tout ça
-                    with io.StringIO() as o_string_io:
-                        o_parser2.write(o_string_io)
-                        o_string_io.seek(0)
-                        print(o_string_io.read()[:-1])
-                except KeyError as e_key_error:
-                    raise GpfSdkError(f"La section '{self.o_args.section}' n'existe pas dans la configuration.") from e_key_error
+                print(toml.dumps({self.o_args.section: d_section}))
         else:
             # On nous demande toute la config
             if self.o_args.file is not None:
                 # On sauvegarde la donnée
                 try:
-                    with open(self.o_args.file, mode="w", encoding="UTF-8") as f_ini:
-                        o_parser.write(f_ini)
+                    with open(self.o_args.file, mode="w", encoding="UTF-8") as f_config:
+                        toml.dump(d_config, f_config)
                 except PermissionError as e_permission_error:
                     raise GpfSdkError(f"Impossible d'écrire le fichier {self.o_args.file} : non autorisé") from e_permission_error
             else:
                 # Sinon on l'affiche
-                with io.StringIO() as o_string_io:
-                    o_parser.write(o_string_io)
-                    o_string_io.seek(0)
-                    print(o_string_io.read()[:-1])
+                print(toml.dumps(d_config))
 
     @staticmethod
     def __monitoring_upload(upload: Upload, message_ok: str, message_ko: str, callback: Optional[Callable[[str], None]] = None, ctrl_c_action: Optional[Callable[[], bool]] = None) -> bool:

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -99,6 +99,7 @@ class Main:
         o_parser.add_argument("--version", action="version", version=f"%(prog)s v{sdk_entrepot_gpf.__version__}")
         o_parser.add_argument("--debug", dest="debug", required=False, default=False, action="store_true", help="Passe l'appli en mode debug (plus de messages affichés)")
         o_parser.add_argument("--datastore", "-d", dest="datastore", required=False, default=None, help="Identifiant du datastore à utiliser")
+        o_parser.add_argument("--compatibility-cartes", dest="compatibility_cartes", required=False, default=False, help="active la compatibilité des traitements du SDK avec ceux de cartes.gouv.fr")
         o_sub_parsers = o_parser.add_subparsers(dest="task", metavar="TASK", required=True, help="Tâche à effectuer")
 
         # Parser pour auth
@@ -347,7 +348,7 @@ class Main:
 
     @staticmethod
     def upload_from_descriptor_file(file: Union[Path, str], behavior: Optional[str] = None, datastore: Optional[str] = None, check_before_close: bool = False) -> Dict[str, Any]:
-        """réalisation des livraison décrite par le fichier
+        """réalisation des livraisons décrites par le fichier
 
         Args:
             file (Union[Path, str]): chemin du fichier descripteur de livraison
@@ -374,7 +375,7 @@ class Main:
             s_nom = o_dataset.upload_infos["name"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
             try:
-                o_ua = UploadAction(o_dataset, behavior=s_behavior)
+                o_ua = UploadAction(o_dataset, cartabilite = False, behavior=s_behavior)
                 o_upload = o_ua.run(datastore, check_before_close=check_before_close)
                 l_uploads.append(o_upload)
             except Exception as e:

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -476,7 +476,7 @@ class Main:
         Sinon on liste les Livraisons avec éventuellement des filtres.
         """
         if self.o_args.file is not None:
-            # on livre les données selon le fichier descripteur donné TODO : ajouter le compatibility dans les args :
+            # on livre les données selon le fichier descripteur donné
             d_res = self.upload_from_descriptor_file(self.o_args.file, self.o_args.behavior, self.o_args.datastore, self.o_args.check_before_close, self.o_args.mode_cartes)
             # Affichage du bilan
             Config().om.info("-" * 100)

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -295,7 +295,7 @@ class Main:
             * si un fichier est précisé on y enregistre toute la config
             * sinon on affiche toute la config
         """
-        o_parser = Config().get_parser()
+        o_parser = Config().get_config()
 
         # Juste une section ou toute la config ?
         if self.o_args.section is not None:

--- a/sdk_entrepot_gpf/__main__.py
+++ b/sdk_entrepot_gpf/__main__.py
@@ -100,7 +100,7 @@ class Main:
         o_parser.add_argument("--version", action="version", version=f"%(prog)s v{sdk_entrepot_gpf.__version__}")
         o_parser.add_argument("--debug", dest="debug", required=False, default=False, action="store_true", help="Passe l'appli en mode debug (plus de messages affichés)")
         o_parser.add_argument("--datastore", "-d", dest="datastore", required=False, default=None, help="Identifiant du datastore à utiliser")
-        o_parser.add_argument("--compatibility-cartes", dest="compatibility_cartes", required=False, default=False, help="active la compatibilité des traitements du SDK avec ceux de cartes.gouv.fr")
+        o_parser.add_argument("--mode-cartes", dest="mode_cartes", required=False, default=None, help="active la compatibilité des traitements du SDK avec ceux de cartes.gouv.fr")
         o_sub_parsers = o_parser.add_subparsers(dest="task", metavar="TASK", required=True, help="Tâche à effectuer")
 
         # Parser pour auth
@@ -344,7 +344,9 @@ class Main:
         return b_res
 
     @staticmethod
-    def upload_from_descriptor_file(file: Union[Path, str], behavior: Optional[str] = None, datastore: Optional[str] = None, check_before_close: bool = False) -> Dict[str, Any]:
+    def upload_from_descriptor_file(
+        file: Union[Path, str], behavior: Optional[str] = None, datastore: Optional[str] = None, check_before_close: bool = False, mode_cartes: Optional[bool] = None
+    ) -> Dict[str, Any]:
         """réalisation des livraisons décrites par le fichier indiqué
 
         Args:
@@ -372,7 +374,7 @@ class Main:
             s_nom = o_dataset.upload_infos["name"]
             Config().om.info(f"{Color.BLUE} * {s_nom}{Color.END}")
             try:
-                o_ua = UploadAction(o_dataset, cartabilite=False, behavior=s_behavior)
+                o_ua = UploadAction(o_dataset, mode_cartes=mode_cartes, behavior=s_behavior)
                 o_upload = o_ua.run(datastore, check_before_close=check_before_close)
                 l_uploads.append(o_upload)
             except Exception as e:
@@ -456,8 +458,8 @@ class Main:
         Sinon on liste les Livraisons avec éventuellement des filtres.
         """
         if self.o_args.file is not None:
-            # on livre les données selon le fichier descripteur donné
-            d_res = self.upload_from_descriptor_file(self.o_args.file, self.o_args.behavior, self.o_args.datastore, self.o_args.check_before_close)
+            # on livre les données selon le fichier descripteur donné TODO : ajouter le compatibility dans les args :
+            d_res = self.upload_from_descriptor_file(self.o_args.file, self.o_args.behavior, self.o_args.datastore, self.o_args.check_before_close, self.o_args.mode_cartes)
             # Affichage du bilan
             Config().om.info("-" * 100)
             if d_res["upload_fail"] or d_res["check_fail"]:

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -18,7 +18,8 @@ totp_key=
 # En cas d'échec lors de l'authentification : max nb_attempts tentatives, sec_between_attempt secondes entre chacune d'entre elles
 nb_attempts=5
 sec_between_attempt=1
-
+# url pour vérifier le bon fonctionnement de la GPF
+check_status_url=https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9
 
 [store_api]
 ############################### Paramètres de l'API Entrepôt ###############################
@@ -35,6 +36,8 @@ nb_limit=10
 # Regex de parsing du Content-Range des réponses
 regex_content_range=(?P<i_min>[0-9]+)-(?P<i_max>[0-9]+)/(?P<len>[0-9]+)
 regex_entity_id=(?P<id>[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})
+# url pour vérifier le bon fonctionnement de la GPF
+check_status_url=https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9
 
 
 [routing]

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -291,3 +291,20 @@ workflow_config=json_schemas/workflow.json
 annexe_descriptor_file=json_schemas/annexe_descriptor_file.json
 static_descriptor_file=json_schemas/static_descriptor_file.json
 metadata_descriptor_file=json_schemas/metadata_descriptor_file.json
+
+
+[compatibility_cartes]
+activate=False
+upload_creation_integration_progress={"send_files_api": "waiting", "wait_checks": "waiting","integration_processing": "waiting"}
+upload_creation_integration_current_step=0
+upload_upload_start_integration_progress={"send_files_api": "in_progress", "wait_checks": "waiting","integration_processing": "waiting"}
+upload_upload_end_integration_progress={"send_files_api": "successful", "wait_checks": "in_progress","integration_processing": "waiting"}
+upload_upload_end_integration_current_step=1
+upload_check_ok_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "waiting"}
+upload_check_ko_integration_progress={"send_files_api": "successful", "wait_checks": "failed","integration_processing": "waiting"}
+execution_start_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}
+execution_start_integration_current_step=2
+execution_end_ok_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "successful"}
+execution_end_ko_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "failed"}
+id_mise_en_base=0de8c60b-9938-4be9-aa36-9026b77c3c96
+id_pyramide_vecteur=aa5f9391-0bdb-4b97-9209-fcde351b82f6

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -288,3 +288,18 @@ workflow_config=json_schemas/workflow.json
 annexe_descriptor_file=json_schemas/annexe_descriptor_file.json
 static_descriptor_file=json_schemas/static_descriptor_file.json
 metadata_descriptor_file=json_schemas/metadata_descriptor_file.json
+
+
+[compatibility_cartes]
+activate=false
+upload_creation_integration_progress={"send_files_api": "waiting", "wait_checks": "waiting","integration_processing": "waiting"}
+upload_creation_integration_current_step=0
+upload_upload_start_integration_progress={"send_files_api": "in_progress", "wait_checks": "waiting","integration_processing": "waiting"}
+upload_upload_end_integration_progress={"send_files_api": "successful", "wait_checks": "in_progress","integration_processing": "waiting"}
+upload_upload_end_integration_current_step=1
+upload_check_ok_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "waiting"}
+upload_check_ko_integration_progress={"send_files_api": "successful", "wait_checks": "failed","integration_processing": "waiting"}
+execution_start_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}
+execution_start_integration_current_step=2
+execution_end_ok_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "successful"}
+execution_end_ko_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "failed"}

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -303,3 +303,5 @@ execution_start_integration_progress={"send_files_api": "successful", "wait_chec
 execution_start_integration_current_step=2
 execution_end_ok_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "successful"}
 execution_end_ko_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "failed"}
+id_mise_en_base=0de8c60b-9938-4be9-aa36-9026b77c3c96
+id_pyramide_vecteur=aa5f9391-0bdb-4b97-9209-fcde351b82f6

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -294,7 +294,7 @@ metadata_descriptor_file=json_schemas/metadata_descriptor_file.json
 
 
 [compatibility_cartes]
-activate=false
+activate=False
 upload_creation_integration_progress={"send_files_api": "waiting", "wait_checks": "waiting","integration_processing": "waiting"}
 upload_creation_integration_current_step=0
 upload_upload_start_integration_progress={"send_files_api": "in_progress", "wait_checks": "waiting","integration_processing": "waiting"}

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -18,7 +18,8 @@ totp_key=
 # En cas d'échec lors de l'authentification : max nb_attempts tentatives, sec_between_attempt secondes entre chacune d'entre elles
 nb_attempts=5
 sec_between_attempt=1
-
+# url pour vérifier le bon fonctionnement de la GPF
+check_status_url=https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9
 
 [store_api]
 ############################### Paramètres de l'API Entrepôt ###############################
@@ -35,6 +36,8 @@ nb_limit=10
 # Regex de parsing du Content-Range des réponses
 regex_content_range=(?P<i_min>[0-9]+)-(?P<i_max>[0-9]+)/(?P<len>[0-9]+)
 regex_entity_id=(?P<id>[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})
+# url pour vérifier le bon fonctionnement de la GPF
+check_status_url=https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9
 
 
 [routing]
@@ -288,3 +291,20 @@ workflow_config=json_schemas/workflow.json
 annexe_descriptor_file=json_schemas/annexe_descriptor_file.json
 static_descriptor_file=json_schemas/static_descriptor_file.json
 metadata_descriptor_file=json_schemas/metadata_descriptor_file.json
+
+
+[compatibility_cartes]
+activate=False
+upload_creation_integration_progress={"send_files_api": "waiting", "wait_checks": "waiting","integration_processing": "waiting"}
+upload_creation_integration_current_step=0
+upload_upload_start_integration_progress={"send_files_api": "in_progress", "wait_checks": "waiting","integration_processing": "waiting"}
+upload_upload_end_integration_progress={"send_files_api": "successful", "wait_checks": "in_progress","integration_processing": "waiting"}
+upload_upload_end_integration_current_step=1
+upload_check_ok_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "waiting"}
+upload_check_ko_integration_progress={"send_files_api": "successful", "wait_checks": "failed","integration_processing": "waiting"}
+execution_start_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}
+execution_start_integration_current_step=2
+execution_end_ok_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "successful"}
+execution_end_ko_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "failed"}
+id_mise_en_base=0de8c60b-9938-4be9-aa36-9026b77c3c96
+id_pyramide_vecteur=aa5f9391-0bdb-4b97-9209-fcde351b82f6

--- a/sdk_entrepot_gpf/_conf/default.ini
+++ b/sdk_entrepot_gpf/_conf/default.ini
@@ -306,3 +306,5 @@ execution_start_integration_progress={"send_files_api": "successful", "wait_chec
 execution_start_integration_current_step=2
 execution_end_ok_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "successful"}
 execution_end_ko_integration_progress={"send_files_api": "successful", "wait_checks": "successful","integration_processing": "failed"}
+id_mise_en_base=0de8c60b-9938-4be9-aa36-9026b77c3c96
+id_pyramide_vecteur=aa5f9391-0bdb-4b97-9209-fcde351b82f6

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -57,8 +57,20 @@
                                                 "type": "string"
                                             }
                                         },
+                                        "remove_comments": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
                                         "tags": {
                                             "type": "object"
+                                        },
+                                        "remove_tags": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
                                         },
                                         "datastore": {
                                             "type": "string"

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -3,9 +3,6 @@
     "title": "Schéma JSON pour un fichier workflow",
     "description": "",
     "type": "object",
-    "workflow": [
-        "workflow"
-    ],
     "properties": {
         "workflow": {
             "type": "object",
@@ -156,6 +153,9 @@
         },
         "tags": {
             "type": "object"
+        },
+        "compatibility_cartes":{
+            "type": "boolean"
         }
     },
     "required": [ "workflow" ],

--- a/sdk_entrepot_gpf/auth/Authentifier.py
+++ b/sdk_entrepot_gpf/auth/Authentifier.py
@@ -61,7 +61,7 @@ class Authentifier(metaclass=Singleton):
             d_params["username"] = Config().get_str("store_authentification", "login")
             d_params["password"] = Config().get_str("store_authentification", "password")
             d_params["client_id"] = Config().get_str("store_authentification", "client_id")
-            s_client_secret = Config().get_str("store_authentification", "client_secret")
+            s_client_secret = Config().get("store_authentification", "client_secret")
             if s_client_secret is not None:
                 d_params["client_secret"] = s_client_secret
         elif s_grant_type == "client_credentials":

--- a/sdk_entrepot_gpf/auth/Authentifier.py
+++ b/sdk_entrepot_gpf/auth/Authentifier.py
@@ -61,7 +61,7 @@ class Authentifier(metaclass=Singleton):
             d_params["username"] = Config().get_str("store_authentification", "login")
             d_params["password"] = Config().get_str("store_authentification", "password")
             d_params["client_id"] = Config().get_str("store_authentification", "client_id")
-            s_client_secret = Config().get_str("store_authentification", "client_secret")
+            s_client_secret = Config().get("store_authentification", "client_secret")
             if s_client_secret is not None:
                 d_params["client_secret"] = s_client_secret
         elif s_grant_type == "client_credentials":
@@ -105,23 +105,26 @@ class Authentifier(metaclass=Singleton):
                 # On tente de récupérer le message
                 try:
                     s_message = o_response.json()["error_description"]
-                    if "Account is not fully set up" in s_message:
-                        raise AuthentificationError(
-                            "Problème lors de l'authentification, veuillez vous connecter via l'interface en ligne KeyCloak pour vérifier son compte."
-                            + f" Votre mot de passe est sûrement expiré. ({s_message})"
-                        )
                 except Exception:
                     s_message = "pas de raison indiquée"
+                if "Account is not fully set up" in s_message:
+                    raise AuthentificationError(
+                        "Problème lors de l'authentification, veuillez vous connecter via l'interface en ligne KeyCloak pour vérifier son compte."
+                        + f" Votre mot de passe est sûrement expiré. ({s_message})"
+                    )
                 raise requests.exceptions.HTTPError(f"Code retour authentification KeyCloak = {o_response.status_code} ({s_message})", response=o_response, request=o_response.request)
         except AuthentificationError as e_auth:
-            Config().om.error(e_auth.message)
-            # Affiche la pile d'exécution
-            Config().om.debug(traceback.format_exc())
             # On propage l'erreur
             raise e_auth
         except Exception as e_error:
             if isinstance(e_error, requests.exceptions.HTTPError):
                 Config().om.warning(e_error.args[0])
+            elif isinstance(e_error, requests.exceptions.ConnectionError):
+                Config().om.warning(
+                    f"Le serveur d'authentification ({self.__token_url}) n'est pas joignable. Cela peut être dû à un problème de configuration si elle a changée récemment."
+                    + " Sinon, c'est un problème sur le service d’authentification : consultez l'état du service pour en savoir plus "
+                    + f": {Config().get_str('store_authentification', 'check_status_url')}."
+                )
             else:
                 Config().om.warning("La récupération du jeton d'authentification a échoué...")
             # Une erreur s'est produite : attend un peu et relance une nouvelle fois la fonction
@@ -150,6 +153,12 @@ class Authentifier(metaclass=Singleton):
             while (self.__last_token is None) or (self.__last_token.is_valid() is False):
                 self.__request_new_token(self.__nb_attempts)
             return self.__last_token.get_access_string()
+        except AuthentificationError as e_auth:
+            # erreur déjà traité
+            Config().om.error(e_auth.message)
+            # Affiche la pile d'exécution
+            Config().om.debug(traceback.format_exc())
+            raise e_auth
         except Exception as e_error:
             s_error_message = f"La récupération du jeton d'authentification a échoué après {self.__nb_attempts} tentatives"
             Config().om.error(s_error_message)

--- a/sdk_entrepot_gpf/helper/JsonHelper.py
+++ b/sdk_entrepot_gpf/helper/JsonHelper.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 import jsonschema
 from jsonc_parser.parser import JsoncParser  # type: ignore
 from jsonc_parser.errors import ParserError  # type: ignore
@@ -117,7 +117,7 @@ class JsonHelper:
         JsonHelper.validate_object(o_json_data, o_schema_data, s_message_json, s_message_schema)
 
     @staticmethod
-    def validate_object(json_data: object, schema_data: object, json_not_valid_message: str, schema_not_valid_message: str) -> None:
+    def validate_object(json_data: object, schema_data: Dict[str, Any], json_not_valid_message: str, schema_not_valid_message: str) -> None:
         """Fonction de validation d'un fichier json face à un schéma JSON.
 
         Args:

--- a/sdk_entrepot_gpf/helper/JsonHelper.py
+++ b/sdk_entrepot_gpf/helper/JsonHelper.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 import jsonschema
 from jsonc_parser.parser import JsoncParser  # type: ignore
 from jsonc_parser.errors import ParserError  # type: ignore
@@ -117,7 +117,7 @@ class JsonHelper:
         JsonHelper.validate_object(o_json_data, o_schema_data, s_message_json, s_message_schema)
 
     @staticmethod
-    def validate_object(json_data: object, schema_data: Any, json_not_valid_message: str, schema_not_valid_message: str) -> None:
+    def validate_object(json_data: object, schema_data: Dict[str, Any], json_not_valid_message: str, schema_not_valid_message: str) -> None:
         """Fonction de validation d'un fichier json face à un schéma JSON.
 
         Args:

--- a/sdk_entrepot_gpf/helper/JsonHelper.py
+++ b/sdk_entrepot_gpf/helper/JsonHelper.py
@@ -117,12 +117,12 @@ class JsonHelper:
         JsonHelper.validate_object(o_json_data, o_schema_data, s_message_json, s_message_schema)
 
     @staticmethod
-    def validate_object(json_data: object, schema_data: object, json_not_valid_message: str, schema_not_valid_message: str) -> None:
+    def validate_object(json_data: object, schema_data: Any, json_not_valid_message: str, schema_not_valid_message: str) -> None:
         """Fonction de validation d'un fichier json face à un schéma JSON.
 
         Args:
             json_data (object): donnée à valider
-            schema_data (object): schéma de validation
+            schema_data (Any): schéma de validation
             json_not_valid_message (str): message à afficher si le json n'est pas valide
             schema_not_valid_message (str): message à afficher si le schéma n'est pas valide
 

--- a/sdk_entrepot_gpf/helper/JsonHelper.py
+++ b/sdk_entrepot_gpf/helper/JsonHelper.py
@@ -122,7 +122,7 @@ class JsonHelper:
 
         Args:
             json_data (object): donnée à valider
-            schema_data (object): schéma de validation
+            schema_data (Any): schéma de validation
             json_not_valid_message (str): message à afficher si le json n'est pas valide
             schema_not_valid_message (str): message à afficher si le schéma n'est pas valide
 

--- a/sdk_entrepot_gpf/io/Config.py
+++ b/sdk_entrepot_gpf/io/Config.py
@@ -1,9 +1,9 @@
 import os
 import configparser
 import pathlib
-import toml
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Union
+import toml
 
 from sdk_entrepot_gpf.pattern.Singleton import Singleton
 from sdk_entrepot_gpf.io.OutputManager import OutputManager
@@ -87,7 +87,7 @@ class Config(metaclass=Singleton):
                     # Fichier non géré
                     raise ValueError(f"L'extension {s_ext} n'est pas gérée par la classe Config.")
         # Fusion des configurations
-        d_full_config: dict[str, Any] = {}
+        d_full_config: Dict[str, Any] = {}
         for d_config_3 in l_configs:
             d_full_config = Config.merge(d_full_config, d_config_3)
         self.__config = d_full_config
@@ -110,7 +110,7 @@ class Config(metaclass=Singleton):
         if isinstance(new, type(old)):
             if isinstance(old, dict):
                 # ce sont des dictionnaires
-                d_merged: dict[str, Any] = old.copy()
+                d_merged: Dict[str, Any] = old.copy()
                 for s_key, o_value in new.items():
                     if s_key in old:
                         d_merged[s_key] = Config.merge(old[s_key], o_value)

--- a/sdk_entrepot_gpf/io/Config.py
+++ b/sdk_entrepot_gpf/io/Config.py
@@ -1,6 +1,9 @@
+import os
 import configparser
+import pathlib
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
+import toml
 
 from sdk_entrepot_gpf.pattern.Singleton import Singleton
 from sdk_entrepot_gpf.io.OutputManager import OutputManager
@@ -8,10 +11,9 @@ from sdk_entrepot_gpf.io.Errors import ConfigReaderError
 
 
 class Config(metaclass=Singleton):
-    """Lit le fichier de configuration (classe Singleton).
+    """Lit et compile les fichiers de configuration (classe Singleton).
     Attributes:
-        __config_parser (configparser): ConfigParser
-        __ini_file_path (string): Chemin vers le fichier de configuration BaGI
+        __config (dict[str, Any]): configuration entière sous forme de dictionnaire (sections) de dictionnaires
     """
 
     conf_dir_path = Path(__file__).parent.parent.absolute() / "_conf"
@@ -29,9 +31,9 @@ class Config(metaclass=Singleton):
         self.__output_manager: OutputManager = OutputManager()
 
         if not Config.ini_file_path.exists():
-            raise ConfigReaderError("Fichier de configuration par défaut {ConfigReader.ini_file_path} non trouvé.")
+            raise ConfigReaderError(f"Fichier de configuration par défaut {Config.ini_file_path} non trouvé.")
 
-        self.__config_parser: configparser.ConfigParser = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation())
+        self.__config: Dict[str, Dict[str, Any]] = {}
         self.read(Config.ini_file_path)
 
         # Définition du niveau de log pour l'OutputManager par défaut
@@ -55,19 +57,79 @@ class Config(metaclass=Singleton):
             filenames (Union[str, Path, Iterable[Union[str, Path]]]): Chemin ou liste des chemins vers le ou les fichier(s) à lire
 
         Returns:
-            liste des fichiers trouvés et lus
+            List[str]: liste des fichiers trouvés et lus
         """
-        return self.__config_parser.read(filenames)
+        if isinstance(filenames, (str, bytes, os.PathLike)):
+            filenames = [filenames]
+        # Ouverture des fichiers existants
+        l_configs = []
+        l_read_files = []
+        for p_file in filenames:
+            if os.path.exists(p_file):
+                s_ext = pathlib.Path(p_file).suffix
+                if s_ext == ".ini":
+                    # Fichier ini
+                    o_config = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation())
+                    o_config.read(p_file, encoding="utf-8")
+                    try:
+                        d_config = {s: dict(o_config.items(s)) for s in o_config.sections()}
+                    except configparser.InterpolationSyntaxError as e_err:
+                        raise ConfigReaderError(f"Veuillez vérifier la config, les caractères spéciaux doivent être doublés. ({e_err.message}) ") from e_err
+                    l_configs.append(d_config)
+                    l_read_files.append(str(p_file))
+                elif s_ext == ".toml":
+                    # Fichier toml
+                    d_config = toml.load(p_file)
+                    l_configs.append(d_config)
+                    l_read_files.append(str(p_file))
+                else:
+                    # Fichier non géré
+                    raise ValueError(f"L'extension {s_ext} n'est pas gérée par la classe Config.")
+        # Fusion des configurations
+        for d_config in l_configs:
+            self.__config = Config.merge(self.__config, d_config)
 
-    def get_parser(self) -> configparser.ConfigParser:
-        """Retourne le config_parser.
+        return l_read_files
+
+    @staticmethod
+    def merge(old: Any, new: Any) -> Any:
+        """Fusionne récursivement new dans old avec une priorité sur new.
+
+        Args:
+            old (Any): old object
+            new (Any): new object
 
         Returns:
-            le config parser
+            Any: old surchargé par new
         """
-        return self.__config_parser
 
-    def get(self, section: str, option: str, fallback: Optional[str] = None) -> Optional[str]:
+        # new est du même type ou d'un type héritant de old
+        if isinstance(new, type(old)):
+            if isinstance(old, dict):
+                # ce sont des dictionnaires
+                d_merged: Dict[str, Any] = old.copy()
+                for s_key, o_value in new.items():
+                    if s_key in old:
+                        d_merged[s_key] = Config.merge(old[s_key], o_value)
+                    else:
+                        d_merged[s_key] = o_value
+                return d_merged
+            if isinstance(old, list):
+                # ce sont des listes
+                l_merged: List[Set[Any]] = list(set(old + new))
+                return l_merged
+        # C'est d'un autre type : on conserve new
+        return new
+
+    def get_config(self) -> Dict[str, Dict[str, Any]]:
+        """Retourne la config entière.
+
+        Returns:
+            Dict[str, Dict[str, Any]]: la full config
+        """
+        return self.__config
+
+    def get(self, section: str, option: str, fallback: Optional[Any] = None) -> Optional[str]:
         """Récupère la valeur associée au paramètre demandé.
 
         Args:
@@ -78,16 +140,14 @@ class Config(metaclass=Singleton):
         Returns:
             Optional[str]: la valeur du paramètre
         """
-        try:
-            s_value: Optional[str] = self.__config_parser.get(section, option, fallback=fallback)
-        except configparser.InterpolationSyntaxError as e_err:
-            raise ConfigReaderError(f"Veuillez vérifier la config ({section}-[{option}]]), les caractères spéciaux doivent être doublés. ({e_err.message}) ") from e_err
-        if s_value == "":
+        s_fallback = str(fallback) if fallback is not None else fallback
+        s_ret = self.__config.get(section, {option: s_fallback}).get(option, s_fallback)
+        if s_ret is None:
             return None
-        return s_value
+        return str(s_ret)
 
     def get_str(self, section: str, option: str, fallback: Optional[str] = None) -> str:
-        """Récupère la valeur du paramètre demandé.
+        """Récupère la valeur du paramètre demandé. Si la valeur est None, une exception est levée.
 
         Args:
             section (str): section du paramètre
@@ -95,15 +155,15 @@ class Config(metaclass=Singleton):
             fallback (Optional[str], optional): valeur par défaut. Defaults to None.
 
         Returns:
-            Optional[str]: la valeur du paramètre
+            str: la valeur du paramètre
         """
-        try:
-            return self.__config_parser.get(section, option, fallback=fallback)  # type: ignore
-        except configparser.InterpolationSyntaxError as e_err:
-            raise ConfigReaderError(f"Veuillez vérifier la config ([{section}-[{option}]]), les caractères spéciaux doivent être doublés. ({e_err.message}) ") from e_err
+        s_ret = self.get(section, option, fallback=fallback)
+        if s_ret is None:
+            raise ConfigReaderError(f"Veuillez vérifier la config ([{section}-[{option}]]), valeur non reconnue.")
+        return str(s_ret)
 
     def get_int(self, section: str, option: str, fallback: Optional[int] = None) -> int:
-        """Récupère la valeur associée au paramètre demandé, convertie en `int`.
+        """Récupère la valeur associée au paramètre demandé, convertie en `int`. Si la valeur est None, une exception est levée.
 
         Args:
             section (str): section du paramètre
@@ -111,12 +171,16 @@ class Config(metaclass=Singleton):
             fallback (Optional[int], optional): valeur par défaut.
 
         Returns:
-            la valeur du paramètre
+            int: la valeur du paramètre
         """
-        return self.__config_parser.getint(section, option, fallback=fallback)  # type: ignore
+        try:
+            s_ret = self.get(section, option, fallback=fallback)
+            return int(s_ret)  # type:ignore
+        except (ValueError, TypeError) as e_err:
+            raise ConfigReaderError(f"Veuillez vérifier la config ([{section}-[{option}]]), entier non reconnu ({s_ret}). ({e_err}) ") from e_err
 
     def get_float(self, section: str, option: str, fallback: Optional[float] = None) -> float:
-        """Récupère la valeur associée au paramètre demandé, convertie en `float`.
+        """Récupère la valeur associée au paramètre demandé, convertie en `float`. Si la valeur est None, une exception est levée.
 
         Args:
             section (str): section du paramètre
@@ -124,12 +188,16 @@ class Config(metaclass=Singleton):
             fallback (Optional[float], optional): valeur par défaut.
 
         Returns:
-            la valeur du paramètre
+            float: la valeur du paramètre
         """
-        return self.__config_parser.getfloat(section, option, fallback=fallback)  # type: ignore
+        try:
+            s_ret = self.get(section, option, fallback=fallback)
+            return float(s_ret)  # type:ignore
+        except (ValueError, TypeError) as e_err:
+            raise ConfigReaderError(f"Veuillez vérifier la config ([{section}-[{option}]]), nombre flottant non reconnu ({s_ret}). ({e_err}) ") from e_err
 
     def get_bool(self, section: str, option: str, fallback: Optional[bool] = None) -> bool:
-        """Récupère la valeur associée au paramètre demandé, convertie en `bool`.
+        """Récupère la valeur associée au paramètre demandé, convertie en `bool`. Si la valeur est None, une exception est levée.
 
         Args:
             section (str): section du paramètre
@@ -137,9 +205,13 @@ class Config(metaclass=Singleton):
             fallback (Optional[bool], optional): valeur par défaut.
 
         Returns:
-            la valeur du paramètre
+            bool: la valeur du paramètre
         """
-        return self.__config_parser.getboolean(section, option, fallback=fallback)  # type: ignore
+        try:
+            s_ret = self.get(section, option, fallback=fallback)
+            return bool(s_ret)
+        except (TypeError, TypeError) as e_err:
+            raise ConfigReaderError(f"Veuillez vérifier la config ([{section}-[{option}]]), booléen non reconnu ({s_ret}). ({e_err}) ") from e_err
 
     def get_temp(self) -> Path:
         """Récupère le chemin racine du dossier temporaire à utiliser.

--- a/sdk_entrepot_gpf/io/OutputManager.py
+++ b/sdk_entrepot_gpf/io/OutputManager.py
@@ -17,7 +17,7 @@ class OutputManager(metaclass=Singleton):
                 [logging](https://docs.python.org/fr/3/library/logging.html#logging.Formatter)) ou `None` si on veut le format par défaut.
         """
         # initialisation du loger
-        self.__logger = logging.getLogger(__name__)
+        self.__logger: logging.Logger = logging.getLogger(__name__)
         self.__logger.setLevel(logging.INFO)
 
         # création formateur
@@ -36,57 +36,78 @@ class OutputManager(metaclass=Singleton):
             o_fh.setFormatter(o_formatter)
             self.__logger.addHandler(o_fh)
 
-    def debug(self, message: str) -> None:
+    def _force_flush(self) -> None:
+        """force la remonté des logs"""
+        for o_handeler in self.__logger.handlers:
+            o_handeler.flush()
+
+    def debug(self, message: str, force_flush: bool = False) -> None:
         """Ajout d'un message de type debug
+
         Args:
             message (str): message de type debug à journaliser
+            force_flush (bool, optional): forcer la remonté des logs. Defaults to False.
         """
         self.__logger.debug("%sDEBUG - %s%s", Color.GREY, message, Color.END)
+        if force_flush:
+            self._force_flush()
 
-    def info(self, message: str, green_colored: bool = False) -> None:
+    def info(self, message: str, green_colored: bool = False, force_flush: bool = False) -> None:
         """Ajout d'un message de type info
 
         Args:
             message (str): message de type info à journaliser
             green_colored (bool, optional): indique si le message doit être écrit en vert (par défaut False)
+            force_flush (bool, optional): forcer la remonté des logs. Defaults to False.
         """
         if green_colored is False:
             self.__logger.info("INFO - %s", message)
         else:
             self.__logger.info("%sINFO - %s%s", Color.GREEN, message, Color.END)
+        if force_flush:
+            self._force_flush()
 
-    def warning(self, message: str, yellow_colored: bool = True) -> None:
+    def warning(self, message: str, yellow_colored: bool = True, force_flush: bool = False) -> None:
         """Ajout d'un message de type warning
         Args:
             message (str): message de type warning à journaliser
             yellow_colored (bool, optional): indique si le message doit être écrit en jaune (par défaut True)
+            force_flush (bool, optional): forcer la remonté des logs. Defaults to False.
         """
         if yellow_colored is False:
             self.__logger.warning("ALERTE - %s", message)
         else:
             self.__logger.warning("%sALERTE - %s%s", Color.YELLOW, message, Color.END)
+        if force_flush:
+            self._force_flush()
 
-    def error(self, message: str, red_colored: bool = True) -> None:
+    def error(self, message: str, red_colored: bool = True, force_flush: bool = False) -> None:
         """Ajout d'un message de type erreur
         Args:
             message (str): message de type erreur à journaliser
             red_colored (bool, optional): indique si le message doit être écrit en rouge (par défaut False)
+            force_flush (bool, optional): forcer la remonté des logs. Defaults to False.
         """
         if red_colored is False:
             self.__logger.error("ERREUR - %s", message)
         else:
             self.__logger.error("%sERREUR - %s%s", Color.RED, message, Color.END)
+        if force_flush:
+            self._force_flush()
 
-    def critical(self, message: str, red_colored: bool = True) -> None:
+    def critical(self, message: str, red_colored: bool = True, force_flush: bool = False) -> None:
         """Ajout d'un message de type critique (apparaît en rouge dans la console)
         Args:
             message (str): message de type critique à journaliser
             red_colored (bool, optional): indique si le message doit être écrit en rouge (par défaut True)
+            force_flush (bool, optional): forcer la remonté des logs. Defaults to False.
         """
         if red_colored is False:
             self.__logger.critical("ERREUR FATALE - %s", message)
         else:
             self.__logger.critical("%sERREUR FATALE - %s%s", Color.RED, message, Color.END)
+        if force_flush:
+            self._force_flush()
 
     def set_log_level(self, level: str) -> None:
         """Défini le niveau de log du logger.

--- a/sdk_entrepot_gpf/store/Annexe.py
+++ b/sdk_entrepot_gpf/store/Annexe.py
@@ -68,3 +68,17 @@ class Annexe(CreatedByUploadFileInterface, DownloadInterface, PartialEditInterfa
         )
 
         return int(o_response.text)
+
+    def __str__(self) -> str:
+        # Affichage à destination d'un utilisateur.
+        # On affiche l'id et le nom si possible.
+
+        # Liste pour stocker les infos à afficher
+        l_infos = []
+        # Ajout de l'id
+        l_infos.append(f"id={self.id}")
+        s_paths = "','".join(self["paths"])
+        l_infos.append(f"paths='{s_paths}'")
+        l_infos.append(f"published={self['published']}")
+        # Retour
+        return f"{self.__class__.__name__}({', '.join(l_infos)})"

--- a/sdk_entrepot_gpf/store/Metadata.py
+++ b/sdk_entrepot_gpf/store/Metadata.py
@@ -59,3 +59,16 @@ class Metadata(CreatedByUploadFileInterface, DownloadInterface, PartialEditInter
             data={"file_identifiers": file_identifiers, "endpoint": endpoint_id},
             method=ApiRequester.POST,
         )
+
+    def __str__(self) -> str:
+        # Affichage à destination d'un utilisateur.
+        # On affiche l'id et le nom si possible.
+
+        # Liste pour stocker les infos à afficher
+        l_infos = []
+        # Ajout de l'id
+        l_infos.append(f"id={self.id}")
+        l_infos.append(f"type={self['type']}")
+        l_infos.append(f"file_identifier={self['file_identifier']}")
+        # Retour
+        return f"{self.__class__.__name__}({', '.join(l_infos)})"

--- a/sdk_entrepot_gpf/store/Offering.py
+++ b/sdk_entrepot_gpf/store/Offering.py
@@ -34,7 +34,7 @@ class Offering(PartialEditInterface, StoreEntity):
 
         except NotFoundError:
             # on a un 404 donc l'offre est bien supprimée
-            return
+            pass
 
     def api_synchronize(self) -> None:
         """répercuter des modifications sur la configuration ou les données stockées utilisées au niveau des services de diffusion"""

--- a/sdk_entrepot_gpf/store/interface/ReUploadFileInterface.py
+++ b/sdk_entrepot_gpf/store/interface/ReUploadFileInterface.py
@@ -26,6 +26,7 @@ class ReUploadFileInterface(StoreEntity):
             s_route,
             file,
             s_file_key,
+            route_params={self._entity_name: self.id, "datastore": self.datastore},
             method=ApiRequester.PUT,
         )
 

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -69,6 +69,7 @@ class Workflow:
         datastore: Optional[str] = None,
         comments: List[str] = [],
         tags: Dict[str, str] = {},
+        compatibility_cartes: Optional[bool] = None,
     ) -> List[StoreEntity]:
         """Lance une étape du workflow à partir de son nom. Liste les entités créées par chaque action et retourne la liste.
 
@@ -80,6 +81,7 @@ class Workflow:
             datastore (Optional[str]): id du datastore à utiliser. Si None, le datastore sera le premier trouvé dans l'action puis dans workflow puis dans configuration.
             comments (Optional[List[str]]): liste des commentaire à rajouté à toute les actions de l'étape (les cas de doublons sont géré).
             tags (Optional[Dict[str, str]]): dictionnaire des tag à rajouté pour toutes les action de l'étape. Écrasé par ceux du workflow, de l'étape et de l'action si les clef sont les même.
+            compatibility_cartes (Optional[bool]): ajout des tags pour compatibilité avec cartes.gouv.fr.
 
         Raises:
             WorkflowError: levée si un problème apparaît pendant l'exécution du workflow
@@ -88,6 +90,9 @@ class Workflow:
             List[StoreEntity]: liste des entités créées
         """
         Config().om.info(f"Lancement de l'étape {step_name}...")
+        # si compatibility_cartes n'est pas déterminé on récupère la valeur dans le workflow ou None
+        if compatibility_cartes is None:
+            compatibility_cartes = self.__raw_definition_dict.get('compatibility_cartes')
         # Création d'une liste pour stocker les entités créées
         l_store_entity: List[StoreEntity] = []
         # Récupération de l'étape dans la définition de workflow (datastore forcé, sinon datastore du workflow/None)
@@ -97,7 +102,7 @@ class Workflow:
         # Pour chaque action définie dans le workflow, instanciation de l'objet Action puis création sur l'entrepôt
         for d_action_raw in d_step_definition["actions"]:
             # création de l'action
-            o_action = Workflow.generate(step_name, d_action_raw, o_parent_action, behavior)
+            o_action = Workflow.generate(step_name, d_action_raw, o_parent_action, behavior, compatibility_cartes)
             # choix du datastore
             ## datastore donné en paramètre
             ## sinon datastore du workflow au niveau de l'action
@@ -254,7 +259,7 @@ class Workflow:
 
     @staticmethod
     def generate(  # pylint: disable=too-many-return-statements
-        workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional[ActionAbstract] = None, behavior: Optional[str] = None
+        workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional[ActionAbstract] = None, behavior: Optional[str] = None, compatibility_cartes: Optional[bool]=None
     ) -> ActionAbstract:
         """Génération de la bonne action selon le type indiqué dans la représentation du workflow.
 
@@ -263,6 +268,7 @@ class Workflow:
             definition_dict (Dict[str, Any]): dictionnaire définissant l'action
             parent_action (Optional[ActionAbstract], optional): action précédente (si étape à plusieurs action). Defaults to None.
             behavior (Optional[str]): comportement à adopter si l'entité créée par l'action existe déjà sur l'entrepôt. Defaults to None.
+            compatibility_cartes (Optional[bool]): ajout des tags pour compatibilité avec cartes.gouv.fr.
 
         Returns:
             instance permettant de lancer l'action

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -278,7 +278,7 @@ class Workflow:
         if definition_dict["type"] == "processing-execution":
             return ProcessingExecutionAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "configuration":
-            return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
+            return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior, compatibility_cartes)
         if definition_dict["type"] == "copy-configuration":
             return CopyConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "used_data-configuration":

--- a/sdk_entrepot_gpf/workflow/Workflow.py
+++ b/sdk_entrepot_gpf/workflow/Workflow.py
@@ -92,7 +92,7 @@ class Workflow:
         Config().om.info(f"Lancement de l'étape {step_name}...")
         # si compatibility_cartes n'est pas déterminé on récupère la valeur dans le workflow ou None
         if compatibility_cartes is None:
-            compatibility_cartes = self.__raw_definition_dict.get('compatibility_cartes')
+            compatibility_cartes = self.__raw_definition_dict.get("compatibility_cartes")
         # Création d'une liste pour stocker les entités créées
         l_store_entity: List[StoreEntity] = []
         # Récupération de l'étape dans la définition de workflow (datastore forcé, sinon datastore du workflow/None)
@@ -259,7 +259,7 @@ class Workflow:
 
     @staticmethod
     def generate(  # pylint: disable=too-many-return-statements
-        workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional[ActionAbstract] = None, behavior: Optional[str] = None, compatibility_cartes: Optional[bool]=None
+        workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional[ActionAbstract] = None, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None
     ) -> ActionAbstract:
         """Génération de la bonne action selon le type indiqué dans la représentation du workflow.
 
@@ -276,9 +276,9 @@ class Workflow:
         if definition_dict["type"] == "delete-entity":
             return DeleteAction(workflow_context, definition_dict, parent_action)
         if definition_dict["type"] == "processing-execution":
-            return ProcessingExecutionAction(workflow_context, definition_dict, parent_action, behavior=behavior)
+            return ProcessingExecutionAction(workflow_context, definition_dict, parent_action, behavior=behavior, compatibility_cartes=compatibility_cartes)
         if definition_dict["type"] == "configuration":
-            return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior, compatibility_cartes)
+            return ConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior, compatibility_cartes=compatibility_cartes)
         if definition_dict["type"] == "copy-configuration":
             return CopyConfigurationAction(workflow_context, definition_dict, parent_action, behavior=behavior)
         if definition_dict["type"] == "used_data-configuration":

--- a/sdk_entrepot_gpf/workflow/action/ActionAbstract.py
+++ b/sdk_entrepot_gpf/workflow/action/ActionAbstract.py
@@ -70,7 +70,7 @@ class ActionAbstract(ABC):
         Raises:
             StepActionError: _description_
         """
-        Config().om.info(f"Résolution de l'action '{self.workflow_context}-{self.index}'...")
+        Config().om.info(f"Résolution de l'action '{self.workflow_context}-{self.index}'...", force_flush=True)
         # Pour faciliter la résolution, on repasse la définition de l'action en json
         s_definition = str(json.dumps(self.__definition_dict, ensure_ascii=False))
         # lancement des résolveurs

--- a/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
@@ -25,7 +25,7 @@ class ConfigurationAction(ActionAbstract):
         self.__behavior: str = behavior if behavior is not None else Config().get_str("configuration", "behavior_if_exists")
 
     def run(self, datastore: Optional[str] = None) -> None:
-        Config().om.info("Création et complétion d'une configuration...")
+        Config().om.info("Création et complétion d'une configuration...", force_flush=True)
         # Création de la Configuration
         self.__create_configuration(datastore)
         # Ajout des tags sur la Configuration
@@ -64,7 +64,7 @@ class ConfigurationAction(ActionAbstract):
                 )
         # Création en gérant une erreur de type ConflictError (si la Configuration existe déjà selon les critères de l'API)
         try:
-            Config().om.info("Création de la configuration...")
+            Config().om.info("Création de la configuration...", force_flush=True)
             self.__configuration = Configuration.api_create(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
             Config().om.info(f"Configuration {self.__configuration['name']} créée avec succès.")
         except ConflictError as e:

--- a/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
@@ -25,7 +25,7 @@ class ConfigurationAction(ActionAbstract):
         self.__configuration: Optional[Configuration] = None
         # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut CONTINUE
         self.__behavior: str = behavior if behavior is not None else Config().get_str("configuration", "behavior_if_exists")
-        self.__compatibility_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
+        self.__mode_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Création et complétion d'une configuration...")
@@ -78,8 +78,8 @@ class ConfigurationAction(ActionAbstract):
         if not self.configuration or not self.definition_dict:
             # uniquement pour le type, dans les fait le programme sort en erreur avant d'arivé ici
             return
-        if self.__compatibility_cartes and "datasheet_name" not in self.definition_dict.get("tags", {}):
-            # tag datasheet_name obligatoire en mode __compatibility_cartes
+        if self.__mode_cartes and "datasheet_name" not in self.definition_dict.get("tags", {}):
+            # tag datasheet_name obligatoire en mode cartes
             raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
         # on vérifie que la configuration et definition_dict ne sont pas null et on vérifie qu'il y'a bien une clé tags
         if self.definition_dict.get("tags"):

--- a/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
@@ -28,7 +28,7 @@ class ConfigurationAction(ActionAbstract):
         self.__mode_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
-        Config().om.info("Création et complétion d'une configuration...")
+        Config().om.info("Création et complétion d'une configuration...", force_flush=True)
         # Création de la Configuration
         self.__create_configuration(datastore)
         # Ajout des tags sur la Configuration
@@ -67,7 +67,7 @@ class ConfigurationAction(ActionAbstract):
                 )
         # Création en gérant une erreur de type ConflictError (si la Configuration existe déjà selon les critères de l'API)
         try:
-            Config().om.info("Création de la configuration...")
+            Config().om.info("Création de la configuration...", force_flush=True)
             self.__configuration = Configuration.api_create(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
             Config().om.info(f"Configuration {self.__configuration['name']} créée avec succès.")
         except ConflictError as e:

--- a/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
@@ -17,12 +17,15 @@ class ConfigurationAction(ActionAbstract):
         __configuration (Optional[Configuration]): représentation Python de la configuration créée
     """
 
-    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None) -> None:
+    def __init__(
+        self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None
+    ) -> None:
         super().__init__(workflow_context, definition_dict, parent_action)
         # Autres attributs
         self.__configuration: Optional[Configuration] = None
         # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut CONTINUE
         self.__behavior: str = behavior if behavior is not None else Config().get_str("configuration", "behavior_if_exists")
+        self.__mode_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Création et complétion d'une configuration...", force_flush=True)
@@ -72,8 +75,14 @@ class ConfigurationAction(ActionAbstract):
 
     def __add_tags(self) -> None:
         """Ajout des tags sur la Configuration."""
+        if not self.configuration or not self.definition_dict:
+            # uniquement pour le type, dans les fait le programme sort en erreur avant d'arivé ici
+            return
+        if self.__mode_cartes and "datasheet_name" not in self.definition_dict.get("tags", {}):
+            # tag datasheet_name obligatoire en mode cartes
+            raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
         # on vérifie que la configuration et definition_dict ne sont pas null et on vérifie qu'il y'a bien une clé tags
-        if self.configuration and self.definition_dict and "tags" in self.definition_dict and self.definition_dict["tags"] != {}:
+        if self.definition_dict.get("tags"):
             Config().om.info(f"Configuration {self.configuration['name']} : ajout des {len(self.definition_dict['tags'])} tags...")
             self.configuration.api_add_tags(self.definition_dict["tags"])
             Config().om.info(f"Configuration {self.configuration['name']} : les {len(self.definition_dict['tags'])} tags ont été ajoutés avec succès.")

--- a/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ConfigurationAction.py
@@ -17,12 +17,15 @@ class ConfigurationAction(ActionAbstract):
         __configuration (Optional[Configuration]): représentation Python de la configuration créée
     """
 
-    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None) -> None:
+    def __init__(
+        self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None
+    ) -> None:
         super().__init__(workflow_context, definition_dict, parent_action)
         # Autres attributs
         self.__configuration: Optional[Configuration] = None
         # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut CONTINUE
         self.__behavior: str = behavior if behavior is not None else Config().get_str("configuration", "behavior_if_exists")
+        self.__compatibility_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Création et complétion d'une configuration...")
@@ -72,8 +75,14 @@ class ConfigurationAction(ActionAbstract):
 
     def __add_tags(self) -> None:
         """Ajout des tags sur la Configuration."""
+        if not self.configuration or not self.definition_dict:
+            # uniquement pour le type, dans les fait le programme sort en erreur avant d'arivé ici
+            return
+        if self.__compatibility_cartes and "datasheet_name" not in self.definition_dict.get("tags", {}):
+            # tag datasheet_name obligatoire en mode __compatibility_cartes
+            raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
         # on vérifie que la configuration et definition_dict ne sont pas null et on vérifie qu'il y'a bien une clé tags
-        if self.configuration and self.definition_dict and "tags" in self.definition_dict and self.definition_dict["tags"] != {}:
+        if self.definition_dict.get("tags"):
             Config().om.info(f"Configuration {self.configuration['name']} : ajout des {len(self.definition_dict['tags'])} tags...")
             self.configuration.api_add_tags(self.definition_dict["tags"])
             Config().om.info(f"Configuration {self.configuration['name']} : les {len(self.definition_dict['tags'])} tags ont été ajoutés avec succès.")

--- a/sdk_entrepot_gpf/workflow/action/CopyConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/CopyConfigurationAction.py
@@ -20,7 +20,7 @@ class CopyConfigurationAction(ConfigurationAction):
         if "body_parameters" not in self.definition_dict or "layer_name" not in self.definition_dict["body_parameters"] or "name" not in self.definition_dict["body_parameters"]:
             raise StepActionError('Les clefs "name" et "layer_name" sont obligatoires dans "body_parameters"')
 
-        Config().om.info("Récupération du paramétrage de l'ancienne configuration...")
+        Config().om.info("Récupération du paramétrage de l'ancienne configuration...", force_flush=True)
         # on récupère la configuration à copier
         o_base_config = Configuration.api_get(self.definition_dict["url_parameters"]["configuration"], datastore=datastore)
         # stockage de l'ancien body_parameters

--- a/sdk_entrepot_gpf/workflow/action/EditAction.py
+++ b/sdk_entrepot_gpf/workflow/action/EditAction.py
@@ -43,7 +43,7 @@ class EditAction(ActionAbstract):
             raise StepActionError('La clef "entity_id" est obligatoire pour cette action.')
         o_entity: StoreEntity = store.TYPE__ENTITY[self.definition_dict["entity_type"]].api_get(self.definition_dict["entity_id"], datastore=datastore)
 
-        Config().om.info(f"Edition de {o_entity}.")
+        Config().om.info(f"Edition de {o_entity}.", force_flush=True)
 
         # Lancement de la mise à jour si demandé
         if self.definition_dict.get("body_parameters"):

--- a/sdk_entrepot_gpf/workflow/action/EditAction.py
+++ b/sdk_entrepot_gpf/workflow/action/EditAction.py
@@ -50,6 +50,22 @@ class EditAction(ActionAbstract):
             o_entity.edit(self.definition_dict["body_parameters"])
             Config().om.info(f"Mise à jour de {o_entity} .")
 
+        # suppression des tags si possible
+        if self.definition_dict.get("remove_tags") and isinstance(o_entity, TagInterface):
+            Config().om.info(f"Suppression des {len(self.definition_dict['remove_tags'])} tags...")
+            o_entity.api_remove_tags(self.definition_dict["remove_tags"])
+            Config().om.info(f"les {len(self.definition_dict['remove_tags'])} tags ont été supprimés avec succès.")
+        # suppression des commentaires si possible
+        if self.definition_dict.get("remove_comments") and isinstance(o_entity, CommentInterface):
+            # dictionnaire text : id
+            d_actual_comments = {d_comment["text"]: d_comment["_id"] for d_comment in o_entity.api_list_comments() if d_comment}
+            Config().om.info(f"Suppression des {len(self.definition_dict['remove_comments'])} commentaires...")
+            for s_comment in self.definition_dict["remove_comments"]:
+                # si le commentaire existe on le supprime
+                if s_comment in d_actual_comments:
+                    o_entity.api_remove_comment(d_actual_comments[s_comment])
+            Config().om.info(f"Les {len(self.definition_dict['remove_comments'])} commentaires ont été supprimés avec succès.")
+
         # ajout des tags si possible
         if self.definition_dict.get("tags") and isinstance(o_entity, TagInterface):
             Config().om.info(f"ajout des {len(self.definition_dict['tags'])} tags...")

--- a/sdk_entrepot_gpf/workflow/action/EditAction.py
+++ b/sdk_entrepot_gpf/workflow/action/EditAction.py
@@ -50,22 +50,6 @@ class EditAction(ActionAbstract):
             o_entity.edit(self.definition_dict["body_parameters"])
             Config().om.info(f"Mise à jour de {o_entity} .")
 
-        # suppression des tags si possible
-        if self.definition_dict.get("remove_tags") and isinstance(o_entity, TagInterface):
-            Config().om.info(f"Suppression des {len(self.definition_dict['remove_tags'])} tags...")
-            o_entity.api_remove_tags(self.definition_dict["remove_tags"])
-            Config().om.info(f"les {len(self.definition_dict['remove_tags'])} tags ont été supprimés avec succès.")
-        # suppression des commentaires si possible
-        if self.definition_dict.get("remove_comments") and isinstance(o_entity, CommentInterface):
-            # dictionnaire text : id
-            d_actual_comments = {d_comment["text"]: d_comment["_id"] for d_comment in o_entity.api_list_comments() if d_comment}
-            Config().om.info(f"Suppression des {len(self.definition_dict['remove_comments'])} commentaires...")
-            for s_comment in self.definition_dict["remove_comments"]:
-                # si le commentaire existe on le supprime
-                if s_comment in d_actual_comments:
-                    o_entity.api_remove_comment(d_actual_comments[s_comment])
-            Config().om.info(f"Les {len(self.definition_dict['remove_comments'])} commentaires ont été supprimés avec succès.")
-
         # ajout des tags si possible
         if self.definition_dict.get("tags") and isinstance(o_entity, TagInterface):
             Config().om.info(f"ajout des {len(self.definition_dict['tags'])} tags...")

--- a/sdk_entrepot_gpf/workflow/action/EditUsedDataConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/EditUsedDataConfigurationAction.py
@@ -16,7 +16,7 @@ class EditUsedDataConfigurationAction(ActionAbstract):
 
     def run(self, datastore: Optional[str] = None) -> None:
 
-        Config().om.info("Récupération du paramétrage de l'ancienne configuration...")
+        Config().om.info("Récupération du paramétrage de l'ancienne configuration...", force_flush=True)
         # on récupère la configuration à copier
         o_base_config = Configuration.api_get(self.definition_dict["entity_id"], datastore=datastore)
         # stockage de l'ancien body_parameters
@@ -38,7 +38,7 @@ class EditUsedDataConfigurationAction(ActionAbstract):
             del d_parameter["type_infos"]["bbox"]
 
         # lancement de la modification
-        Config().om.info(f"Modification de la configuration {o_base_config} ...")
+        Config().om.info(f"Modification de la configuration {o_base_config} ...", force_flush=True)
 
         o_base_config.api_full_edit(d_parameter)
         Config().om.info("Modification de la configuration : terminé")

--- a/sdk_entrepot_gpf/workflow/action/OfferingAction.py
+++ b/sdk_entrepot_gpf/workflow/action/OfferingAction.py
@@ -28,7 +28,7 @@ class OfferingAction(ActionAbstract):
         self.__behavior: str = behavior if behavior is not None else Config().get_str("offering", "behavior_if_exists")
 
     def run(self, datastore: Optional[str] = None) -> None:
-        Config().om.info("Création d'une offre...")
+        Config().om.info("Création d'une offre...", force_flush=True)
         # Ajout de l'Offering
         self.__create_offering(datastore)
         # Affichage
@@ -42,7 +42,7 @@ class OfferingAction(ActionAbstract):
         o_offering.api_update()
         Config().om.info(f"Offre créée : {self.__offering}\n   - " + "\n   - ".join(o_offering.get_url()), green_colored=True)
         # vérification du status.
-        Config().om.info("vérification du statut ...")
+        Config().om.info("vérification du statut ...", force_flush=True)
         while True:
             o_offering.api_update()
             s_status = o_offering["status"]

--- a/sdk_entrepot_gpf/workflow/action/PermissionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/PermissionAction.py
@@ -23,7 +23,7 @@ class PermissionAction(ActionAbstract):
         self.__permission: Optional[Permission] = None
 
     def run(self, datastore: Optional[str] = None) -> None:
-        Config().om.info("Création d'une permission...")
+        Config().om.info("Création d'une permission...", force_flush=True)
         # Création de la permission
         self.__create_permission(datastore)
         Config().om.info(f"Permissions créées : {self.permission}")

--- a/sdk_entrepot_gpf/workflow/action/PermissionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/PermissionAction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from sdk_entrepot_gpf.store.Permission import Permission
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
@@ -20,27 +20,27 @@ class PermissionAction(ActionAbstract):
     def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None) -> None:
         super().__init__(workflow_context, definition_dict, parent_action)
         # Autres attributs
-        self.__permission: Optional[Permission] = None
+        self.__permissions: List[Permission] = []
 
     def run(self, datastore: Optional[str] = None) -> None:
-        Config().om.info("Création d'une permission...", force_flush=True)
+        Config().om.info("Création des permissions...", force_flush=True)
         # Création de la permission
-        self.__create_permission(datastore)
-        Config().om.info(f"Permissions créées : {self.permission}")
-        Config().om.info("Création d'une permission : terminée")
+        self.__create_permissions(datastore)
+        Config().om.info(f"Permissions créées : {self.permissions}")
+        Config().om.info("Création des permissions : terminée")
 
-    def __create_permission(self, datastore: Optional[str]) -> None:
-        """Création de la permission sur l'API à partir des paramètres de définition de l'action.
+    def __create_permissions(self, datastore: Optional[str]) -> None:
+        """Création des permissions sur l'API à partir des paramètres de définition de l'action.
 
         Args:
             datastore (Optional[str]): id du datastore à utiliser.
         """
         # Création en gérant une erreur de type ConflictError (si la Permission existe déjà selon les critères de l'API)
         try:
-            self.__permission = Permission.api_create(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
+            self.__permissions = Permission.api_create_list(self.definition_dict["body_parameters"], route_params={"datastore": datastore})
         except ConflictError as e:
-            raise StepActionError(f"Impossible de créer la permission il y a un conflict : \n{e.message}") from e
+            raise StepActionError(f"Impossible de créer les permissions il y a un conflict : \n{e.message}") from e
 
     @property
-    def permission(self) -> Optional[Permission]:
-        return self.__permission
+    def permissions(self) -> List[Permission]:
+        return self.__permissions

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -103,7 +103,6 @@ class ProcessingExecutionAction(ActionAbstract):
             # ou le processing execution est terminé (StoredData.STATUS_GENERATED)
             self.__stored_data = o_stored_data
             l_proc_exec = ProcessingExecution.api_list({"output_stored_data": o_stored_data.id}, datastore=datastore)
-            print(l_proc_exec, "--", self.__behavior)
             if not l_proc_exec:
                 raise GpfSdkError(f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_stored_data}")
             # arbitrairement, on prend le premier de la liste

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -254,7 +254,7 @@ class ProcessingExecutionAction(ActionAbstract):
         # gestion des tags pour compatibility_cartes
         if self.__mode_cartes and self.__processing_execution:
             # mise en base de donnée livrée (vecteur)
-            if self.__processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+            if self.__processing_execution.get_store_properties().get("processing", {"_id": ""})["_id"] == Config().get_str("compatibility_cartes", "id_mise_en_base"):
                 if "datasheet_name" not in d_tags:
                     raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
                 if not self.__inputs_upload or not self.stored_data:

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -113,6 +113,77 @@ class ProcessingExecutionAction(ActionAbstract):
         else:
             raise GpfSdkError(f"Le comportement {self.__behavior} n'est pas reconnu ({'|'.join(self.BEHAVIORS)}), l'exécution de traitement n'est pas possible.")
 
+    def __gestion_update_entity(self, datastore: Optional[str]) -> None:
+        """gestion des behaviors quand il y a mise à jour d'une entité.
+
+        Args:
+            datastore (Optional[str]): Identifiant du datastore.
+        """
+        if not "_id" in self.definition_dict["body_parameters"].get("output", {}).get("stored_data", {}):
+            # on ne gère que les mise à jour des stored_data
+            return
+        # On recherche le traitement entre les données en entré et celle en sortie
+        o_stored_data = StoredData.api_get(self.definition_dict["body_parameters"]["output"]["stored_data"]["_id"], datastore=datastore)
+        # Si on a trouvé une Donnée Stockée sur la gpf :
+        if o_stored_data is None:
+            raise GpfSdkError("La donnée en sortie est introuvable, impossible de faire la mise à jour.")
+
+        d_filter = {
+            "output_stored_data": o_stored_data.id,
+            "processing": self.definition_dict["body_parameters"]["processing"],
+        }
+        if self.definition_dict["body_parameters"].get("inputs", {}).get("upload"):
+            d_filter["input_upload"] = self.definition_dict["body_parameters"]["inputs"]["upload"][0]
+        elif self.definition_dict["body_parameters"].get("inputs", {}).get("stored_data"):
+            d_filter["input_stored_data"] = self.definition_dict["body_parameters"]["inputs"]["stored_data"][0]
+
+        # On recherche le traitement
+        l_proc_exec = ProcessingExecution.api_list(d_filter, datastore=datastore)
+        # affinage de la recherche
+        for o_proc_exec in l_proc_exec:
+            o_proc_exec.api_update()
+            # vérification des entrées ( si on a plus d'une entrée):
+            l_in_ids_upload = sorted(self.definition_dict["body_parameters"].get("inputs", {}).get("upload", []))
+            l_in_ids_stored_data = sorted(self.definition_dict["body_parameters"].get("inputs", {}).get("stored_data", []))
+            d_data_pe = o_proc_exec.get_store_properties()
+            l_pe_ids_upload = sorted([o_upload["_id"] for o_upload in d_data_pe.get("inputs", {}).get("upload", [])])
+            l_pe_ids_stored_data = sorted([o_upload["_id"] for o_upload in d_data_pe.get("inputs", {}).get("stored_data", [])])
+            if l_in_ids_upload == l_pe_ids_upload and l_in_ids_stored_data == l_pe_ids_stored_data and d_data_pe["parameters"] == self.definition_dict["body_parameters"].get("parameters", {}):
+                # les entrées, les sorties et paramètres correspondent, on a trouvé le traitement (o_proc_exec)
+                break
+        else:
+            # aucun traitement trouvé
+            return
+
+        # Comportement d'arrêt du programme
+        if self.__behavior == self.BEHAVIOR_STOP:
+            raise GpfSdkError(f"Le traitement a déjà été lancée pour mettre à jour cette donnée {o_proc_exec}.")
+
+        # on met à jour o_stored_data pour avoir son status
+        o_stored_data.api_update()
+        # Comportement de suppression des entités détectées (il n'est pas possible de supprimer la mise à jour précédente mais on relance la mise à jour)
+        if self.__behavior == self.BEHAVIOR_DELETE or (d_data_pe["status"] in [ProcessingExecution.STATUS_FAILURE, ProcessingExecution.STATUS_ABORTED] and self.__behavior == self.BEHAVIOR_RESUME):
+            Config().om.warning(f"Le traitement à déjà été lancé pour cette donnée ({o_proc_exec} statut {d_data_pe['status']}). On relance le traitement.")
+            # on force à None pour que la création soit faite
+            self.__processing_execution = None
+        # Comportement "on continue l'exécution"
+        elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
+            # on regarde si le résultat du traitement précédent est en échec (peut-être causé un autre traitement)
+            if o_stored_data["status"] == StoredData.STATUS_UNSTABLE:
+                raise GpfSdkError(f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_stored_data}. Impossible de lancer le traitement demandé.")
+
+            # on est donc dans un des cas suivants :
+            # le processing_execution a été créé mais pas exécuté (StoredData.STATUS_CREATED)
+            # ou le processing execution est en cours d'exécution (StoredData.STATUS_GENERATING ou StoredData.STATUS_MODIFYING)
+            # ou le processing execution est terminé (StoredData.STATUS_GENERATED)
+            self.__stored_data = o_stored_data
+            self.__processing_execution = o_proc_exec
+            Config().om.info(f"La donnée stocké en sortie {o_stored_data} à déjà été mis à jour, on reprend le traitement associé : {self.__processing_execution}.")
+            return
+        # Comportement non reconnu
+        else:
+            raise GpfSdkError(f"Le comportement {self.__behavior} n'est pas reconnu ({'|'.join(self.BEHAVIORS)}), l'exécution de traitement n'est pas possible.")
+
     def __create_processing_execution(self, datastore: Optional[str] = None) -> None:
         """Création du ProcessingExecution sur l'API à partir des paramètres de définition de l'action.
         Récupération des attributs processing_execution et Upload/StoredData.
@@ -122,6 +193,9 @@ class ProcessingExecutionAction(ActionAbstract):
         # On regarde si cette Exécution de Traitement implique la création d'une nouvelle entité (Livraison ou Donnée Stockée)
         if self.output_new_entity:
             self.__gestion_new_output(datastore)
+
+        if self.output_update_entity:
+            self.__gestion_update_entity(datastore)
 
         # A ce niveau là, si on a encore self.__processing_execution qui est None, c'est qu'on peut créer l'Exécution de Traitement sans problème
         if self.__processing_execution is None:
@@ -349,6 +423,20 @@ class ProcessingExecutionAction(ActionAbstract):
         else:
             return False
         return "name" in d_el
+
+    @property
+    def output_update_entity(self) -> bool:
+        """Indique s'il y aura mise à jour d'une entité par rapport au paramètre de création de l'exécution de traitement
+        (la clé "_id" et non la clé "name" est présente dans le paramètre "output" du corps de requête).
+        """
+        d_output = self.definition_dict["body_parameters"].get("output", {})
+        if "upload" in d_output:
+            d_el = d_output["upload"]
+        elif "stored_data" in d_output:
+            d_el = d_output["stored_data"]
+        else:
+            return False
+        return "_id" in d_el
 
     ##############################################################
     # Fonctions de représentation

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -170,13 +170,13 @@ class ProcessingExecutionAction(ActionAbstract):
         """Ajout des tags sur l'Upload ou la StoredData en sortie du ProcessingExecution."""
 
         # gestion des tags pour compatibility_cartes
-        if self.__compatibility_cartes and self.processing_execution:
+        if self.__compatibility_cartes and self.__processing_execution:
             # ajout de de la clef tags si non présente
             if not "tags" in self.definition_dict:
                 self.definition_dict["tags"] = {}
             d_data = self.__processing_execution.get_store_properties()
             # mise en base de donnée livrée (vecteur)
-            if self.__processing_execution.id == Config().get("compatibility_cartes", "id_mise_en_base"):
+            if self.__processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
                 if "datasheet_name" not in self.definition_dict["tags"]:
                     raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
                 if not self.__inputs_upload or not self.__stored_data:
@@ -184,15 +184,15 @@ class ProcessingExecutionAction(ActionAbstract):
                 for o_upload in self.__inputs_upload:
                     o_upload.api_add_tags(
                         {
-                            "integration_progress": Config().get("compatibility_cartes", "execution_start_integration_progress"),
-                            "integration_current_step": Config().get("compatibility_cartes", "execution_start_integration_current_step"),
+                            "integration_progress": Config().get_str("compatibility_cartes", "execution_start_integration_progress"),
+                            "integration_current_step": Config().get_str("compatibility_cartes", "execution_start_integration_current_step"),
                             "proc_int_id": self.__processing_execution.id,
                             "vectordb_id": self.__stored_data.id,
                         }
                     )
                 self.__definition_dict["tags"]["uuid_upload"] = self.__inputs_upload[0].id
             # création de pyramide vecteur
-            elif self.__processing_execution.id == Config().get("compatibility_cartes", "id_pyramide_vecteur"):
+            elif self.__processing_execution.id == Config().get_str("compatibility_cartes", "id_pyramide_vecteur"):
                 if "datasheet_name" not in self.definition_dict["tags"]:
                     raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
                 self.__definition_dict["tags"]["vectordb_id"] = d_data["inputs"]["stores_data"]["_id"]
@@ -368,7 +368,7 @@ class ProcessingExecutionAction(ActionAbstract):
         if self.__compatibility_cartes and self.__inputs_upload:
             s_key = "execution_end_ok_integration_progress" if s_status == ProcessingExecution.STATUS_SUCCESS else "execution_end_ko_integration_progress"
             for o_upload in self.__inputs_upload:
-                o_upload.api_add_tags({"integration_progress": Config().get("compatibility_cartes", s_key)})
+                o_upload.api_add_tags({"integration_progress": Config().get_str("compatibility_cartes", s_key)})
 
         ## on return le status de fin
         return str(s_status)

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -47,6 +47,7 @@ class ProcessingExecutionAction(ActionAbstract):
         # les données en sortie
         self.__upload: Optional[Upload] = None
         self.__stored_data: Optional[StoredData] = None
+        self.__no_output = False
         # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut STOP
         self.__behavior: str = behavior if behavior is not None else Config().get_str("processing_execution", "behavior_if_exists")
 
@@ -61,9 +62,56 @@ class ProcessingExecutionAction(ActionAbstract):
         # Lancement du traitement
         self.__launch()
         # Affichage
-        o_output_entity = self.__stored_data if self.__stored_data is not None else self.__upload
+        o_output_entity = self.__stored_data if self.__stored_data is not None else self.__upload if self.__upload is not None else "pas de donnée en sortie"
         Config().om.info(f"Exécution de traitement créée et lancée ({self.processing_execution}) et entité en sortie complétée ({o_output_entity}).")
         Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie : terminé")
+
+    def __gestion_new_output(self, datastore: Optional[str]) -> None:
+        """gestion des behaviors quand il y a création d'un nouveau traitement.
+
+        Args:
+            datastore (Optional[str]): Identifiant du datastore.
+        """
+        # TODO : gérer également les Livraisons
+        # On vérifie si une Donnée Stockée équivalente à celle du dictionnaire de définition (champ name) existe déjà sur la gpf
+        o_stored_data = self.find_stored_data(datastore)
+        # Si on a trouvé une Donnée Stockée sur la gpf :
+        if o_stored_data is None:
+            return
+        # Comportement d'arrêt du programme
+        if self.__behavior == self.BEHAVIOR_STOP:
+            raise GpfSdkError(f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_stored_data} existe déjà.")
+
+        # on met à jour o_stored_data pour avoir son status
+        o_stored_data.api_update()
+        # Comportement de suppression des entités détectées
+        if self.__behavior == self.BEHAVIOR_DELETE or (o_stored_data["status"] == StoredData.STATUS_UNSTABLE and self.__behavior == self.BEHAVIOR_RESUME):
+            Config().om.warning(f"Une donnée stockée équivalente à {o_stored_data} va être supprimée puis recréée.")
+            # Suppression de la donnée stockée
+            o_stored_data.api_delete()
+            # on force à None pour que la création soit faite
+            self.__processing_execution = None
+        # Comportement "on continue l'exécution"
+        elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
+            # on regarde si le résultat du traitement précédent est en échec (cas pour self.BEHAVIOR_RESUME, déjà traité)
+            if o_stored_data["status"] == StoredData.STATUS_UNSTABLE:
+                raise GpfSdkError(f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_stored_data}. Impossible de lancer le traitement demandé.")
+
+            # on est donc dans un des cas suivants :
+            # le processing_execution a été créé mais pas exécuté (StoredData.STATUS_CREATED)
+            # ou le processing execution est en cours d'exécution (StoredData.STATUS_GENERATING ou StoredData.STATUS_MODIFYING)
+            # ou le processing execution est terminé (StoredData.STATUS_GENERATED)
+            self.__stored_data = o_stored_data
+            l_proc_exec = ProcessingExecution.api_list({"output_stored_data": o_stored_data.id}, datastore=datastore)
+            if not l_proc_exec:
+                raise GpfSdkError(f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_stored_data}")
+            # arbitrairement, on prend le premier de la liste
+            self.__processing_execution = l_proc_exec[0]
+            Config().om.info(f"La donnée stocké en sortie {o_stored_data} déjà existante, on reprend le traitement associé : {self.__processing_execution}.")
+            return
+        # Comportement non reconnu
+        else:
+            raise GpfSdkError(f"Le comportement {self.__behavior} n'est pas reconnu ({'|'.join(self.BEHAVIORS)}), l'exécution de traitement n'est pas possible.")
 
     def __create_processing_execution(self, datastore: Optional[str] = None) -> None:
         """Création du ProcessingExecution sur l'API à partir des paramètres de définition de l'action.
@@ -73,56 +121,24 @@ class ProcessingExecutionAction(ActionAbstract):
 
         # On regarde si cette Exécution de Traitement implique la création d'une nouvelle entité (Livraison ou Donnée Stockée)
         if self.output_new_entity:
-            # TODO : gérer également les Livraisons
-            # On vérifie si une Donnée Stockée équivalente à celle du dictionnaire de définition (champ name) existe déjà sur la gpf
-            o_stored_data = self.find_stored_data(datastore)
-            # Si on a trouvé une Donnée Stockée sur la gpf :
-            if o_stored_data is not None:
-                # Comportement d'arrêt du programme
-                if self.__behavior == self.BEHAVIOR_STOP:
-                    raise GpfSdkError(f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_stored_data} existe déjà.")
-
-                # on met à jour o_stored_data pour avoir son status
-                o_stored_data.api_update()
-                # Comportement de suppression des entités détectées
-                if self.__behavior == self.BEHAVIOR_DELETE or (o_stored_data["status"] == StoredData.STATUS_UNSTABLE and self.__behavior == self.BEHAVIOR_RESUME):
-                    Config().om.warning(f"Une donnée stockée équivalente à {o_stored_data} va être supprimée puis recréée.")
-                    # Suppression de la donnée stockée
-                    o_stored_data.api_delete()
-                    # on force à None pour que la création soit faite
-                    self.__processing_execution = None
-                # Comportement "on continue l'exécution"
-                elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
-                    # on regarde si le résultat du traitement précédent est en échec (cas pour self.BEHAVIOR_RESUME, déjà traité)
-                    if o_stored_data["status"] == StoredData.STATUS_UNSTABLE:
-                        raise GpfSdkError(f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_stored_data}. Impossible de lancer le traitement demandé.")
-
-                    # on est donc dans un des cas suivants :
-                    # le processing_execution a été créé mais pas exécuté (StoredData.STATUS_CREATED)
-                    # ou le processing execution est en cours d'exécution (StoredData.STATUS_GENERATING ou StoredData.STATUS_MODIFYING)
-                    # ou le processing execution est terminé (StoredData.STATUS_GENERATED)
-                    self.__stored_data = o_stored_data
-                    l_proc_exec = ProcessingExecution.api_list({"output_stored_data": o_stored_data.id}, datastore=datastore)
-                    if not l_proc_exec:
-                        raise GpfSdkError(f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_stored_data}")
-                    # arbitrairement, on prend le premier de la liste
-                    self.__processing_execution = l_proc_exec[0]
-                    Config().om.info(f"La donnée stocké en sortie {o_stored_data} déjà existante, on reprend le traitement associé : {self.__processing_execution}.")
-                    return
-                # Comportement non reconnu
-                else:
-                    raise GpfSdkError(f"Le comportement {self.__behavior} n'est pas reconnu ({'|'.join(self.BEHAVIORS)}), l'exécution de traitement n'est pas possible.")
+            self.__gestion_new_output(datastore)
 
         # A ce niveau là, si on a encore self.__processing_execution qui est None, c'est qu'on peut créer l'Exécution de Traitement sans problème
         if self.__processing_execution is None:
             # création de la ProcessingExecution
             self.__processing_execution = ProcessingExecution.api_create(self.definition_dict["body_parameters"], {"datastore": datastore})
-            d_info = self.__processing_execution.get_store_properties()["output"]
+
+        # récupération de la sortie si elle existe
+        d_info = self.__processing_execution.get_store_properties().get("output", {"no_output": ""})
 
         if d_info is None:
             Config().om.debug(self.__processing_execution.to_json(indent=4))
             raise GpfSdkError("Erreur à la création de l'exécution de traitement : impossible de récupérer l'entité en sortie.")
 
+        if "no_output" in d_info:
+            Config().om.info("Traitement sans donnée en sortie")
+            self.__no_output = True
+            return
         # Récupération des entités de l'exécution de traitement
         if "upload" in d_info:
             # récupération de l'upload
@@ -136,7 +152,7 @@ class ProcessingExecutionAction(ActionAbstract):
 
     def __add_tags(self) -> None:
         """Ajout des tags sur l'Upload ou la StoredData en sortie du ProcessingExecution."""
-        if "tags" not in self.definition_dict or self.definition_dict["tags"] == {}:
+        if "tags" not in self.definition_dict or self.definition_dict["tags"] == {} or self.__no_output:
             # cas on a pas de tag ou vide: on ne fait rien
             return
         # on ajoute les tags
@@ -154,7 +170,7 @@ class ProcessingExecutionAction(ActionAbstract):
 
     def __add_comments(self) -> None:
         """Ajout des commentaires sur l'Upload ou la StoredData en sortie du ProcessingExecution."""
-        if "comments" not in self.definition_dict:
+        if "comments" not in self.definition_dict or self.__no_output:
             # cas on a pas de commentaires : on ne fait rien
             return
         # on ajoute les commentaires
@@ -317,15 +333,19 @@ class ProcessingExecutionAction(ActionAbstract):
         return self.__stored_data
 
     @property
+    def no_output(self) -> bool:
+        return self.__no_output
+
+    @property
     def output_new_entity(self) -> bool:
         """Indique s'il y aura création d'une nouvelle entité par rapport au paramètre de création de l'exécution de traitement
         (la clé "name" et non la clé "_id" est présente dans le paramètre "output" du corps de requête).
         """
-        d_output = self.definition_dict["body_parameters"]["output"]
+        d_output = self.definition_dict["body_parameters"].get("output", {})
         if "upload" in d_output:
-            d_el = self.definition_dict["body_parameters"]["output"]["upload"]
+            d_el = d_output["upload"]
         elif "stored_data" in d_output:
-            d_el = self.definition_dict["body_parameters"]["output"]["stored_data"]
+            d_el = d_output["stored_data"]
         else:
             return False
         return "name" in d_el

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from sdk_entrepot_gpf.io.Config import Config
@@ -8,6 +8,9 @@ from sdk_entrepot_gpf.store.StoredData import StoredData
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.store.Upload import Upload
+from sdk_entrepot_gpf.workflow.action.UploadAction import UploadAction
+
+# cSpell:ignore datasheet vectordb creat
 
 
 class ProcessingExecutionAction(ActionAbstract):
@@ -40,20 +43,28 @@ class ProcessingExecutionAction(ActionAbstract):
     # STATUS_GENERATING STATUS_MODIFYING
     # STATUS_GENERATED
 
-    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None) -> None:
+    def __init__(
+        self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None
+    ) -> None:
         super().__init__(workflow_context, definition_dict, parent_action)
         # l'exécution du traitement
         self.__processing_execution: Optional[ProcessingExecution] = None
         # les données en sortie
         self.__upload: Optional[Upload] = None
         self.__stored_data: Optional[StoredData] = None
+        self.__no_output = False
+        # donnée en entrée
+        self.__inputs_upload: Optional[List[Upload]] = None
+        self.__inputs_stored_data: Optional[List[StoredData]] = None
         # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut STOP
         self.__behavior: str = behavior if behavior is not None else Config().get_str("processing_execution", "behavior_if_exists")
+        self.__mode_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie...")
         # Création de l'exécution du traitement (attributs processing_execution et Upload/StoredData défini)
         self.__create_processing_execution(datastore)
+
         # Ajout des tags sur l'Upload ou la StoredData
         self.__add_tags()
         # Ajout des commentaires sur l'Upload ou la StoredData
@@ -61,9 +72,133 @@ class ProcessingExecutionAction(ActionAbstract):
         # Lancement du traitement
         self.__launch()
         # Affichage
-        o_output_entity = self.__stored_data if self.__stored_data is not None else self.__upload
+        o_output_entity = self.__stored_data if self.__stored_data is not None else self.__upload if self.__upload is not None else "pas de donnée en sortie"
         Config().om.info(f"Exécution de traitement créée et lancée ({self.processing_execution}) et entité en sortie complétée ({o_output_entity}).")
         Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie : terminé")
+
+    def __gestion_new_output(self, datastore: Optional[str]) -> None:
+        """gestion des behaviors quand il y a création d'un nouveau traitement.
+
+        Args:
+            datastore (Optional[str]): Identifiant du datastore.
+        """
+        # TODO : gérer également les Livraisons
+        # On vérifie si une Donnée Stockée équivalente à celle du dictionnaire de définition (champ name) existe déjà sur la gpf
+        o_stored_data = self.find_stored_data(datastore)
+        # Si on a trouvé une Donnée Stockée sur la gpf :
+        if o_stored_data is None:
+            return
+        # Comportement d'arrêt du programme
+        if self.__behavior == self.BEHAVIOR_STOP:
+            raise GpfSdkError(f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_stored_data} existe déjà.")
+
+        # on met à jour o_stored_data pour avoir son status
+        o_stored_data.api_update()
+        # Comportement de suppression des entités détectées
+        if self.__behavior == self.BEHAVIOR_DELETE or (o_stored_data["status"] == StoredData.STATUS_UNSTABLE and self.__behavior == self.BEHAVIOR_RESUME):
+            Config().om.warning(f"Une donnée stockée équivalente à {o_stored_data} va être supprimée puis recréée.")
+            # Suppression de la donnée stockée
+            o_stored_data.api_delete()
+            # on force à None pour que la création soit faite
+            self.__processing_execution = None
+        # Comportement "on continue l'exécution"
+        elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
+            # on regarde si le résultat du traitement précédent est en échec (cas pour self.BEHAVIOR_RESUME, déjà traité)
+            if o_stored_data["status"] == StoredData.STATUS_UNSTABLE:
+                raise GpfSdkError(f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_stored_data}. Impossible de lancer le traitement demandé.")
+
+            # on est donc dans un des cas suivants :
+            # le processing_execution a été créé mais pas exécuté (StoredData.STATUS_CREATED)
+            # ou le processing execution est en cours d'exécution (StoredData.STATUS_GENERATING ou StoredData.STATUS_MODIFYING)
+            # ou le processing execution est terminé (StoredData.STATUS_GENERATED)
+            self.__stored_data = o_stored_data
+            l_proc_exec = ProcessingExecution.api_list({"output_stored_data": o_stored_data.id}, datastore=datastore)
+            if not l_proc_exec:
+                raise GpfSdkError(f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_stored_data}")
+            # arbitrairement, on prend le premier de la liste
+            self.__processing_execution = l_proc_exec[0]
+            Config().om.info(f"La donnée stocké en sortie {o_stored_data} déjà existante, on reprend le traitement associé : {self.__processing_execution}.")
+            return
+        # Comportement non reconnu
+        else:
+            raise GpfSdkError(f"Le comportement {self.__behavior} n'est pas reconnu ({'|'.join(self.BEHAVIORS)}), l'exécution de traitement n'est pas possible.")
+
+    def __gestion_update_entity(self, datastore: Optional[str]) -> None:
+        """gestion des behaviors quand il y a mise à jour d'une entité.
+
+        Args:
+            datastore (Optional[str]): Identifiant du datastore.
+        """
+        if not "_id" in self.definition_dict["body_parameters"].get("output", {}).get("stored_data", {}):
+            # on ne gère que les mises à jour des stored_data
+            return
+        # On recherche le traitement entre les données en entrée et celle en sortie
+        o_stored_data = StoredData.api_get(self.definition_dict["body_parameters"]["output"]["stored_data"]["_id"], datastore=datastore)
+        # Si on a trouvé une Donnée Stockée sur la gpf :
+        if o_stored_data is None:
+            raise GpfSdkError("La donnée en sortie est introuvable, impossible de faire la mise à jour.")
+
+        d_filter = {
+            "output_stored_data": o_stored_data.id,
+            "processing": self.definition_dict["body_parameters"]["processing"],
+        }
+        if self.definition_dict["body_parameters"].get("inputs", {}).get("upload"):
+            d_filter["input_upload"] = self.definition_dict["body_parameters"]["inputs"]["upload"][0]
+        elif self.definition_dict["body_parameters"].get("inputs", {}).get("stored_data"):
+            d_filter["input_stored_data"] = self.definition_dict["body_parameters"]["inputs"]["stored_data"][0]
+
+        # On recherche le traitement
+        l_proc_exec = ProcessingExecution.api_list(d_filter, datastore=datastore)
+        # affinage de la recherche
+        for o_proc_exec in l_proc_exec:
+            o_proc_exec.api_update()
+            # vérification des entrées (si on a plus d'une entrée):
+            l_in_ids_upload = sorted(self.definition_dict["body_parameters"].get("inputs", {}).get("upload", []))
+            l_in_ids_stored_data = sorted(self.definition_dict["body_parameters"].get("inputs", {}).get("stored_data", []))
+            d_data_pe = o_proc_exec.get_store_properties()
+            l_pe_ids_upload = sorted([o_upload["_id"] for o_upload in d_data_pe.get("inputs", {}).get("upload", [])])
+            l_pe_ids_stored_data = sorted([o_upload["_id"] for o_upload in d_data_pe.get("inputs", {}).get("stored_data", [])])
+            if l_in_ids_upload == l_pe_ids_upload and l_in_ids_stored_data == l_pe_ids_stored_data and d_data_pe["parameters"] == self.definition_dict["body_parameters"].get("parameters", {}):
+                # les entrées, les sorties et paramètres correspondent, on a trouvé le traitement (o_proc_exec)
+                break
+        else:
+            # aucun traitement trouvé
+            return
+
+        # Comportement d'arrêt du programme
+        if self.__behavior == self.BEHAVIOR_STOP:
+            raise GpfSdkError(f"Le traitement a déjà été lancé pour mettre à jour cette donnée {o_proc_exec}.")
+
+        # on met à jour o_stored_data pour avoir son status
+        o_stored_data.api_update()
+        # Comportement de suppression des entités détectées (il n'est pas possible de supprimer la mise à jour précédente mais on relance la mise à jour)
+        if self.__behavior == self.BEHAVIOR_DELETE or (d_data_pe["status"] in [ProcessingExecution.STATUS_FAILURE, ProcessingExecution.STATUS_ABORTED] and self.__behavior == self.BEHAVIOR_RESUME):
+            Config().om.warning(f"Le traitement a déjà été lancé sans succès pour cette donnée ({o_proc_exec} statut {d_data_pe['status']}). On relance le traitement.")
+            # on force à None pour que la création soit faite
+            self.__processing_execution = None
+        # Comportement "on continue l'exécution"
+        elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
+            # on regarde si le résultat du traitement précédent est en échec (peut-être causé un autre traitement)
+            if o_stored_data["status"] == StoredData.STATUS_UNSTABLE:
+                raise GpfSdkError(
+                    (
+                        f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_stored_data}. "
+                        "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
+                        "pour faire réinitialiser son statut."
+                    )
+                )
+
+            # on est donc dans un des cas suivants :
+            # la processing_execution a été créé mais pas exécutée (StoredData.STATUS_CREATED)
+            # ou la processing_execution est en cours d'exécution (StoredData.STATUS_GENERATING ou StoredData.STATUS_MODIFYING)
+            # ou la processing_execution est terminée (StoredData.STATUS_GENERATED)
+            self.__stored_data = o_stored_data
+            self.__processing_execution = o_proc_exec
+            Config().om.info(f"La donnée stockée en sortie {o_stored_data} est en cours de mise à jour, on reprend le traitement associé : {self.__processing_execution}.")
+            return
+        # Comportement non reconnu
+        else:
+            raise GpfSdkError(f"Le comportement {self.__behavior} n'est pas reconnu ({'|'.join(self.BEHAVIORS)}), l'exécution de traitement n'est pas possible.")
 
     def __create_processing_execution(self, datastore: Optional[str] = None) -> None:
         """Création du ProcessingExecution sur l'API à partir des paramètres de définition de l'action.
@@ -73,56 +208,35 @@ class ProcessingExecutionAction(ActionAbstract):
 
         # On regarde si cette Exécution de Traitement implique la création d'une nouvelle entité (Livraison ou Donnée Stockée)
         if self.output_new_entity:
-            # TODO : gérer également les Livraisons
-            # On vérifie si une Donnée Stockée équivalente à celle du dictionnaire de définition (champ name) existe déjà sur la gpf
-            o_stored_data = self.find_stored_data(datastore)
-            # Si on a trouvé une Donnée Stockée sur la gpf :
-            if o_stored_data is not None:
-                # Comportement d'arrêt du programme
-                if self.__behavior == self.BEHAVIOR_STOP:
-                    raise GpfSdkError(f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_stored_data} existe déjà.")
+            self.__gestion_new_output(datastore)
 
-                # on met à jour o_stored_data pour avoir son status
-                o_stored_data.api_update()
-                # Comportement de suppression des entités détectées
-                if self.__behavior == self.BEHAVIOR_DELETE or (o_stored_data["status"] == StoredData.STATUS_UNSTABLE and self.__behavior == self.BEHAVIOR_RESUME):
-                    Config().om.warning(f"Une donnée stockée équivalente à {o_stored_data} va être supprimée puis recréée.")
-                    # Suppression de la donnée stockée
-                    o_stored_data.api_delete()
-                    # on force à None pour que la création soit faite
-                    self.__processing_execution = None
-                # Comportement "on continue l'exécution"
-                elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
-                    # on regarde si le résultat du traitement précédent est en échec (cas pour self.BEHAVIOR_RESUME, déjà traité)
-                    if o_stored_data["status"] == StoredData.STATUS_UNSTABLE:
-                        raise GpfSdkError(f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_stored_data}. Impossible de lancer le traitement demandé.")
-
-                    # on est donc dans un des cas suivants :
-                    # le processing_execution a été créé mais pas exécuté (StoredData.STATUS_CREATED)
-                    # ou le processing execution est en cours d'exécution (StoredData.STATUS_GENERATING ou StoredData.STATUS_MODIFYING)
-                    # ou le processing execution est terminé (StoredData.STATUS_GENERATED)
-                    self.__stored_data = o_stored_data
-                    l_proc_exec = ProcessingExecution.api_list({"output_stored_data": o_stored_data.id}, datastore=datastore)
-                    if not l_proc_exec:
-                        raise GpfSdkError(f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_stored_data}")
-                    # arbitrairement, on prend le premier de la liste
-                    self.__processing_execution = l_proc_exec[0]
-                    Config().om.info(f"La donnée stocké en sortie {o_stored_data} déjà existante, on reprend le traitement associé : {self.__processing_execution}.")
-                    return
-                # Comportement non reconnu
-                else:
-                    raise GpfSdkError(f"Le comportement {self.__behavior} n'est pas reconnu ({'|'.join(self.BEHAVIORS)}), l'exécution de traitement n'est pas possible.")
+        if self.output_update_entity:
+            self.__gestion_update_entity(datastore)
 
         # A ce niveau là, si on a encore self.__processing_execution qui est None, c'est qu'on peut créer l'Exécution de Traitement sans problème
         if self.__processing_execution is None:
             # création de la ProcessingExecution
             self.__processing_execution = ProcessingExecution.api_create(self.definition_dict["body_parameters"], {"datastore": datastore})
-            d_info = self.__processing_execution.get_store_properties()["output"]
+
+        d_data = self.__processing_execution.get_store_properties()
+
+        # récupération des entrées :
+        if "upload" in d_data.get("inputs", {}):
+            self.__inputs_upload = [Upload.api_get(d_upload["_id"], datastore=datastore) for d_upload in d_data["inputs"]["upload"]]
+        if "stored_data" in d_data.get("inputs", {}):
+            self.__inputs_stored_data = [StoredData.api_get(d_stored_data["_id"], datastore=datastore) for d_stored_data in d_data["inputs"]["stored_data"]]
+
+        # récupération de la sortie si elle existe
+        d_info = d_data.get("output", {"no_output": ""})
 
         if d_info is None:
             Config().om.debug(self.__processing_execution.to_json(indent=4))
             raise GpfSdkError("Erreur à la création de l'exécution de traitement : impossible de récupérer l'entité en sortie.")
 
+        if "no_output" in d_info:
+            Config().om.info("Traitement sans donnée en sortie")
+            self.__no_output = True
+            return
         # Récupération des entités de l'exécution de traitement
         if "upload" in d_info:
             # récupération de l'upload
@@ -136,17 +250,42 @@ class ProcessingExecutionAction(ActionAbstract):
 
     def __add_tags(self) -> None:
         """Ajout des tags sur l'Upload ou la StoredData en sortie du ProcessingExecution."""
-        if "tags" not in self.definition_dict or self.definition_dict["tags"] == {}:
-            # cas on a pas de tag ou vide: on ne fait rien
+        d_tags = self.definition_dict.get("tags", {})
+        # gestion des tags pour compatibility_cartes
+        if self.__mode_cartes and self.__processing_execution:
+            s_processing_id = self.__processing_execution.get_store_properties().get("processing", {"_id": ""})["_id"]
+            # mise en base de donnée livrée (vecteur)
+            if s_processing_id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+                if "datasheet_name" not in d_tags:
+                    raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+                if not self.__inputs_upload or not self.stored_data:
+                    raise GpfSdkError("Intégration de données vecteur livrées en base : input and output obligatoires")
+                for o_upload in self.__inputs_upload:
+                    # ajout des tags "mode cartes" permettant d'identifier le traitement et la donnée stockée liés à la livraison
+                    o_upload.api_add_tags({"proc_int_id": self.__processing_execution.id, "vectordb_id": self.stored_data.id})
+                    # ajout des tags "mode cartes" permettant de suivre l'étape du traitement
+                    UploadAction.add_carte_tags(self.__mode_cartes, o_upload, "execution_start")
+                d_tags["uuid_upload"] = self.__inputs_upload[0].id
+            # création de pyramide vecteur
+            elif s_processing_id == Config().get_str("compatibility_cartes", "id_pyramide_vecteur"):
+                if "datasheet_name" not in d_tags:
+                    raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+                if not self.__inputs_stored_data or not self.stored_data:
+                    raise GpfSdkError("Création de pyramide vecteur : input and output obligatoires")
+                d_tags["vectordb_id"] = self.__inputs_stored_data[0].id
+                d_tags["proc_pyr_creat_id"] = self.__processing_execution.id
+
+        if not self.definition_dict.get("tags") or self.__no_output:
+            # cas on a pas de tag ou pas de donnée en sortie: on ne fait rien
             return
         # on ajoute les tags
         if self.upload is not None:
             Config().om.info(f"Livraison {self.upload['name']} : ajout des {len(self.definition_dict['tags'])} tags...")
-            self.upload.api_add_tags(self.definition_dict["tags"])
+            self.upload.api_add_tags(d_tags)
             Config().om.info(f"Livraison {self.upload['name']} : les {len(self.definition_dict['tags'])} tags ont été ajoutés avec succès.")
         elif self.stored_data is not None:
             Config().om.info(f"Donnée stockée {self.stored_data['name']} : ajout des {len(self.definition_dict['tags'])} tags...")
-            self.stored_data.api_add_tags(self.definition_dict["tags"])
+            self.stored_data.api_add_tags(d_tags)
             Config().om.info(f"Donnée stockée {self.stored_data['name']} : les {len(self.definition_dict['tags'])} tags ont été ajoutés avec succès.")
         else:
             # on a pas de stored_data ni de upload
@@ -154,7 +293,7 @@ class ProcessingExecutionAction(ActionAbstract):
 
     def __add_comments(self) -> None:
         """Ajout des commentaires sur l'Upload ou la StoredData en sortie du ProcessingExecution."""
-        if "comments" not in self.definition_dict:
+        if "comments" not in self.definition_dict or self.__no_output:
             # cas on a pas de commentaires : on ne fait rien
             return
         # on ajoute les commentaires
@@ -301,6 +440,15 @@ class ProcessingExecutionAction(ActionAbstract):
         # Si on est sorti du while c'est que la processing execution est terminée
         ## dernier affichage
         callback_not_null(self.processing_execution)
+
+        # gestion du mode cartes
+        if self.__mode_cartes and self.processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+            if not self.__inputs_upload:
+                raise GpfSdkError("Intégration de données vecteur livrées en base : input and output obligatoires")
+            s_key = "execution_end_ok_integration_progress" if s_status == ProcessingExecution.STATUS_SUCCESS else "execution_end_ko_integration_progress"
+            for o_upload in self.__inputs_upload:
+                o_upload.api_add_tags({"integration_progress": Config().get_str("compatibility_cartes", s_key)})
+
         ## on return le status de fin
         return str(s_status)
 
@@ -317,18 +465,44 @@ class ProcessingExecutionAction(ActionAbstract):
         return self.__stored_data
 
     @property
+    def no_output(self) -> bool:
+        return self.__no_output
+
+    @property
+    def inputs_stored_data(self) -> Optional[List[StoredData]]:
+        return self.__inputs_stored_data
+
+    @property
+    def inputs_upload(self) -> Optional[List[Upload]]:
+        return self.__inputs_upload
+
+    @property
     def output_new_entity(self) -> bool:
         """Indique s'il y aura création d'une nouvelle entité par rapport au paramètre de création de l'exécution de traitement
         (la clé "name" et non la clé "_id" est présente dans le paramètre "output" du corps de requête).
         """
-        d_output = self.definition_dict["body_parameters"]["output"]
+        d_output = self.definition_dict["body_parameters"].get("output", {})
         if "upload" in d_output:
-            d_el = self.definition_dict["body_parameters"]["output"]["upload"]
+            d_el = d_output["upload"]
         elif "stored_data" in d_output:
-            d_el = self.definition_dict["body_parameters"]["output"]["stored_data"]
+            d_el = d_output["stored_data"]
         else:
             return False
         return "name" in d_el
+
+    @property
+    def output_update_entity(self) -> bool:
+        """Indique s'il y aura mise à jour d'une entité par rapport au paramètre de création de l'exécution de traitement
+        (la clé "_id" et non la clé "name" est présente dans le paramètre "output" du corps de requête).
+        """
+        d_output = self.definition_dict["body_parameters"].get("output", {})
+        if "upload" in d_output:
+            d_el = d_output["upload"]
+        elif "stored_data" in d_output:
+            d_el = d_output["stored_data"]
+        else:
+            return False
+        return "_id" in d_el
 
     ##############################################################
     # Fonctions de représentation

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -61,7 +61,7 @@ class ProcessingExecutionAction(ActionAbstract):
         self.__mode_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
-        Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie...")
+        Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie...", force_flush=True)
         # Création de l'exécution du traitement (attributs processing_execution et Upload/StoredData défini)
         self.__create_processing_execution(datastore)
 
@@ -322,11 +322,11 @@ class ProcessingExecutionAction(ActionAbstract):
             raise StepActionError("Aucune exécution de traitement trouvée. Impossible de lancer le traitement")
 
         if self.processing_execution["status"] == ProcessingExecution.STATUS_CREATED:
-            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : lancement...")
+            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : lancement...", force_flush=True)
             self.processing_execution.api_launch()
-            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : lancée avec succès.")
+            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : lancée avec succès.", force_flush=True)
         elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
-            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : déjà lancée.")
+            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : déjà lancée.", force_flush=True)
         else:
             # processing_execution est déjà lancé ET le __behavior n'est pas en "continue", on ne devrait pas être ici :
             raise StepActionError("L'exécution de traitement est déjà lancée.")
@@ -375,7 +375,7 @@ class ProcessingExecutionAction(ActionAbstract):
 
         # NOTE :  Ne pas utiliser self.__processing_execution mais self.processing_execution pour faciliter les tests
         i_nb_sec_between_check = Config().get_int("processing_execution", "nb_sec_between_check_updates")
-        Config().om.info(f"Monitoring du traitement toutes les {i_nb_sec_between_check} secondes...")
+        Config().om.info(f"Monitoring du traitement toutes les {i_nb_sec_between_check} secondes...", force_flush=True)
         if self.processing_execution is None:
             raise StepActionError("Aucune processing-execution trouvée. Impossible de suivre le déroulement du traitement")
 
@@ -411,7 +411,7 @@ class ProcessingExecutionAction(ActionAbstract):
                         raise
 
                     # arrêt du traitement
-                    Config().om.warning("Ctrl+C : traitement en cours d’interruption, veuillez attendre...")
+                    Config().om.warning("Ctrl+C : traitement en cours d’interruption, veuillez attendre...", force_flush=True)
                     self.processing_execution.api_abort()
                     # attente que le traitement passe dans un statut terminé
                     self.processing_execution.api_update()

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -103,6 +103,7 @@ class ProcessingExecutionAction(ActionAbstract):
             # ou le processing execution est terminé (StoredData.STATUS_GENERATED)
             self.__stored_data = o_stored_data
             l_proc_exec = ProcessingExecution.api_list({"output_stored_data": o_stored_data.id}, datastore=datastore)
+            print(l_proc_exec, "--", self.__behavior)
             if not l_proc_exec:
                 raise GpfSdkError(f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_stored_data}")
             # arbitrairement, on prend le premier de la liste
@@ -127,7 +128,9 @@ class ProcessingExecutionAction(ActionAbstract):
         if self.__processing_execution is None:
             # création de la ProcessingExecution
             self.__processing_execution = ProcessingExecution.api_create(self.definition_dict["body_parameters"], {"datastore": datastore})
-            d_info = self.__processing_execution.get_store_properties().get("output", {"no_output": ""})
+
+        # récupération de la sortie si elle existe
+        d_info = self.__processing_execution.get_store_properties().get("output", {"no_output": ""})
 
         if d_info is None:
             Config().om.debug(self.__processing_execution.to_json(indent=4))

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -333,6 +333,10 @@ class ProcessingExecutionAction(ActionAbstract):
         return self.__stored_data
 
     @property
+    def no_output(self) -> bool:
+        return self.__no_output
+
+    @property
     def output_new_entity(self) -> bool:
         """Indique s'il y aura création d'une nouvelle entité par rapport au paramètre de création de l'exécution de traitement
         (la clé "name" et non la clé "_id" est présente dans le paramètre "output" du corps de requête).

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -55,7 +55,7 @@ class ProcessingExecutionAction(ActionAbstract):
         self.__inputs_stored_data: Optional[List[StoredData]] = None
         # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut STOP
         self.__behavior: str = behavior if behavior is not None else Config().get_str("processing_execution", "behavior_if_exists")
-        self.__compatibility_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
+        self.__mode_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie...")
@@ -169,7 +169,7 @@ class ProcessingExecutionAction(ActionAbstract):
         """Ajout des tags sur l'Upload ou la StoredData en sortie du ProcessingExecution."""
         d_tags = self.definition_dict.get("tags", {})
         # gestion des tags pour compatibility_cartes
-        if self.__compatibility_cartes and self.__processing_execution:
+        if self.__mode_cartes and self.__processing_execution:
             # mise en base de donnée livrée (vecteur)
             if self.__processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
                 if "datasheet_name" not in d_tags:
@@ -361,8 +361,8 @@ class ProcessingExecutionAction(ActionAbstract):
         ## dernier affichage
         callback_not_null(self.processing_execution)
 
-        # gestion de __compatibility_cartes
-        if self.__compatibility_cartes and self.processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+        # gestion du mode cartes
+        if self.__mode_cartes and self.processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
             if not self.__inputs_upload:
                 raise GpfSdkError("Intégration de données vecteur livrées en base : input and output obligatoire")
             s_key = "execution_end_ok_integration_progress" if s_status == ProcessingExecution.STATUS_SUCCESS else "execution_end_ko_integration_progress"

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from sdk_entrepot_gpf.io.Config import Config
@@ -8,6 +8,9 @@ from sdk_entrepot_gpf.store.StoredData import StoredData
 from sdk_entrepot_gpf.workflow.Errors import StepActionError
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.store.Upload import Upload
+from sdk_entrepot_gpf.workflow.action.UploadAction import UploadAction
+
+# cSpell:ignore datasheet vectordb creat
 
 
 class ProcessingExecutionAction(ActionAbstract):
@@ -40,7 +43,9 @@ class ProcessingExecutionAction(ActionAbstract):
     # STATUS_GENERATING STATUS_MODIFYING
     # STATUS_GENERATED
 
-    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None) -> None:
+    def __init__(
+        self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None
+    ) -> None:
         super().__init__(workflow_context, definition_dict, parent_action)
         # l'exécution du traitement
         self.__processing_execution: Optional[ProcessingExecution] = None
@@ -48,13 +53,18 @@ class ProcessingExecutionAction(ActionAbstract):
         self.__upload: Optional[Upload] = None
         self.__stored_data: Optional[StoredData] = None
         self.__no_output = False
+        # donnée en entrée
+        self.__inputs_upload: Optional[List[Upload]] = None
+        self.__inputs_stored_data: Optional[List[StoredData]] = None
         # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut STOP
         self.__behavior: str = behavior if behavior is not None else Config().get_str("processing_execution", "behavior_if_exists")
+        self.__mode_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie...")
         # Création de l'exécution du traitement (attributs processing_execution et Upload/StoredData défini)
         self.__create_processing_execution(datastore)
+
         # Ajout des tags sur l'Upload ou la StoredData
         self.__add_tags()
         # Ajout des commentaires sur l'Upload ou la StoredData
@@ -208,8 +218,16 @@ class ProcessingExecutionAction(ActionAbstract):
             # création de la ProcessingExecution
             self.__processing_execution = ProcessingExecution.api_create(self.definition_dict["body_parameters"], {"datastore": datastore})
 
+        d_data = self.__processing_execution.get_store_properties()
+
+        # récupération des entrées :
+        if "upload" in d_data.get("inputs", {}):
+            self.__inputs_upload = [Upload.api_get(d_upload["_id"], datastore=datastore) for d_upload in d_data["inputs"]["upload"]]
+        if "stored_data" in d_data.get("inputs", {}):
+            self.__inputs_stored_data = [StoredData.api_get(d_stored_data["_id"], datastore=datastore) for d_stored_data in d_data["inputs"]["stored_data"]]
+
         # récupération de la sortie si elle existe
-        d_info = self.__processing_execution.get_store_properties().get("output", {"no_output": ""})
+        d_info = d_data.get("output", {"no_output": ""})
 
         if d_info is None:
             Config().om.debug(self.__processing_execution.to_json(indent=4))
@@ -232,17 +250,42 @@ class ProcessingExecutionAction(ActionAbstract):
 
     def __add_tags(self) -> None:
         """Ajout des tags sur l'Upload ou la StoredData en sortie du ProcessingExecution."""
-        if "tags" not in self.definition_dict or self.definition_dict["tags"] == {} or self.__no_output:
-            # cas on a pas de tag ou vide: on ne fait rien
+        d_tags = self.definition_dict.get("tags", {})
+        # gestion des tags pour compatibility_cartes
+        if self.__mode_cartes and self.__processing_execution:
+            s_processing_id = self.__processing_execution.get_store_properties().get("processing", {"_id": ""})["_id"]
+            # mise en base de donnée livrée (vecteur)
+            if s_processing_id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+                if "datasheet_name" not in d_tags:
+                    raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+                if not self.__inputs_upload or not self.stored_data:
+                    raise GpfSdkError("Intégration de données vecteur livrées en base : input and output obligatoires")
+                for o_upload in self.__inputs_upload:
+                    # ajout des tags "mode cartes" permettant d'identifier le traitement et la donnée stockée liés à la livraison
+                    o_upload.api_add_tags({"proc_int_id": self.__processing_execution.id, "vectordb_id": self.stored_data.id})
+                    # ajout des tags "mode cartes" permettant de suivre l'étape du traitement
+                    UploadAction.add_carte_tags(self.__mode_cartes, o_upload, "execution_start")
+                d_tags["uuid_upload"] = self.__inputs_upload[0].id
+            # création de pyramide vecteur
+            elif s_processing_id == Config().get_str("compatibility_cartes", "id_pyramide_vecteur"):
+                if "datasheet_name" not in d_tags:
+                    raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+                if not self.__inputs_stored_data or not self.stored_data:
+                    raise GpfSdkError("Création de pyramide vecteur : input and output obligatoires")
+                d_tags["vectordb_id"] = self.__inputs_stored_data[0].id
+                d_tags["proc_pyr_creat_id"] = self.__processing_execution.id
+
+        if not self.definition_dict.get("tags") or self.__no_output:
+            # cas on a pas de tag ou pas de donnée en sortie: on ne fait rien
             return
         # on ajoute les tags
         if self.upload is not None:
             Config().om.info(f"Livraison {self.upload['name']} : ajout des {len(self.definition_dict['tags'])} tags...")
-            self.upload.api_add_tags(self.definition_dict["tags"])
+            self.upload.api_add_tags(d_tags)
             Config().om.info(f"Livraison {self.upload['name']} : les {len(self.definition_dict['tags'])} tags ont été ajoutés avec succès.")
         elif self.stored_data is not None:
             Config().om.info(f"Donnée stockée {self.stored_data['name']} : ajout des {len(self.definition_dict['tags'])} tags...")
-            self.stored_data.api_add_tags(self.definition_dict["tags"])
+            self.stored_data.api_add_tags(d_tags)
             Config().om.info(f"Donnée stockée {self.stored_data['name']} : les {len(self.definition_dict['tags'])} tags ont été ajoutés avec succès.")
         else:
             # on a pas de stored_data ni de upload
@@ -397,6 +440,15 @@ class ProcessingExecutionAction(ActionAbstract):
         # Si on est sorti du while c'est que la processing execution est terminée
         ## dernier affichage
         callback_not_null(self.processing_execution)
+
+        # gestion du mode cartes
+        if self.__mode_cartes and self.processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+            if not self.__inputs_upload:
+                raise GpfSdkError("Intégration de données vecteur livrées en base : input and output obligatoires")
+            s_key = "execution_end_ok_integration_progress" if s_status == ProcessingExecution.STATUS_SUCCESS else "execution_end_ko_integration_progress"
+            for o_upload in self.__inputs_upload:
+                o_upload.api_add_tags({"integration_progress": Config().get_str("compatibility_cartes", s_key)})
+
         ## on return le status de fin
         return str(s_status)
 
@@ -415,6 +467,14 @@ class ProcessingExecutionAction(ActionAbstract):
     @property
     def no_output(self) -> bool:
         return self.__no_output
+
+    @property
+    def inputs_stored_data(self) -> Optional[List[StoredData]]:
+        return self.__inputs_stored_data
+
+    @property
+    def inputs_upload(self) -> Optional[List[Upload]]:
+        return self.__inputs_upload
 
     @property
     def output_new_entity(self) -> bool:

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from sdk_entrepot_gpf.io.Config import Config
@@ -40,7 +40,9 @@ class ProcessingExecutionAction(ActionAbstract):
     # STATUS_GENERATING STATUS_MODIFYING
     # STATUS_GENERATED
 
-    def __init__(self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None) -> None:
+    def __init__(
+        self, workflow_context: str, definition_dict: Dict[str, Any], parent_action: Optional["ActionAbstract"] = None, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None
+    ) -> None:
         super().__init__(workflow_context, definition_dict, parent_action)
         # l'exécution du traitement
         self.__processing_execution: Optional[ProcessingExecution] = None
@@ -48,13 +50,18 @@ class ProcessingExecutionAction(ActionAbstract):
         self.__upload: Optional[Upload] = None
         self.__stored_data: Optional[StoredData] = None
         self.__no_output = False
+        # donnée en entrée
+        self.__inputs_upload: Optional[List[Upload]] = None
+        self.__inputs_stored_data: Optional[List[StoredData]] = None
         # comportement (écrit dans la ligne de commande par l'utilisateur), sinon celui par défaut (dans la config) qui vaut STOP
         self.__behavior: str = behavior if behavior is not None else Config().get_str("processing_execution", "behavior_if_exists")
+        self.__mode_cartes: Optional[bool] = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate")
 
     def run(self, datastore: Optional[str] = None) -> None:
         Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie...")
         # Création de l'exécution du traitement (attributs processing_execution et Upload/StoredData défini)
         self.__create_processing_execution(datastore)
+
         # Ajout des tags sur l'Upload ou la StoredData
         self.__add_tags()
         # Ajout des commentaires sur l'Upload ou la StoredData
@@ -208,8 +215,16 @@ class ProcessingExecutionAction(ActionAbstract):
             # création de la ProcessingExecution
             self.__processing_execution = ProcessingExecution.api_create(self.definition_dict["body_parameters"], {"datastore": datastore})
 
+        d_data = self.__processing_execution.get_store_properties()
+
+        # récupération des entrées :
+        if "upload" in d_data.get("inputs", {}):
+            self.__inputs_upload = [Upload.api_get(d_upload["_id"], datastore=datastore) for d_upload in d_data["inputs"]["upload"]]
+        if "stored_data" in d_data.get("inputs", {}):
+            self.__inputs_stored_data = [StoredData.api_get(d_stored_data["_id"], datastore=datastore) for d_stored_data in d_data["inputs"]["stored_data"]]
+
         # récupération de la sortie si elle existe
-        d_info = self.__processing_execution.get_store_properties().get("output", {"no_output": ""})
+        d_info = d_data.get("output", {"no_output": ""})
 
         if d_info is None:
             Config().om.debug(self.__processing_execution.to_json(indent=4))
@@ -232,17 +247,45 @@ class ProcessingExecutionAction(ActionAbstract):
 
     def __add_tags(self) -> None:
         """Ajout des tags sur l'Upload ou la StoredData en sortie du ProcessingExecution."""
-        if "tags" not in self.definition_dict or self.definition_dict["tags"] == {} or self.__no_output:
-            # cas on a pas de tag ou vide: on ne fait rien
+        d_tags = self.definition_dict.get("tags", {})
+        # gestion des tags pour compatibility_cartes
+        if self.__mode_cartes and self.__processing_execution:
+            # mise en base de donnée livrée (vecteur)
+            if self.__processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+                if "datasheet_name" not in d_tags:
+                    raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+                if not self.__inputs_upload or not self.stored_data:
+                    raise GpfSdkError("Intégration de données vecteur livrées en base : input and output obligatoire")
+                for o_upload in self.__inputs_upload:
+                    o_upload.api_add_tags(
+                        {
+                            "integration_progress": Config().get_str("compatibility_cartes", "execution_start_integration_progress"),
+                            "integration_current_step": Config().get_str("compatibility_cartes", "execution_start_integration_current_step"),
+                            "proc_int_id": self.__processing_execution.id,
+                            "vectordb_id": self.stored_data.id,
+                        }
+                    )
+                d_tags["uuid_upload"] = self.__inputs_upload[0].id
+            # création de pyramide vecteur
+            elif self.__processing_execution.id == Config().get_str("compatibility_cartes", "id_pyramide_vecteur"):
+                if "datasheet_name" not in d_tags:
+                    raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+                if not self.__inputs_stored_data or not self.stored_data:
+                    raise GpfSdkError("Création de pyramide vecteur : input and output obligatoire")
+                d_tags["vectordb_id"] = self.__inputs_stored_data[0].id
+                d_tags["proc_pyr_creat_id"] = self.__processing_execution.id
+
+        if not self.definition_dict.get("tags") or self.__no_output:
+            # cas on a pas de tag ou pas de donnée en sortie: on ne fait rien
             return
         # on ajoute les tags
         if self.upload is not None:
             Config().om.info(f"Livraison {self.upload['name']} : ajout des {len(self.definition_dict['tags'])} tags...")
-            self.upload.api_add_tags(self.definition_dict["tags"])
+            self.upload.api_add_tags(d_tags)
             Config().om.info(f"Livraison {self.upload['name']} : les {len(self.definition_dict['tags'])} tags ont été ajoutés avec succès.")
         elif self.stored_data is not None:
             Config().om.info(f"Donnée stockée {self.stored_data['name']} : ajout des {len(self.definition_dict['tags'])} tags...")
-            self.stored_data.api_add_tags(self.definition_dict["tags"])
+            self.stored_data.api_add_tags(d_tags)
             Config().om.info(f"Donnée stockée {self.stored_data['name']} : les {len(self.definition_dict['tags'])} tags ont été ajoutés avec succès.")
         else:
             # on a pas de stored_data ni de upload
@@ -397,6 +440,15 @@ class ProcessingExecutionAction(ActionAbstract):
         # Si on est sorti du while c'est que la processing execution est terminée
         ## dernier affichage
         callback_not_null(self.processing_execution)
+
+        # gestion du mode cartes
+        if self.__mode_cartes and self.processing_execution.id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+            if not self.__inputs_upload:
+                raise GpfSdkError("Intégration de données vecteur livrées en base : input and output obligatoire")
+            s_key = "execution_end_ok_integration_progress" if s_status == ProcessingExecution.STATUS_SUCCESS else "execution_end_ko_integration_progress"
+            for o_upload in self.__inputs_upload:
+                o_upload.api_add_tags({"integration_progress": Config().get_str("compatibility_cartes", s_key)})
+
         ## on return le status de fin
         return str(s_status)
 
@@ -415,6 +467,14 @@ class ProcessingExecutionAction(ActionAbstract):
     @property
     def no_output(self) -> bool:
         return self.__no_output
+
+    @property
+    def inputs_stored_data(self) -> Optional[List[StoredData]]:
+        return self.__inputs_stored_data
+
+    @property
+    def inputs_upload(self) -> Optional[List[Upload]]:
+        return self.__inputs_upload
 
     @property
     def output_new_entity(self) -> bool:

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -260,9 +260,9 @@ class ProcessingExecutionAction(ActionAbstract):
                 if not self.__inputs_upload or not self.stored_data:
                     raise GpfSdkError("Intégration de données vecteur livrées en base : input and output obligatoires")
                 for o_upload in self.__inputs_upload:
-                    # ajout des tags génériques
+                    # ajout des tags "mode cartes" permettant d'identifier le traitement et la donnée stockée liés à la livraison
                     o_upload.api_add_tags({"proc_int_id": self.__processing_execution.id, "vectordb_id": self.stored_data.id})
-                    # ajout des tags spécifiques au mode cartes
+                    # ajout des tags "mode cartes" permettant de suivre l'étape du traitement
                     UploadAction.add_carte_tags(self.__mode_cartes, o_upload, "execution_start")
                 d_tags["uuid_upload"] = self.__inputs_upload[0].id
             # création de pyramide vecteur

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -253,8 +253,9 @@ class ProcessingExecutionAction(ActionAbstract):
         d_tags = self.definition_dict.get("tags", {})
         # gestion des tags pour compatibility_cartes
         if self.__mode_cartes and self.__processing_execution:
+            s_processing_id = self.__processing_execution.get_store_properties().get("processing", {"_id": ""})["_id"]
             # mise en base de donnée livrée (vecteur)
-            if self.__processing_execution.get_store_properties().get("processing", {"_id": ""})["_id"] == Config().get_str("compatibility_cartes", "id_mise_en_base"):
+            if s_processing_id == Config().get_str("compatibility_cartes", "id_mise_en_base"):
                 if "datasheet_name" not in d_tags:
                     raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
                 if not self.__inputs_upload or not self.stored_data:
@@ -266,7 +267,7 @@ class ProcessingExecutionAction(ActionAbstract):
                     UploadAction.add_carte_tags(self.__mode_cartes, o_upload, "execution_start")
                 d_tags["uuid_upload"] = self.__inputs_upload[0].id
             # création de pyramide vecteur
-            elif self.__processing_execution.id == Config().get_str("compatibility_cartes", "id_pyramide_vecteur"):
+            elif s_processing_id == Config().get_str("compatibility_cartes", "id_pyramide_vecteur"):
                 if "datasheet_name" not in d_tags:
                     raise GpfSdkError("Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
                 if not self.__inputs_stored_data or not self.stored_data:

--- a/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
+++ b/sdk_entrepot_gpf/workflow/action/ProcessingExecutionAction.py
@@ -52,7 +52,7 @@ class ProcessingExecutionAction(ActionAbstract):
         self.__behavior: str = behavior if behavior is not None else Config().get_str("processing_execution", "behavior_if_exists")
 
     def run(self, datastore: Optional[str] = None) -> None:
-        Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie...")
+        Config().om.info("Création d'une exécution de traitement et complétion de l'entité en sortie...", force_flush=True)
         # Création de l'exécution du traitement (attributs processing_execution et Upload/StoredData défini)
         self.__create_processing_execution(datastore)
         # Ajout des tags sur l'Upload ou la StoredData
@@ -279,11 +279,11 @@ class ProcessingExecutionAction(ActionAbstract):
             raise StepActionError("Aucune exécution de traitement trouvée. Impossible de lancer le traitement")
 
         if self.processing_execution["status"] == ProcessingExecution.STATUS_CREATED:
-            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : lancement...")
+            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : lancement...", force_flush=True)
             self.processing_execution.api_launch()
-            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : lancée avec succès.")
+            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : lancée avec succès.", force_flush=True)
         elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
-            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : déjà lancée.")
+            Config().om.info(f"Exécution de traitement {self.processing_execution['processing']['name']} : déjà lancée.", force_flush=True)
         else:
             # processing_execution est déjà lancé ET le __behavior n'est pas en "continue", on ne devrait pas être ici :
             raise StepActionError("L'exécution de traitement est déjà lancée.")
@@ -332,7 +332,7 @@ class ProcessingExecutionAction(ActionAbstract):
 
         # NOTE :  Ne pas utiliser self.__processing_execution mais self.processing_execution pour faciliter les tests
         i_nb_sec_between_check = Config().get_int("processing_execution", "nb_sec_between_check_updates")
-        Config().om.info(f"Monitoring du traitement toutes les {i_nb_sec_between_check} secondes...")
+        Config().om.info(f"Monitoring du traitement toutes les {i_nb_sec_between_check} secondes...", force_flush=True)
         if self.processing_execution is None:
             raise StepActionError("Aucune processing-execution trouvée. Impossible de suivre le déroulement du traitement")
 
@@ -368,7 +368,7 @@ class ProcessingExecutionAction(ActionAbstract):
                         raise
 
                     # arrêt du traitement
-                    Config().om.warning("Ctrl+C : traitement en cours d’interruption, veuillez attendre...")
+                    Config().om.warning("Ctrl+C : traitement en cours d’interruption, veuillez attendre...", force_flush=True)
                     self.processing_execution.api_abort()
                     # attente que le traitement passe dans un statut terminé
                     self.processing_execution.api_update()

--- a/sdk_entrepot_gpf/workflow/action/SynchronizeOfferingAction.py
+++ b/sdk_entrepot_gpf/workflow/action/SynchronizeOfferingAction.py
@@ -77,7 +77,7 @@ class SynchronizeOfferingAction(ActionAbstract):
             StepActionError: Plusieurs offres trouvées pour la synchronisation (uniquement si "if_multi" == "error")
             StepActionError: La synchronisation d'au moins une offre est terminée en erreur
         """
-        Config().om.info("Synchronisation d'offres ...")
+        Config().om.info("Synchronisation d'offres ...", force_flush=True)
         # récupération des offres
         l_offering = self._find_offerings(datastore)
         # gestion des cas particuliers
@@ -119,7 +119,7 @@ class SynchronizeOfferingAction(ActionAbstract):
             ## Récupération des liens
             Config().om.info(f"Offre synchronisée : {o_offering}\n   - " + "\n   - ".join(o_offering.get_url()), green_colored=True)
             ## vérification du status.
-            Config().om.info("vérification du statut ...")
+            Config().om.info("vérification du statut ...", force_flush=True)
             while True:
                 o_offering.api_update()
                 s_status = o_offering["status"]

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -33,8 +33,8 @@ class UploadAction:
 
         Args:
             dataset (Dataset): _description_
-            mode_cartes (Optional[bool]): récupère l'information du fonctionnement en mode compatibilité avec cartes.gouv
             behavior (Optional[str], optional): _description_. Defaults to None.
+            mode_cartes (Optional[bool]): récupère l'information du fonctionnement en mode compatibilité avec cartes.gouv
         """
         self.__dataset: Dataset = dataset
         self.__upload: Optional[Upload] = None

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -133,9 +133,9 @@ class UploadAction:
         if not self.__mode_cartes and not self.__dataset.tags['datasheet_name']:
             raise GpfSdkError('En mode compatibilité avec cartes.gouv tag contenant le nom de la fiche de donnée est obligatoire')
         if self.__upload is not None and self.__dataset.tags:
-                Config().om.info(f"Livraison {self.__upload['name']} : ajout des {len(self.__dataset.tags)} tags...")
-                self.__upload.api_add_tags(self.__dataset.tags)
-                Config().om.info(f"Livraison {self.__upload['name']} : les {len(self.__dataset.tags)} tags ont été ajoutés avec succès.")
+            Config().om.info(f"Livraison {self.__upload['name']} : ajout des {len(self.__dataset.tags)} tags...")
+            self.__upload.api_add_tags(self.__dataset.tags)
+            Config().om.info(f"Livraison {self.__upload['name']} : les {len(self.__dataset.tags)} tags ont été ajoutés avec succès.")
     def __add_comments(self) -> None:
         """Ajoute les commentaires."""
         if self.__upload is not None:

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -67,7 +67,7 @@ class UploadAction:
         # Envoie des fichiers md5 (pas de vérification sur les problèmes de livraison si check_before_close)
         self.__push_md5_files(not check_before_close)
         if check_before_close:
-            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescent avant livraison ...")
+            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescence avant livraison ...")
             # vérification de la livraison des fichiers de données + ficher md5
             l_error = self.__check_file_uploaded(list(self.__dataset.data_files.items()) + [(p_file, "") for p_file in self.__dataset.md5_files])
             if l_error:

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -80,7 +80,7 @@ class UploadAction:
         # Envoie des fichiers md5 (pas de vérification sur les problèmes de livraison si check_before_close)
         self.__push_md5_files(not check_before_close)
         if check_before_close:
-            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescent avant livraison ...")
+            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescence avant livraison ...")
             # vérification de la livraison des fichiers de données + ficher md5
             l_error = self.__check_file_uploaded(list(self.__dataset.data_files.items()) + [(p_file, "") for p_file in self.__dataset.md5_files])
             if l_error:

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -143,7 +143,7 @@ class UploadAction:
 
     @staticmethod
     def add_carte_tags(mode_cartes: bool, upload: Optional[Upload], upload_step: str) -> None:
-        """En mode cartes.gouv, ajoute les tags nécessaires."""
+        """En mode cartes, ajoute les tags nécessaires."""
         # lister toutes les clés dans la section compatibility_cartes, filtrer chaque clé qui commence par upload_step,
         # mettre la fin de la clé dans un tag et mettre la value (en string) comme value du tag (self.__upload.api_add_tags(...))
         if not mode_cartes:
@@ -159,7 +159,7 @@ class UploadAction:
                 upload.api_add_tags(d_tag)
 
     def __add_carte_tags(self, upload_step: str) -> None:
-        """En mode cartes.gouv, ajoute les tags nécessaires via la méthode statique."""
+        """En mode cartes, ajoute les tags nécessaires via la méthode statique."""
         UploadAction.add_carte_tags(self.__mode_cartes, self.__upload, upload_step)
 
     def __add_comments(self) -> None:

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -28,19 +28,19 @@ class UploadAction:
     BEHAVIOR_CONTINUE = "CONTINUE"
     BEHAVIORS = [BEHAVIOR_STOP, BEHAVIOR_CONTINUE, BEHAVIOR_DELETE]
 
-    def __init__(self, dataset: Dataset, behavior: Optional[str] = None, mode_cartes: Optional[bool] = None) -> None:
+    def __init__(self, dataset: Dataset, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None) -> None:
         """initialise le comportement de UploadAction
 
         Args:
             dataset (Dataset): _description_
             behavior (Optional[str], optional): _description_. Defaults to None.
-            mode_cartes (Optional[bool]): récupère l'information du fonctionnement en mode compatibilité avec cartes.gouv
+            compatibility_cartes (Optional[bool]): récupère l'information du fonctionnement en mode compatibilité avec cartes.gouv
         """
         self.__dataset: Dataset = dataset
         self.__upload: Optional[Upload] = None
         # On suit le comportement donnée en paramètre ou à défaut celui de la config
         self.__behavior: str = behavior if behavior is not None else Config().get_str("upload", "behavior_if_exists")
-        self.__mode_cartes = mode_cartes if mode_cartes is not None else Config().get_bool("compatibility_cartes", "activate", False)
+        self.__mode_cartes = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate", False)
 
     def run(self, datastore: Optional[str], check_before_close: bool = False) -> Upload:
         """Crée la livraison décrite dans le dataset et livre les données avant de
@@ -58,7 +58,7 @@ class UploadAction:
         """
         # test: si le mode carte est actif alors le data_sheet doit être présent
         if self.__mode_cartes and not self.__dataset.tags["datasheet_name"]:
-            raise GpfSdkError("En mode compatibilité avec le site cartes.gouv: le nom de la fiche de donnée est obligatoire")
+            raise GpfSdkError("En mode compatibilité avec cartes.gouv, le tag datasheet_name contenant le nom de la fiche de donnée est obligatoire")
         Config().om.info("Création et complétion d'une livraison...")
         # Création de la livraison
         self.__create_upload(datastore)

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -28,11 +28,19 @@ class UploadAction:
     BEHAVIOR_CONTINUE = "CONTINUE"
     BEHAVIORS = [BEHAVIOR_STOP, BEHAVIOR_CONTINUE, BEHAVIOR_DELETE]
 
-    def __init__(self, dataset: Dataset, behavior: Optional[str] = None) -> None:
+    def __init__(self, dataset: Dataset, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None) -> None:
+        """initialise le comportement de UploadAction
+
+        Args:
+            dataset (Dataset): _description_
+            behavior (Optional[str], optional): _description_. Defaults to None.
+            compatibility_cartes (Optional[bool]): récupère l'information du fonctionnement en mode compatibilité avec cartes.gouv
+        """
         self.__dataset: Dataset = dataset
         self.__upload: Optional[Upload] = None
         # On suit le comportement donnée en paramètre ou à défaut celui de la config
         self.__behavior: str = behavior if behavior is not None else Config().get_str("upload", "behavior_if_exists")
+        self.__mode_cartes = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate", False)
 
     def run(self, datastore: Optional[str], check_before_close: bool = False) -> Upload:
         """Crée la livraison décrite dans le dataset et livre les données avant de
@@ -48,26 +56,31 @@ class UploadAction:
         Returns:
             livraison créée
         """
+        # test: si le mode carte est actif alors le data_sheet doit être présent
+        if self.__mode_cartes and not self.__dataset.tags["datasheet_name"]:
+            raise GpfSdkError("En mode compatibilité avec cartes.gouv, le tag datasheet_name contenant le nom de la fiche de donnée est obligatoire")
         Config().om.info("Création et complétion d'une livraison...")
         # Création de la livraison
         self.__create_upload(datastore)
-
         if not self.upload:
             raise GpfSdkError("Erreur à la création de la livraison.")
         # Cas livraison fermé = déjà traité : on sort
         if not self.upload.is_open():
             return self.upload
+        self.__add_carte_tags("upload_creation")
 
         # Ajout des tags
         self.__add_tags()
         # Ajout des commentaires
         self.__add_comments()
+
+        self.__add_carte_tags("upload_upload_start")
         # Envoie des fichiers de données (pas de vérification sur les problèmes de livraison si check_before_close)
         self.__push_data_files(not check_before_close)
         # Envoie des fichiers md5 (pas de vérification sur les problèmes de livraison si check_before_close)
         self.__push_md5_files(not check_before_close)
         if check_before_close:
-            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescent avant livraison ...")
+            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescence avant livraison ...")
             # vérification de la livraison des fichiers de données + ficher md5
             l_error = self.__check_file_uploaded(list(self.__dataset.data_files.items()) + [(p_file, "") for p_file in self.__dataset.md5_files])
             if l_error:
@@ -79,6 +92,7 @@ class UploadAction:
             # Affichage
             Config().om.info(f"Livraison créée et complétée : {self.upload}")
             Config().om.info("Création et complétion d'une livraison : terminé")
+            self.__add_carte_tags("upload_upload_end")
             # Retour
             return self.upload
         # On ne devrait pas arriver ici...
@@ -127,6 +141,27 @@ class UploadAction:
             self.__upload.api_add_tags(self.__dataset.tags)
             Config().om.info(f"Livraison {self.__upload['name']} : les {len(self.__dataset.tags)} tags ont été ajoutés avec succès.")
 
+    @staticmethod
+    def add_carte_tags(mode_cartes: bool, upload: Optional[Upload], upload_step: str) -> None:
+        """En mode cartes, ajoute les tags nécessaires."""
+        # lister toutes les clés dans la section compatibility_cartes, filtrer chaque clé qui commence par upload_step,
+        # mettre la fin de la clé dans un tag et mettre la value (en string) comme value du tag (self.__upload.api_add_tags(...))
+        if not mode_cartes:
+            return
+        d_section = Config().get_config()["compatibility_cartes"]
+        if upload is not None and d_section is not None:
+            d_tag = {}
+            for s_key, s_val in d_section.items():
+                if s_key.startswith(upload_step):
+                    # on va chercher la fin du mot clé (apres le upload_step et le underscore)
+                    d_tag[s_key[len(upload_step) + 1 :]] = str(s_val)
+            if d_tag:
+                upload.api_add_tags(d_tag)
+
+    def __add_carte_tags(self, upload_step: str) -> None:
+        """En mode cartes, ajoute les tags nécessaires via la méthode statique."""
+        UploadAction.add_carte_tags(self.__mode_cartes, self.__upload, upload_step)
+
     def __add_comments(self) -> None:
         """Ajoute les commentaires."""
         if self.__upload is not None:
@@ -171,7 +206,7 @@ class UploadAction:
             Config().om.info(f"Livraison {self.__upload}: les {len(self.__dataset.md5_files)} fichiers md5 ont été ajoutés avec succès. ({i_file_upload} livré(s) lors de ce traitement)")
 
     def __normalise_api_push_md5_file(self, path: Path, nom: str) -> None:
-        """fonction cachant api_push_md5_file pour avoir une fonction ayant les même entrées que api_push_data_file, utilisé comme paramétre de __push_files
+        """fonction cachant api_push_md5_file pour avoir une fonction ayant les même entrées que api_push_data_file, utilisé comme paramètre de __push_files
 
         Args:
             path (Path): chemin le la chef MD5
@@ -304,7 +339,7 @@ class UploadAction:
         return self.__upload
 
     @staticmethod
-    def monitor_until_end(upload: Upload, callback: Optional[Callable[[str], None]] = None, ctrl_c_action: Optional[Callable[[], bool]] = None) -> bool:
+    def monitor_until_end(upload: Upload, callback: Optional[Callable[[str], None]] = None, ctrl_c_action: Optional[Callable[[], bool]] = None, mode_cartes: Optional[bool] = None) -> bool:
         """Attend que toute les vérifications liées à la Livraison indiquée
         soient terminées (en erreur ou en succès) avant de rendre la main.
 
@@ -377,10 +412,13 @@ class UploadAction:
 
         # Si on est sorti du while c'est que les vérifications sont terminées
         # On log le dernier rapport selon l'état et on sort
+        mode_cartes = mode_cartes if mode_cartes is not None else Config().get_bool("compatibility_cartes", "activate", False)
         if b_success:
             Config().om.info(s_message)
+            UploadAction.add_carte_tags(mode_cartes, upload, "upload_check_ok")
             return True
         Config().om.warning(s_message)
+        UploadAction.add_carte_tags(mode_cartes, upload, "upload_check_ko")
         return False
 
     @staticmethod

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -28,11 +28,19 @@ class UploadAction:
     BEHAVIOR_CONTINUE = "CONTINUE"
     BEHAVIORS = [BEHAVIOR_STOP, BEHAVIOR_CONTINUE, BEHAVIOR_DELETE]
 
-    def __init__(self, dataset: Dataset, behavior: Optional[str] = None) -> None:
+    def __init__(self, dataset: Dataset, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None) -> None:
+        """initialise le comportement de UploadAction
+
+        Args:
+            dataset (Dataset): _description_
+            behavior (Optional[str], optional): _description_. Defaults to None.
+            compatibility_cartes (Optional[bool]): récupère l'information du fonctionnement en mode compatibilité avec cartes.gouv
+        """
         self.__dataset: Dataset = dataset
         self.__upload: Optional[Upload] = None
         # On suit le comportement donnée en paramètre ou à défaut celui de la config
         self.__behavior: str = behavior if behavior is not None else Config().get_str("upload", "behavior_if_exists")
+        self.__mode_cartes = compatibility_cartes if compatibility_cartes is not None else Config().get_bool("compatibility_cartes", "activate", False)
 
     def run(self, datastore: Optional[str], check_before_close: bool = False) -> Upload:
         """Crée la livraison décrite dans le dataset et livre les données avant de
@@ -49,19 +57,24 @@ class UploadAction:
             livraison créée
         """
         Config().om.info("Création et complétion d'une livraison...", force_flush=True)
+        # test: si le mode carte est actif alors le tag datasheet_name doit être présent
+        if self.__mode_cartes and not self.__dataset.tags["datasheet_name"]:
+            raise GpfSdkError("En mode compatibilité avec cartes.gouv, le tag datasheet_name contenant le nom de la fiche de donnée est obligatoire")
         # Création de la livraison
         self.__create_upload(datastore)
-
         if not self.upload:
             raise GpfSdkError("Erreur à la création de la livraison.")
         # Cas livraison fermé = déjà traité : on sort
         if not self.upload.is_open():
             return self.upload
+        self.__add_carte_tags("upload_creation")
 
         # Ajout des tags
         self.__add_tags()
         # Ajout des commentaires
         self.__add_comments()
+
+        self.__add_carte_tags("upload_upload_start")
         # Envoie des fichiers de données (pas de vérification sur les problèmes de livraison si check_before_close)
         self.__push_data_files(not check_before_close)
         # Envoie des fichiers md5 (pas de vérification sur les problèmes de livraison si check_before_close)
@@ -79,6 +92,7 @@ class UploadAction:
             # Affichage
             Config().om.info(f"Livraison créée et complétée : {self.upload}")
             Config().om.info("Création et complétion d'une livraison : terminé")
+            self.__add_carte_tags("upload_upload_end")
             # Retour
             return self.upload
         # On ne devrait pas arriver ici...
@@ -127,6 +141,27 @@ class UploadAction:
             self.__upload.api_add_tags(self.__dataset.tags)
             Config().om.info(f"Livraison {self.__upload['name']} : les {len(self.__dataset.tags)} tags ont été ajoutés avec succès.")
 
+    @staticmethod
+    def add_carte_tags(mode_cartes: bool, upload: Optional[Upload], upload_step: str) -> None:
+        """En mode cartes, ajoute les tags nécessaires."""
+        # lister toutes les clés dans la section compatibility_cartes, filtrer chaque clé qui commence par upload_step,
+        # mettre la fin de la clé dans un tag et mettre la value (en string) comme value du tag (self.__upload.api_add_tags(...))
+        if not mode_cartes:
+            return
+        d_section = Config().get_config()["compatibility_cartes"]
+        if upload is not None and d_section is not None:
+            d_tag = {}
+            for s_key, s_val in d_section.items():
+                if s_key.startswith(upload_step):
+                    # on va chercher la fin du mot clé (apres le upload_step et le underscore)
+                    d_tag[s_key[len(upload_step) + 1 :]] = str(s_val)
+            if d_tag:
+                upload.api_add_tags(d_tag)
+
+    def __add_carte_tags(self, upload_step: str) -> None:
+        """En mode cartes, ajoute les tags nécessaires via la méthode statique."""
+        UploadAction.add_carte_tags(self.__mode_cartes, self.__upload, upload_step)
+
     def __add_comments(self) -> None:
         """Ajoute les commentaires."""
         if self.__upload is not None:
@@ -171,7 +206,7 @@ class UploadAction:
             Config().om.info(f"Livraison {self.__upload}: les {len(self.__dataset.md5_files)} fichiers md5 ont été ajoutés avec succès. ({i_file_upload} livré(s) lors de ce traitement)")
 
     def __normalise_api_push_md5_file(self, path: Path, nom: str) -> None:
-        """fonction cachant api_push_md5_file pour avoir une fonction ayant les même entrées que api_push_data_file, utilisé comme paramétre de __push_files
+        """fonction cachant api_push_md5_file pour avoir une fonction ayant les même entrées que api_push_data_file, utilisé comme paramètre de __push_files
 
         Args:
             path (Path): chemin le la chef MD5
@@ -304,7 +339,7 @@ class UploadAction:
         return self.__upload
 
     @staticmethod
-    def monitor_until_end(upload: Upload, callback: Optional[Callable[[str], None]] = None, ctrl_c_action: Optional[Callable[[], bool]] = None) -> bool:
+    def monitor_until_end(upload: Upload, callback: Optional[Callable[[str], None]] = None, ctrl_c_action: Optional[Callable[[], bool]] = None, mode_cartes: Optional[bool] = None) -> bool:
         """Attend que toute les vérifications liées à la Livraison indiquée
         soient terminées (en erreur ou en succès) avant de rendre la main.
 
@@ -377,10 +412,13 @@ class UploadAction:
 
         # Si on est sorti du while c'est que les vérifications sont terminées
         # On log le dernier rapport selon l'état et on sort
+        mode_cartes = mode_cartes if mode_cartes is not None else Config().get_bool("compatibility_cartes", "activate", False)
         if b_success:
             Config().om.info(s_message)
+            UploadAction.add_carte_tags(mode_cartes, upload, "upload_check_ok")
             return True
         Config().om.warning(s_message)
+        UploadAction.add_carte_tags(mode_cartes, upload, "upload_check_ko")
         return False
 
     @staticmethod

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -41,10 +41,6 @@ class UploadAction:
         # On suit le comportement donnée en paramètre ou à défaut celui de la config
         self.__behavior: str = behavior if behavior is not None else Config().get_str("upload", "behavior_if_exists")
         self.__mode_cartes = cartabilite
-    def __carte_tag__(self,upload_step):
-        """_summary_
-        """
-        return Config().get_str("compatibility_cartes", upload_step)
 
     def run(self, datastore: Optional[str], compatibilite_cartes : bool,check_before_close: bool = False) -> Upload:
         """Crée la livraison décrite dans le dataset et livre les données avant de
@@ -141,6 +137,10 @@ class UploadAction:
             Config().om.info(f"Livraison {self.__upload['name']} : ajout des {len(self.__dataset.tags)} tags...")
             self.__upload.api_add_tags(self.__dataset.tags)
             Config().om.info(f"Livraison {self.__upload['name']} : les {len(self.__dataset.tags)} tags ont été ajoutés avec succès.")
+    def __add_carte_tags(self,upload_step)->None:
+        """En mode cartes.gouv, ajoute les tags nécessaires.
+        """
+        return Config().get_str("compatibility_cartes", upload_step)
     def __add_comments(self) -> None:
         """Ajoute les commentaires."""
         if self.__upload is not None:

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -56,10 +56,10 @@ class UploadAction:
         Returns:
             livraison créée
         """
-        # test: si le mode carte est actif alors le data_sheet doit être présent
+        Config().om.info("Création et complétion d'une livraison...", force_flush=True)
+        # test: si le mode carte est actif alors le tag datasheet_name doit être présent
         if self.__mode_cartes and not self.__dataset.tags["datasheet_name"]:
             raise GpfSdkError("En mode compatibilité avec cartes.gouv, le tag datasheet_name contenant le nom de la fiche de donnée est obligatoire")
-        Config().om.info("Création et complétion d'une livraison...")
         # Création de la livraison
         self.__create_upload(datastore)
         if not self.upload:
@@ -80,7 +80,7 @@ class UploadAction:
         # Envoie des fichiers md5 (pas de vérification sur les problèmes de livraison si check_before_close)
         self.__push_md5_files(not check_before_close)
         if check_before_close:
-            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescence avant livraison ...")
+            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescence avant livraison ...", force_flush=True)
             # vérification de la livraison des fichiers de données + ficher md5
             l_error = self.__check_file_uploaded(list(self.__dataset.data_files.items()) + [(p_file, "") for p_file in self.__dataset.md5_files])
             if l_error:
@@ -104,7 +104,7 @@ class UploadAction:
         Args:
             datastore (Optional[str]): id du datastore à utiliser.
         """
-        Config().om.info("Création d'une livraison...")
+        Config().om.info("Création d'une livraison...", force_flush=True)
         # On tente de récupérer l'upload
         o_upload = self.find_upload(datastore)
         # S'il n'est pas null
@@ -180,7 +180,7 @@ class UploadAction:
         """
         if self.__upload is not None:
             # Liste les fichiers déjà téléversés sur l'entrepôt et récupère leur taille
-            Config().om.info(f"Livraison {self.__upload['name']} : récupération de l'arborescence des données déjà téléversées...")
+            Config().om.info(f"Livraison {self.__upload['name']} : récupération de l'arborescence des données déjà téléversées...", force_flush=True)
             i_file_upload = self.__push_files(
                 list(self.__dataset.data_files.items()),
                 self.__upload.api_push_data_file,
@@ -357,7 +357,7 @@ class UploadAction:
         i_nb_sec_between_check = Config().get_int("upload", "nb_sec_between_check_updates")
         s_check_message_pattern = Config().get_str("upload", "check_message_pattern")
         b_success: Optional[bool] = None
-        Config().om.info(f"Monitoring des vérifications toutes les {i_nb_sec_between_check} secondes...")
+        Config().om.info(f"Monitoring des vérifications toutes les {i_nb_sec_between_check} secondes...", force_flush=True)
         while b_success is None:
             try:
                 # On récupère les vérifications
@@ -390,7 +390,7 @@ class UploadAction:
                         raise
 
                     # arrêt des vérifications
-                    Config().om.warning("Ctrl+C : vérifications en cours d’interruption, veuillez attendre...")
+                    Config().om.warning("Ctrl+C : vérifications en cours d’interruption, veuillez attendre...", force_flush=True)
                     # suppression des vérifications non terminées
                     for d_check_exec in d_checks["in_progress"]:
                         CheckExecution(d_check_exec, upload.datastore).api_delete()

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -48,7 +48,7 @@ class UploadAction:
         Returns:
             livraison créée
         """
-        Config().om.info("Création et complétion d'une livraison...")
+        Config().om.info("Création et complétion d'une livraison...", force_flush=True)
         # Création de la livraison
         self.__create_upload(datastore)
 
@@ -67,7 +67,7 @@ class UploadAction:
         # Envoie des fichiers md5 (pas de vérification sur les problèmes de livraison si check_before_close)
         self.__push_md5_files(not check_before_close)
         if check_before_close:
-            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescence avant livraison ...")
+            Config().om.info(f"Livraison {self.upload}: vérification de l'arborescence avant livraison ...", force_flush=True)
             # vérification de la livraison des fichiers de données + ficher md5
             l_error = self.__check_file_uploaded(list(self.__dataset.data_files.items()) + [(p_file, "") for p_file in self.__dataset.md5_files])
             if l_error:
@@ -90,7 +90,7 @@ class UploadAction:
         Args:
             datastore (Optional[str]): id du datastore à utiliser.
         """
-        Config().om.info("Création d'une livraison...")
+        Config().om.info("Création d'une livraison...", force_flush=True)
         # On tente de récupérer l'upload
         o_upload = self.find_upload(datastore)
         # S'il n'est pas null
@@ -145,7 +145,7 @@ class UploadAction:
         """
         if self.__upload is not None:
             # Liste les fichiers déjà téléversés sur l'entrepôt et récupère leur taille
-            Config().om.info(f"Livraison {self.__upload['name']} : récupération de l'arborescence des données déjà téléversées...")
+            Config().om.info(f"Livraison {self.__upload['name']} : récupération de l'arborescence des données déjà téléversées...", force_flush=True)
             i_file_upload = self.__push_files(
                 list(self.__dataset.data_files.items()),
                 self.__upload.api_push_data_file,
@@ -322,7 +322,7 @@ class UploadAction:
         i_nb_sec_between_check = Config().get_int("upload", "nb_sec_between_check_updates")
         s_check_message_pattern = Config().get_str("upload", "check_message_pattern")
         b_success: Optional[bool] = None
-        Config().om.info(f"Monitoring des vérifications toutes les {i_nb_sec_between_check} secondes...")
+        Config().om.info(f"Monitoring des vérifications toutes les {i_nb_sec_between_check} secondes...", force_flush=True)
         while b_success is None:
             try:
                 # On récupère les vérifications
@@ -355,7 +355,7 @@ class UploadAction:
                         raise
 
                     # arrêt des vérifications
-                    Config().om.warning("Ctrl+C : vérifications en cours d’interruption, veuillez attendre...")
+                    Config().om.warning("Ctrl+C : vérifications en cours d’interruption, veuillez attendre...", force_flush=True)
                     # suppression des vérifications non terminées
                     for d_check_exec in d_checks["in_progress"]:
                         CheckExecution(d_check_exec, upload.datastore).api_delete()

--- a/tests/_conf/test_overload.ini
+++ b/tests/_conf/test_overload.ini
@@ -1,8 +1,3 @@
-[logging]
-# Niveaux de log expliqués ici : https://docs.python.org/2/library/logging.html#logging-levels
-# 10 DEBUG 20 INFO 30 WARNING 40 ERROR 50 CRITICAL
-log_level=20
-
 [store_authentification]
 login=TEST_LOGIN
 password=TEST_PASSWORD

--- a/tests/_conf/test_overload.toml
+++ b/tests/_conf/test_overload.toml
@@ -1,0 +1,9 @@
+[store_authentification]
+login="TEST_LOGIN_TOML"
+password="TEST_PASSWORD_TOML"
+
+[store_api]
+datastore="TEST_DATASTORE_TOML"
+
+[miscellaneous]
+tmp_workdir="/tmp/TOML"

--- a/tests/auth/AuthentifierTestCase.py
+++ b/tests/auth/AuthentifierTestCase.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 from http import HTTPStatus
+import requests
 import requests_mock
 
 from sdk_entrepot_gpf.io.Config import Config
@@ -29,8 +30,7 @@ class AuthentifierTestCase(GpfTestCase):
         # On détruit le Singleton Config
         Config._instance = None
         # On charge une config spéciale pour les tests d'authentification
-        o_config = Config()
-        o_config.read(GpfTestCase.conf_dir_path / "test_authentifier.ini")
+        Config().read(GpfTestCase.conf_dir_path / "test_authentifier.ini")
 
     def setUp(self) -> None:
         """fonction lancée avant chaque test de la classe"""
@@ -47,6 +47,7 @@ class AuthentifierTestCase(GpfTestCase):
     def test_get_access_token_string_ok(self) -> None:
         """Vérifie le bon fonctionnement de get_access_token_string dans un cas normal."""
         # On mock...
+        self.assertEqual(Config().get("store_authentification", "grant_type"), "password")
         with requests_mock.Mocker() as o_mock:
             # Une authentification réussie
             o_mock.post(AuthentifierTestCase.url, json=AuthentifierTestCase.valid_token)
@@ -92,10 +93,10 @@ class AuthentifierTestCase(GpfTestCase):
             o_mock.post(
                 AuthentifierTestCase.url,
                 [
-                    {"status_code": HTTPStatus.INTERNAL_SERVER_ERROR},
-                    {"status_code": HTTPStatus.INTERNAL_SERVER_ERROR},
-                    {"status_code": HTTPStatus.INTERNAL_SERVER_ERROR},
-                    {"status_code": HTTPStatus.INTERNAL_SERVER_ERROR},
+                    {"exc": Exception()},
+                    {"status_code": 1, "json": {"error_description": "..."}},
+                    {"status_code": 1, "json": {}},
+                    {"exc": requests.exceptions.ConnectionError()},
                 ],
             )
             # On s'attend à une exception
@@ -106,6 +107,22 @@ class AuthentifierTestCase(GpfTestCase):
             self.assertEqual(o_arc.exception.message, "La récupération du jeton d'authentification a échoué après 3 tentatives")
             # On a dû faire 4 requêtes
             self.assertEqual(o_mock.call_count, 4, "o_mock.call_count == 4")
+
+    def test_get_access_token_string_ko(self) -> None:
+        """Vérifie les sorties en erreur de get_access_token_string"""
+        # code sortie non spécifique et mdp expirer
+        with requests_mock.Mocker() as o_mock:
+            s_message = "blabla. Account is not fully set up ... suite"
+            o_mock.post(AuthentifierTestCase.url, json={"error_description": s_message}, status_code=1)
+            with self.assertRaises(AuthentificationError) as o_arc:
+                # On tente de récupérer un token...
+                Authentifier().get_access_token_string()
+            print(o_arc.exception.args)
+            self.assertEqual(
+                o_arc.exception.message,
+                f"Problème lors de l'authentification, veuillez vous connecter via l'interface en ligne KeyCloak pour vérifier son compte. Votre mot de passe est sûrement expiré. ({s_message})",
+            )
+        # erreur de connexion
 
     def test_get_http_header(self) -> None:
         """Vérifie le bon fonctionnement de test_get_http_header."""

--- a/tests/auth/AuthentifierTestCase.py
+++ b/tests/auth/AuthentifierTestCase.py
@@ -30,8 +30,7 @@ class AuthentifierTestCase(GpfTestCase):
         # On détruit le Singleton Config
         Config._instance = None
         # On charge une config spéciale pour les tests d'authentification
-        o_config = Config()
-        o_config.read(GpfTestCase.conf_dir_path / "test_authentifier.ini")
+        Config().read(GpfTestCase.conf_dir_path / "test_authentifier.ini")
 
     def setUp(self) -> None:
         """fonction lancée avant chaque test de la classe"""
@@ -48,6 +47,7 @@ class AuthentifierTestCase(GpfTestCase):
     def test_get_access_token_string_ok(self) -> None:
         """Vérifie le bon fonctionnement de get_access_token_string dans un cas normal."""
         # On mock...
+        self.assertEqual(Config().get("store_authentification", "grant_type"), "password")
         with requests_mock.Mocker() as o_mock:
             # Une authentification réussie
             o_mock.post(AuthentifierTestCase.url, json=AuthentifierTestCase.valid_token)

--- a/tests/auth/AuthentifierTestCase.py
+++ b/tests/auth/AuthentifierTestCase.py
@@ -29,8 +29,7 @@ class AuthentifierTestCase(GpfTestCase):
         # On détruit le Singleton Config
         Config._instance = None
         # On charge une config spéciale pour les tests d'authentification
-        o_config = Config()
-        o_config.read(GpfTestCase.conf_dir_path / "test_authentifier.ini")
+        Config().read(GpfTestCase.conf_dir_path / "test_authentifier.ini")
 
     def setUp(self) -> None:
         """fonction lancée avant chaque test de la classe"""
@@ -47,6 +46,7 @@ class AuthentifierTestCase(GpfTestCase):
     def test_get_access_token_string_ok(self) -> None:
         """Vérifie le bon fonctionnement de get_access_token_string dans un cas normal."""
         # On mock...
+        self.assertEqual(Config().get("store_authentification", "grant_type"), "password")
         with requests_mock.Mocker() as o_mock:
             # Une authentification réussie
             o_mock.post(AuthentifierTestCase.url, json=AuthentifierTestCase.valid_token)

--- a/tests/io/ApiRequesterTestCase.py
+++ b/tests/io/ApiRequesterTestCase.py
@@ -11,7 +11,7 @@ from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from sdk_entrepot_gpf.auth.Authentifier import Authentifier
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
-from sdk_entrepot_gpf.io.Errors import NotFoundError, RouteNotFoundError, ConflictError
+from sdk_entrepot_gpf.io.Errors import NotFoundError, RouteNotFoundError, ConflictError, StatusCodeError
 from tests.GpfTestCase import GpfTestCase
 
 # pylint:disable=protected-access
@@ -59,6 +59,8 @@ class ApiRequesterTestCase(GpfTestCase):
         super().tearDownClass()
         # On ne mock plus la classe d'authentification
         cls.o_mock_authentifier.stop()
+        # On détruit le Singleton Config
+        Config._instance = None
 
     def test_route_request_ok_datastore_config(self) -> None:
         """Test de route_request quand la route existe en utilisant le datastore de base."""
@@ -247,14 +249,7 @@ class ApiRequesterTestCase(GpfTestCase):
         # On mock...
         with requests_mock.Mocker() as o_mock:
             # Une requête non réussie
-            o_mock.post(
-                self.url,
-                [
-                    {"status_code": HTTPStatus.INTERNAL_SERVER_ERROR},
-                    {"status_code": HTTPStatus.INTERNAL_SERVER_ERROR},
-                    {"status_code": HTTPStatus.INTERNAL_SERVER_ERROR},
-                ],
-            )
+            o_mock.post(self.url, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
             # On s'attend à une exception
             with self.assertRaises(GpfSdkError) as o_arc:
                 # On effectue une requête
@@ -300,14 +295,7 @@ class ApiRequesterTestCase(GpfTestCase):
         # On mock...
         with requests_mock.Mocker() as o_mock:
             # Une requête non réussie
-            o_mock.post(
-                self.url,
-                [
-                    {"status_code": HTTPStatus.NOT_FOUND},
-                    {"status_code": HTTPStatus.NOT_FOUND},
-                    {"status_code": HTTPStatus.NOT_FOUND},
-                ],
-            )
+            o_mock.post(self.url, status_code=HTTPStatus.NOT_FOUND)
             # On s'attend à une exception
             with self.assertRaises(NotFoundError):
                 # On effectue une requête
@@ -336,6 +324,25 @@ class ApiRequesterTestCase(GpfTestCase):
                 # On a dû faire 2 appels à revoke_token
                 self.assertEqual(o_mock_revoke_token.call_count, 2, "o_mock_revoke_token.call_count == 2")
 
+    def test_url_request_connection_error(self) -> None:
+        """Test de url_request dans le cadre d'une erreur ConnectionError."""
+        # On mock...
+        with requests_mock.Mocker() as o_mock:
+            o_mock.get(self.url, exc=requests.exceptions.ConnectionError)
+            # On s'attend à une exception
+            with self.assertRaises(GpfSdkError) as o_arc:
+                # Lancement de la requête
+                ApiRequester().url_request(self.url, ApiRequester.GET, params=self.param, data=self.data)
+            # On doit avoir un message d'erreur
+            self.assertEqual(
+                o_arc.exception.message,
+                f"Le serveur de l'API Entrepôt ({self.url}) n'est pas joignable. Cela peut être dû à un problème de configuration si elle a changée récemment."
+                + " Sinon, c'est un problème sur l'API Entrepôt : consultez l'état du service pour en savoir plus "
+                + f": {Config().get_str('store_api', 'check_status_url')}.",
+            )
+            # On a dû faire le max de requête
+            self.assertEqual(o_mock.call_count, Config().get_int("store_api", "nb_attempts"), "o_mock.call_count == max")
+
     def test_url_request_http_error(self) -> None:
         """Test de url_request dans le cadre où on a une HTTPError."""
         # On mock...
@@ -349,6 +356,20 @@ class ApiRequesterTestCase(GpfTestCase):
             self.assertEqual(o_arc.exception.message, "L'URL indiquée en configuration est invalide ou inexistante. Contactez le support.")
             # On a dû faire 1 seule requête
             self.assertEqual(o_mock.call_count, 1, "o_mock.call_count == 1")
+
+    def test_url_request_code_autre(self) -> None:
+        """Test de url_request dans le cadre où on code retour non pris en charge."""
+        # On mock...
+        with requests_mock.Mocker() as o_mock:
+            o_mock.post(self.url, status_code=1)
+            # On s'attend à une exception
+            with self.assertRaises(GpfSdkError) as o_arc:
+                # Lancement de la requête
+                ApiRequester().url_request(self.url, ApiRequester.POST, params=self.param, data=self.data)
+            # On doit avoir un message d'erreur
+            self.assertEqual(o_arc.exception.message, "L'exécution d'une requête a échoué après 3 tentatives.")
+            # On a dû faire 1 seule requête
+            self.assertEqual(o_mock.call_count, 3, "o_mock.call_count == 3")
 
     def test_url_request_url_required(self) -> None:
         """Test de url_request dans le cadre où on a une URLRequired."""

--- a/tests/io/ApiRequesterTestCase.py
+++ b/tests/io/ApiRequesterTestCase.py
@@ -11,7 +11,7 @@ from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from sdk_entrepot_gpf.auth.Authentifier import Authentifier
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
-from sdk_entrepot_gpf.io.Errors import NotFoundError, RouteNotFoundError, ConflictError, StatusCodeError
+from sdk_entrepot_gpf.io.Errors import NotFoundError, RouteNotFoundError, ConflictError
 from tests.GpfTestCase import GpfTestCase
 
 # pylint:disable=protected-access

--- a/tests/io/ConfigTestCase.py
+++ b/tests/io/ConfigTestCase.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from sdk_entrepot_gpf.io.Config import Config
+from sdk_entrepot_gpf.io.Errors import ConfigReaderError
 from tests.GpfTestCase import GpfTestCase
 
 # pylint:disable=protected-access
@@ -26,12 +27,21 @@ class ConfigTestCase(GpfTestCase):
         self.assertEqual(Config().get("store_authentification", "login"), "LOGIN_TO_MODIFY")
         self.assertEqual(Config().get("store_authentification", "password"), "PASSWORD_TO_MODIFY")
         self.assertEqual(Config().get("store_api", "datastore"), "DATASTORE_ID_TO_MODIFY")
+        self.assertEqual(Config().get("logging", "log_level"), "INFO")
         # On ouvre le nouveau fichier
         Config().read(GpfTestCase.conf_dir_path / "test_overload.ini")
-        # On vérifie que l'on a les nouvelles valeurs
+        # On vérifie que l'on a les nouvelles valeurs et toujours les anciennes non modifiés
         self.assertEqual(Config().get("store_authentification", "login"), "TEST_LOGIN")
         self.assertEqual(Config().get("store_authentification", "password"), "TEST_PASSWORD")
         self.assertEqual(Config().get("store_api", "datastore"), "TEST_DATASTORE")
+        self.assertEqual(Config().get("logging", "log_level"), "INFO")
+        # On ouvre le nouveau fichier TOML cette fois-ci
+        Config().read(GpfTestCase.conf_dir_path / "test_overload.toml")
+        # On vérifie que l'on a les nouvelles valeurs et toujours les anciennes non modifiés
+        self.assertEqual(Config().get("store_authentification", "login"), "TEST_LOGIN_TOML")
+        self.assertEqual(Config().get("store_authentification", "password"), "TEST_PASSWORD_TOML")
+        self.assertEqual(Config().get("store_api", "datastore"), "TEST_DATASTORE_TOML")
+        self.assertEqual(Config().get("logging", "log_level"), "INFO")
 
     def test_get(self) -> None:
         """Vérifie le bon fonctionnement de get, get_int, get_float et get_bool."""
@@ -45,15 +55,21 @@ class ConfigTestCase(GpfTestCase):
         self.assertEqual(Config().get_int("test_value_type", "my_int"), 42)
         self.assertEqual(Config().get_float("test_value_type", "my_float"), 4.2)
         self.assertEqual(Config().get_bool("test_value_type", "my_bool"), True)
-        # On a la valeur par défaut si non existant
-        self.assertIsNone(Config().get("test_value_type", "not_existing", fallback=None))
-        self.assertIsNone(Config().get_int("test_value_type", "not_existing", fallback=None))
-        self.assertIsNone(Config().get_float("test_value_type", "not_existing", fallback=None))
-        self.assertIsNone(Config().get_bool("test_value_type", "not_existing", fallback=None))
+        # On a la valeur fallback par défaut si non existant et fall back non None
         self.assertEqual(Config().get("test_value_type", "not_existing", fallback="fallback"), "fallback")
         self.assertEqual(Config().get_int("test_value_type", "not_existing", fallback=42), 42)
         self.assertEqual(Config().get_float("test_value_type", "not_existing", fallback=4.2), 4.2)
         self.assertEqual(Config().get_bool("test_value_type", "not_existing", fallback=True), True)
+        # On a None si option non existante et fallback None avec 'get' et 'get_bool'
+        self.assertIsNone(Config().get("test_value_type", "not_existing", fallback=None))
+        self.assertFalse(Config().get_bool("test_value_type", "not_existing", fallback=None))
+        # On a une exception si option non existante, fallback None et qu'un type est demandé
+        with self.assertRaises(ConfigReaderError) as o_arc:
+            Config().get_int("test_value_type", "not_existing", fallback=None)
+        self.assertIn("Veuillez vérifier la config ([test_value_type-[not_existing]]), entier non reconnu (None).", o_arc.exception.message)
+        with self.assertRaises(ConfigReaderError) as o_arc:
+            Config().get_float("test_value_type", "not_existing", fallback=None)
+        self.assertIn("Veuillez vérifier la config ([test_value_type-[not_existing]]), nombre flottant non reconnu (None).", o_arc.exception.message)
 
     def test_get_temp(self) -> None:
         """Vérifie le bon fonctionnement de get_temp."""

--- a/tests/io/ConfigTestCase.py
+++ b/tests/io/ConfigTestCase.py
@@ -1,7 +1,6 @@
-import configparser
 from pathlib import Path
-
 from sdk_entrepot_gpf.io.Config import Config
+from sdk_entrepot_gpf.io.Errors import ConfigReaderError
 from tests.GpfTestCase import GpfTestCase
 
 # pylint:disable=protected-access
@@ -17,24 +16,32 @@ class ConfigTestCase(GpfTestCase):
         # On détruit le singleton Config
         Config._instance = None
 
-    def test_get_parser(self) -> None:
-        """Vérifie le bon fonctionnement de get_parser."""
-        # On vérifie le type de get_parser
-        self.assertIsInstance(Config().get_parser(), configparser.ConfigParser)
+    def test_get_config(self) -> None:
+        """Vérifie le bon fonctionnement de get_config."""
+        # On vérifie le type de get_config
+        self.assertEqual(type(Config().get_config()), dict)
 
     def test_read(self) -> None:
         """Vérifie le bon fonctionnement de read."""
-        o_parser = Config().get_parser()
         # On vérifie que l'on a les valeurs par défaut
-        self.assertEqual(o_parser.get("store_authentification", "login"), "LOGIN_TO_MODIFY")
-        self.assertEqual(o_parser.get("store_authentification", "password"), "PASSWORD_TO_MODIFY")
-        self.assertEqual(o_parser.get("store_api", "datastore"), "DATASTORE_ID_TO_MODIFY")
+        self.assertEqual(Config().get("store_authentification", "login"), "LOGIN_TO_MODIFY")
+        self.assertEqual(Config().get("store_authentification", "password"), "PASSWORD_TO_MODIFY")
+        self.assertEqual(Config().get("store_api", "datastore"), "DATASTORE_ID_TO_MODIFY")
+        self.assertEqual(Config().get("logging", "log_level"), "INFO")
         # On ouvre le nouveau fichier
         Config().read(GpfTestCase.conf_dir_path / "test_overload.ini")
-        # On vérifie que l'on a les nouvelles valeurs
-        self.assertEqual(o_parser.get("store_authentification", "login"), "TEST_LOGIN")
-        self.assertEqual(o_parser.get("store_authentification", "password"), "TEST_PASSWORD")
-        self.assertEqual(o_parser.get("store_api", "datastore"), "TEST_DATASTORE")
+        # On vérifie que l'on a les nouvelles valeurs et toujours les anciennes non modifiés
+        self.assertEqual(Config().get("store_authentification", "login"), "TEST_LOGIN")
+        self.assertEqual(Config().get("store_authentification", "password"), "TEST_PASSWORD")
+        self.assertEqual(Config().get("store_api", "datastore"), "TEST_DATASTORE")
+        self.assertEqual(Config().get("logging", "log_level"), "INFO")
+        # On ouvre le nouveau fichier TOML cette fois-ci
+        Config().read(GpfTestCase.conf_dir_path / "test_overload.toml")
+        # On vérifie que l'on a les nouvelles valeurs et toujours les anciennes non modifiés
+        self.assertEqual(Config().get("store_authentification", "login"), "TEST_LOGIN_TOML")
+        self.assertEqual(Config().get("store_authentification", "password"), "TEST_PASSWORD_TOML")
+        self.assertEqual(Config().get("store_api", "datastore"), "TEST_DATASTORE_TOML")
+        self.assertEqual(Config().get("logging", "log_level"), "INFO")
 
     def test_get(self) -> None:
         """Vérifie le bon fonctionnement de get, get_int, get_float et get_bool."""
@@ -48,15 +55,21 @@ class ConfigTestCase(GpfTestCase):
         self.assertEqual(Config().get_int("test_value_type", "my_int"), 42)
         self.assertEqual(Config().get_float("test_value_type", "my_float"), 4.2)
         self.assertEqual(Config().get_bool("test_value_type", "my_bool"), True)
-        # On a la valeur par défaut si non existant
-        self.assertIsNone(Config().get("test_value_type", "not_existing", fallback=None))
-        self.assertIsNone(Config().get_int("test_value_type", "not_existing", fallback=None))
-        self.assertIsNone(Config().get_float("test_value_type", "not_existing", fallback=None))
-        self.assertIsNone(Config().get_bool("test_value_type", "not_existing", fallback=None))
+        # On a la valeur fallback par défaut si non existant et fall back non None
         self.assertEqual(Config().get("test_value_type", "not_existing", fallback="fallback"), "fallback")
         self.assertEqual(Config().get_int("test_value_type", "not_existing", fallback=42), 42)
         self.assertEqual(Config().get_float("test_value_type", "not_existing", fallback=4.2), 4.2)
         self.assertEqual(Config().get_bool("test_value_type", "not_existing", fallback=True), True)
+        # On a None si option non existante et fallback None avec 'get' et 'get_bool'
+        self.assertIsNone(Config().get("test_value_type", "not_existing", fallback=None))
+        self.assertFalse(Config().get_bool("test_value_type", "not_existing", fallback=None))
+        # On a une exception si option non existante, fallback None et qu'un type est demandé
+        with self.assertRaises(ConfigReaderError) as o_arc:
+            Config().get_int("test_value_type", "not_existing", fallback=None)
+        self.assertIn("Veuillez vérifier la config ([test_value_type-[not_existing]]), entier non reconnu (None).", o_arc.exception.message)
+        with self.assertRaises(ConfigReaderError) as o_arc:
+            Config().get_float("test_value_type", "not_existing", fallback=None)
+        self.assertIn("Veuillez vérifier la config ([test_value_type-[not_existing]]), nombre flottant non reconnu (None).", o_arc.exception.message)
 
     def test_get_temp(self) -> None:
         """Vérifie le bon fonctionnement de get_temp."""

--- a/tests/io/ConfigTestCase.py
+++ b/tests/io/ConfigTestCase.py
@@ -1,6 +1,4 @@
-import configparser
 from pathlib import Path
-
 from sdk_entrepot_gpf.io.Config import Config
 from tests.GpfTestCase import GpfTestCase
 
@@ -17,24 +15,23 @@ class ConfigTestCase(GpfTestCase):
         # On détruit le singleton Config
         Config._instance = None
 
-    def test_get_parser(self) -> None:
-        """Vérifie le bon fonctionnement de get_parser."""
-        # On vérifie le type de get_parser
-        self.assertIsInstance(Config().get_parser(), configparser.ConfigParser)
+    def test_get_config(self) -> None:
+        """Vérifie le bon fonctionnement de get_config."""
+        # On vérifie le type de get_config
+        self.assertEqual(type(Config().get_config()), dict)
 
     def test_read(self) -> None:
         """Vérifie le bon fonctionnement de read."""
-        o_parser = Config().get_parser()
         # On vérifie que l'on a les valeurs par défaut
-        self.assertEqual(o_parser.get("store_authentification", "login"), "LOGIN_TO_MODIFY")
-        self.assertEqual(o_parser.get("store_authentification", "password"), "PASSWORD_TO_MODIFY")
-        self.assertEqual(o_parser.get("store_api", "datastore"), "DATASTORE_ID_TO_MODIFY")
+        self.assertEqual(Config().get("store_authentification", "login"), "LOGIN_TO_MODIFY")
+        self.assertEqual(Config().get("store_authentification", "password"), "PASSWORD_TO_MODIFY")
+        self.assertEqual(Config().get("store_api", "datastore"), "DATASTORE_ID_TO_MODIFY")
         # On ouvre le nouveau fichier
         Config().read(GpfTestCase.conf_dir_path / "test_overload.ini")
         # On vérifie que l'on a les nouvelles valeurs
-        self.assertEqual(o_parser.get("store_authentification", "login"), "TEST_LOGIN")
-        self.assertEqual(o_parser.get("store_authentification", "password"), "TEST_PASSWORD")
-        self.assertEqual(o_parser.get("store_api", "datastore"), "TEST_DATASTORE")
+        self.assertEqual(Config().get("store_authentification", "login"), "TEST_LOGIN")
+        self.assertEqual(Config().get("store_authentification", "password"), "TEST_PASSWORD")
+        self.assertEqual(Config().get("store_api", "datastore"), "TEST_DATASTORE")
 
     def test_get(self) -> None:
         """Vérifie le bon fonctionnement de get, get_int, get_float et get_bool."""

--- a/tests/store/interface/ReUploadFileInterfaceTestCase.py
+++ b/tests/store/interface/ReUploadFileInterfaceTestCase.py
@@ -33,6 +33,7 @@ class ReUploadFileInterfaceTestCase(GpfTestCase):
                         "store_entity_re_upload",
                         p_file,
                         s_file_key,
+                        route_params={"store_entity": "123456789", "datastore": None},
                         method=ApiRequester.PUT,
                     )
                     o_mock_update.assert_called_once_with()

--- a/tests/workflow/WorkflowTestCase.py
+++ b/tests/workflow/WorkflowTestCase.py
@@ -27,6 +27,7 @@ from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
 from tests.GpfTestCase import GpfTestCase
 
 # pylint:disable=too-many-statements
+# fmt:off
 
 
 class WorkflowTestCase(GpfTestCase):

--- a/tests/workflow/WorkflowTestCase.py
+++ b/tests/workflow/WorkflowTestCase.py
@@ -27,7 +27,6 @@ from sdk_entrepot_gpf.workflow.resolver.GlobalResolver import GlobalResolver
 from tests.GpfTestCase import GpfTestCase
 
 # pylint:disable=too-many-statements
-# fmt:off
 
 
 class WorkflowTestCase(GpfTestCase):

--- a/tests/workflow/action/ConfigurationActionTestCase.py
+++ b/tests/workflow/action/ConfigurationActionTestCase.py
@@ -101,7 +101,7 @@ class ConfigurationActionTestCase(GpfTestCase):
         with patch.object(Configuration, "api_create", **d_api_create) as o_mock_configuration_api_create:
             with patch.object(ConfigurationAction, "find_configuration", return_value=o_configs) as o_mock_find_configuration:
                 # initialisation de Configuration
-                o_conf = ConfigurationAction("contexte", d_action, behavior=behavior)
+                o_conf = ConfigurationAction("contexte", d_action, behavior=behavior, compatibility_cartes=False)
                 if config_already_exists:
                     if behavior == "STOP":
                         # on attend une erreur

--- a/tests/workflow/action/EditActionTestCase.py
+++ b/tests/workflow/action/EditActionTestCase.py
@@ -28,23 +28,23 @@ class EditActionTestCase(GpfTestCase):
 
         # problème de avec le workflow : entity_type non présent
         d_action: Dict[str, Any] = {"type": "edit-entity"}
-        o_action_edit = EditAction("contexte", d_action)
+        o_action_delete = EditAction("contexte", d_action)
         with self.assertRaises(StepActionError) as o_err:
-            o_action_edit.run(s_datastore)
+            o_action_delete.run(s_datastore)
         self.assertEqual('La clef "entity_type" est obligatoire pour cette action', o_err.exception.message)
 
         # problème de avec le workflow : entity_type non valide
         d_action = {"type": "edit-entity", "entity_type": "non valide"}
-        o_action_edit = EditAction("contexte", d_action)
+        o_action_delete = EditAction("contexte", d_action)
         with self.assertRaises(StepActionError) as o_err:
-            o_action_edit.run(s_datastore)
+            o_action_delete.run(s_datastore)
         self.assertEqual(f"Type {d_action['entity_type']} non reconnu. Types valides : {', '.join(EditAction.UPDATABLE_TYPES)}", o_err.exception.message)
 
         # problème de avec le workflow : entity_type non valide
         d_action = {"type": "edit-entity", "entity_type": "offering"}
-        o_action_edit = EditAction("contexte", d_action)
+        o_action_delete = EditAction("contexte", d_action)
         with self.assertRaises(StepActionError) as o_err:
-            o_action_edit.run(s_datastore)
+            o_action_delete.run(s_datastore)
         self.assertEqual('La clef "entity_id" est obligatoire pour cette action.', o_err.exception.message)
 
     def test_run_ok(self) -> None:  # pylint: disable=too-many-locals,too-many-statements
@@ -55,9 +55,9 @@ class EditActionTestCase(GpfTestCase):
             # ne fait rien
             o_entity = MagicMock(spec=c_classe)
             d_action: Dict[str, Any] = {"type": "edit-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id}
-            o_action_edit = EditAction("contexte", d_action)
+            o_action_delete = EditAction("contexte", d_action)
             with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
-                o_action_edit.run(s_datastore)
+                o_action_delete.run(s_datastore)
             o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
             o_entity.edit.assert_not_called()
             if isinstance(o_entity, TagInterface):
@@ -68,9 +68,9 @@ class EditActionTestCase(GpfTestCase):
             # edition entity seule
             o_entity = MagicMock(spec=c_classe)
             d_action = {"type": "edit-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id, "body_parameters": {"key": "val"}}
-            o_action_edit = EditAction("contexte", d_action)
+            o_action_delete = EditAction("contexte", d_action)
             with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
-                o_action_edit.run(s_datastore)
+                o_action_delete.run(s_datastore)
             o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
             o_entity.edit.assert_called_once_with(d_action["body_parameters"])
             if isinstance(o_entity, TagInterface):
@@ -80,27 +80,21 @@ class EditActionTestCase(GpfTestCase):
 
             # edition entity + comments + tags
             o_entity = MagicMock(spec=c_classe)
-            if isinstance(o_entity, CommentInterface):
-                o_entity.api_list_comments.return_value = [{"text": "supp1", "_id": "id1"}, {"text": "supp2", "_id": "id2"}]
             d_action = {
                 "type": "edit-entity",
                 "entity_type": c_classe.entity_name(),
                 "entity_id": s_entity_id,
                 "body_parameters": {"key": "val"},
-                "remove_tags": ["supp1", "supp2"],
-                "remove_comments": ["supp1", "supp2"],
                 "tags": {"key1": "val1", "key2": "val2"},
                 "comments": ["comm1", "comm2"],
             }
-            o_action_edit = EditAction("contexte", d_action)
+            o_action_delete = EditAction("contexte", d_action)
             with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
-                o_action_edit.run(s_datastore)
+                o_action_delete.run(s_datastore)
             o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
             o_entity.edit.assert_called_once_with(d_action["body_parameters"])
             if isinstance(o_entity, TagInterface):
                 o_entity.api_add_tags.assert_called_once_with(d_action["tags"])
-                o_entity.api_remove_tags.assert_called_once_with(d_action["remove_tags"])
             if isinstance(o_entity, CommentInterface):
                 # o_entity.api_add_comment.
                 self.assertEqual(o_entity.api_add_comment.call_args_list, [call({"text": s_comm}) for s_comm in d_action["comments"]])
-                self.assertEqual(o_entity.api_remove_comment.call_args_list, [call("id1"), call("id2")])

--- a/tests/workflow/action/EditActionTestCase.py
+++ b/tests/workflow/action/EditActionTestCase.py
@@ -28,23 +28,23 @@ class EditActionTestCase(GpfTestCase):
 
         # problème de avec le workflow : entity_type non présent
         d_action: Dict[str, Any] = {"type": "edit-entity"}
-        o_action_delete = EditAction("contexte", d_action)
+        o_action_edit = EditAction("contexte", d_action)
         with self.assertRaises(StepActionError) as o_err:
-            o_action_delete.run(s_datastore)
+            o_action_edit.run(s_datastore)
         self.assertEqual('La clef "entity_type" est obligatoire pour cette action', o_err.exception.message)
 
         # problème de avec le workflow : entity_type non valide
         d_action = {"type": "edit-entity", "entity_type": "non valide"}
-        o_action_delete = EditAction("contexte", d_action)
+        o_action_edit = EditAction("contexte", d_action)
         with self.assertRaises(StepActionError) as o_err:
-            o_action_delete.run(s_datastore)
+            o_action_edit.run(s_datastore)
         self.assertEqual(f"Type {d_action['entity_type']} non reconnu. Types valides : {', '.join(EditAction.UPDATABLE_TYPES)}", o_err.exception.message)
 
         # problème de avec le workflow : entity_type non valide
         d_action = {"type": "edit-entity", "entity_type": "offering"}
-        o_action_delete = EditAction("contexte", d_action)
+        o_action_edit = EditAction("contexte", d_action)
         with self.assertRaises(StepActionError) as o_err:
-            o_action_delete.run(s_datastore)
+            o_action_edit.run(s_datastore)
         self.assertEqual('La clef "entity_id" est obligatoire pour cette action.', o_err.exception.message)
 
     def test_run_ok(self) -> None:  # pylint: disable=too-many-locals,too-many-statements
@@ -55,9 +55,9 @@ class EditActionTestCase(GpfTestCase):
             # ne fait rien
             o_entity = MagicMock(spec=c_classe)
             d_action: Dict[str, Any] = {"type": "edit-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id}
-            o_action_delete = EditAction("contexte", d_action)
+            o_action_edit = EditAction("contexte", d_action)
             with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
-                o_action_delete.run(s_datastore)
+                o_action_edit.run(s_datastore)
             o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
             o_entity.edit.assert_not_called()
             if isinstance(o_entity, TagInterface):
@@ -68,9 +68,9 @@ class EditActionTestCase(GpfTestCase):
             # edition entity seule
             o_entity = MagicMock(spec=c_classe)
             d_action = {"type": "edit-entity", "entity_type": c_classe.entity_name(), "entity_id": s_entity_id, "body_parameters": {"key": "val"}}
-            o_action_delete = EditAction("contexte", d_action)
+            o_action_edit = EditAction("contexte", d_action)
             with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
-                o_action_delete.run(s_datastore)
+                o_action_edit.run(s_datastore)
             o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
             o_entity.edit.assert_called_once_with(d_action["body_parameters"])
             if isinstance(o_entity, TagInterface):
@@ -80,21 +80,27 @@ class EditActionTestCase(GpfTestCase):
 
             # edition entity + comments + tags
             o_entity = MagicMock(spec=c_classe)
+            if isinstance(o_entity, CommentInterface):
+                o_entity.api_list_comments.return_value = [{"text": "supp1", "_id": "id1"}, {"text": "supp2", "_id": "id2"}]
             d_action = {
                 "type": "edit-entity",
                 "entity_type": c_classe.entity_name(),
                 "entity_id": s_entity_id,
                 "body_parameters": {"key": "val"},
+                "remove_tags": ["supp1", "supp2"],
+                "remove_comments": ["supp1", "supp2"],
                 "tags": {"key1": "val1", "key2": "val2"},
                 "comments": ["comm1", "comm2"],
             }
-            o_action_delete = EditAction("contexte", d_action)
+            o_action_edit = EditAction("contexte", d_action)
             with patch.object(c_classe, "api_get", return_value=o_entity) as o_mock_api_get:
-                o_action_delete.run(s_datastore)
+                o_action_edit.run(s_datastore)
             o_mock_api_get.assert_called_once_with(s_entity_id, datastore=s_datastore)
             o_entity.edit.assert_called_once_with(d_action["body_parameters"])
             if isinstance(o_entity, TagInterface):
                 o_entity.api_add_tags.assert_called_once_with(d_action["tags"])
+                o_entity.api_remove_tags.assert_called_once_with(d_action["remove_tags"])
             if isinstance(o_entity, CommentInterface):
                 # o_entity.api_add_comment.
                 self.assertEqual(o_entity.api_add_comment.call_args_list, [call({"text": s_comm}) for s_comm in d_action["comments"]])
+                self.assertEqual(o_entity.api_remove_comment.call_args_list, [call("id1"), call("id2")])

--- a/tests/workflow/action/PermissionActionTestCase.py
+++ b/tests/workflow/action/PermissionActionTestCase.py
@@ -7,11 +7,6 @@ from sdk_entrepot_gpf.workflow.action.PermissionAction import PermissionAction
 from tests.GpfTestCase import GpfTestCase
 
 
-# pylint:disable=too-many-arguments
-# pylint:disable=too-many-locals
-# pylint:disable=too-many-branches
-
-
 class PermissionActionTestCase(GpfTestCase):
     """Tests PermissionAction class.
 
@@ -29,13 +24,13 @@ class PermissionActionTestCase(GpfTestCase):
         }
         o_action = PermissionAction("context", d_action)
         # Permet de vérifier qu'il n'y a pas encore de permission
-        self.assertIsNone(o_action.permission)
+        self.assertListEqual(o_action.permissions, [])
 
         # fonctionnement OK
-        o_permission = MagicMock()
-        with patch.object(Permission, "api_create", return_value=o_permission) as o_mock_create:
+        l_permissions = [MagicMock()]
+        with patch.object(Permission, "api_create_list", return_value=l_permissions) as o_mock_create:
             o_action.run("datastore")
         # Permet de mocker l'appel à la création de la permission
         o_mock_create.assert_called_once_with(d_action["body_parameters"], route_params={"datastore": "datastore"})
         # Permet de vérifier qu'après l'appel la permission ajoutée correspond à celle qui est demandée
-        self.assertEqual(o_permission, o_action.permission)
+        self.assertEqual(l_permissions, o_action.permissions)

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -12,9 +12,10 @@ from sdk_entrepot_gpf.workflow.Errors import StepActionError
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
 from sdk_entrepot_gpf.Errors import GpfSdkError
+from sdk_entrepot_gpf.workflow.action.UploadAction import UploadAction
 from tests.GpfTestCase import GpfTestCase
 
-# cSpell:ignore datasheet vectordb creat
+# cSpell:ignore datasheet vectordb creat specifique
 
 
 # pylint:disable=too-many-arguments
@@ -351,14 +352,15 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         d_def["tags"] = {**d_tags, "datasheet_name": "name"}
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
             with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
-                o_pe._ProcessingExecutionAction__add_tags()  # appelle la méthode privée __add_tags
-                # o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_progress")
-                # o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_current_step")
+                # on appelle la méthode privée __add_tags :
+                o_pe._ProcessingExecutionAction__add_tags()
                 for o_upload in l_inputs_upload:
+                    # test sur le nombre d'appels :
                     self.assertEqual(o_upload.api_add_tags.call_count, 2)
-                    # TODO Alain ? tester l'appel avec successivement :
-                    # {"proc_int_id": o_processing_execution.id, "vectordb_id": o_mock_stored_data.return_value.id}
-                    # {'integration_progress': '{"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}', 'integration_current_step': '2'}
+                    # test sur les paramètres passés :
+                    d_general = {"proc_int_id": o_processing_execution.id, "vectordb_id": o_mock_stored_data.return_value.id}
+                    d_specifique = {"integration_progress": '{"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}', "integration_current_step": "2"}
+                    o_upload.api_add_tags.assert_has_calls([call(d_general), call(d_specifique)])
                 o_mock_stored_data.return_value.api_add_tags.assert_called_once_with({**d_tags, "datasheet_name": "name", "uuid_upload": l_inputs_upload[0].id})
 
         ## pyramide_vecteur : manque datasheet_name

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -1,5 +1,6 @@
+# mypy: disable-error-code="attr-defined"
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from unittest.mock import PropertyMock, call, patch, MagicMock
 
@@ -13,12 +14,13 @@ from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import Processin
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from tests.GpfTestCase import GpfTestCase
 
+# cSpell:ignore datasheet vectordb creat
+
 
 # pylint:disable=too-many-arguments
 # pylint:disable=too-many-locals
 # pylint:disable=too-many-branches
-# pylint:disable=too-many-statements
-# fmt: off
+# pylint:disable=too-many-statements, too-many-lines
 class ProcessingExecutionActionTestCase(GpfTestCase):
     """Tests ProcessingExecutionAction class.
 
@@ -32,14 +34,14 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_pe1 = ProcessingExecution({"_id": "pe_1"})
         o_pe2 = ProcessingExecution({"_id": "pe_2"})
         # création du dict décrivant l'action
-        d_action:Dict[str, Any] = {
+        d_action: Dict[str, Any] = {
             "type": "processing-execution",
             "body_parameters": {
                 "output": {
-                    "stored_data": {"name": "name_stored_data"}
-                }
+                    "stored_data": {"name": "name_stored_data"},
+                },
             },
-            "tags": {"tag": "val"}
+            "tags": {"tag": "val"},
         }
         # exécution de ProcessingExecutionAction
         o_ua = ProcessingExecutionAction("contexte", d_action)
@@ -47,321 +49,679 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         for s_datastore in [None, "datastore"]:
             ## execution sans datastore
             # Mock de ActionAbstract.get_filters et Upload.api_list
-            with patch.object(ActionAbstract, "get_filters", return_value=({"info":"val"}, {"tag":"val"})) as o_mock_get_filters:
-                with patch.object(StoredData, "api_list", return_value=[o_pe1, o_pe2]) as o_mock_api_list :
+            with patch.object(ActionAbstract, "get_filters", return_value=({"info": "val"}, {"tag": "val"})) as o_mock_get_filters:
+                with patch.object(StoredData, "api_list", return_value=[o_pe1, o_pe2]) as o_mock_api_list:
                     # Appel de la fonction find_stored_data
                     o_stored_data = o_ua.find_stored_data(s_datastore)
                     # Vérifications
                     o_mock_get_filters.assert_called_once_with("processing_execution", d_action["body_parameters"]["output"]["stored_data"], d_action["tags"])
-                    o_mock_api_list.assert_called_once_with(infos_filter={"info":"val"}, tags_filter={"tag":"val"}, datastore=s_datastore)
+                    o_mock_api_list.assert_called_once_with(infos_filter={"info": "val"}, tags_filter={"tag": "val"}, datastore=s_datastore)
                     self.assertEqual(o_stored_data, o_pe1)
         # pas de stored data trouvé
-        with patch.object(ActionAbstract, "get_filters", return_value=({"info":"val"}, {"tag":"val"})) as o_mock_get_filters:
-            with patch.object(StoredData, "api_list", return_value=[]) as o_mock_api_list :
+        with patch.object(ActionAbstract, "get_filters", return_value=({"info": "val"}, {"tag": "val"})) as o_mock_get_filters:
+            with patch.object(StoredData, "api_list", return_value=[]) as o_mock_api_list:
                 # Appel de la fonction find_stored_data
                 o_stored_data = o_ua.find_stored_data(s_datastore)
                 # Vérifications
                 o_mock_get_filters.assert_called_once_with("processing_execution", d_action["body_parameters"]["output"]["stored_data"], d_action["tags"])
-                o_mock_api_list.assert_called_once_with(infos_filter={"info":"val"}, tags_filter={"tag":"val"}, datastore=s_datastore)
+                o_mock_api_list.assert_called_once_with(infos_filter={"info": "val"}, tags_filter={"tag": "val"}, datastore=s_datastore)
                 self.assertEqual(o_stored_data, None)
 
-    def run_args(self,
-        tags: Optional[Dict[str,Any]],
-        comments: Optional[List[str]],
-        s_key: str,
-        s_type_output: str,
-        datastore: Optional[str],
-        output_already_exist: bool = False,
-        behavior: Optional[str] = None,
-    ) -> None:
-        """lancement + test de ProcessingExecutionAction.run selon param
+    # pylint: disable=protected-access
+    def test_gestion_update_entity(self) -> None:
+        """test de __gestion_update_entity"""
+        s_datastore = "update"
+        s_behavior = ProcessingExecutionAction.BEHAVIOR_STOP
 
-        Args:
-            tags (Optional[Dict[str, Any]]): dictionnaire des tags ou None
-            comments (Optional[List]): liste des commentaires ou None
-            s_type_output (str): type de l'output (stored_data ou upload)
-        """
-        self.i += 1
-        with self.subTest(i=self.i):
-            d_action: Dict[str, Any] = {"type": "processing-execution", "body_parameters":{"output":{s_key:"test"}}}
-            if tags is not None:
-                d_action["tags"] = tags
-            if comments is not None:
-                d_action["comments"] = comments
+        # cas non pris en compte
+        l_action: List[Dict[str, Any]] = [
+            {"body_parameters": {}},
+            {"body_parameters": {"output": {}}},
+            {"body_parameters": {"output": {"upload": {}}}},
+            {"body_parameters": {"output": {"stored_data": {"name": ""}}}},
+        ]
+        for d_action in l_action:
+            o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
+            with patch.object(StoredData, "api_get") as o_mock_api_get:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                o_mock_api_get.assert_not_called()
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", d_action, behavior=behavior)
+        # pas de stored_data
+        s_id = "uuid"
+        d_action = {"body_parameters": {"output": {"stored_data": {"_id": s_id}}, "processing": "id_processing", "inputs": {"stored_data": ["id_1", "id_2"]}, "parameters": {"param1": "val1"}}}
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
+        with patch.object(StoredData, "api_get", return_value=None) as o_mock_api_get:
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+            o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+            self.assertEqual(e_err.exception.message, "La donnée en sortie est introuvable, impossible de faire la mise à jour.")
 
-            # mock de processing execution
-            d_store_properties = {"output": {s_type_output: {"_id": "id"}}}
-            o_mock_processing_execution = MagicMock()
-            o_mock_processing_execution.get_store_properties.return_value = d_store_properties
-            o_mock_processing_execution.api_launch.return_value = None
-            # o_mock_processing_execution.__getitem__.return_value = ProcessingExecution.STATUS_CREATED
-            # ça veut dire que : o_mock_processing_execution["quelchechose"] = "CREATED"
-            def get_items_processing(key:str) -> Any:
-                if key == "status":
-                    return "CREATED"
-                return MagicMock()
-            o_mock_processing_execution.__getitem__.side_effect = get_items_processing
+        # pas de traitement correspondant trouvé
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+        # les traitements ne correspondent pas
+        o_pe_1 = MagicMock()  # input upload
+        o_pe_1.get_store_properties.return_value = {"inputs": {"upload": [{"_id": "uuid"}]}}
+        o_pe_2 = MagicMock()  # input stored_data not match
+        o_pe_2.get_store_properties.return_value = {"inputs": {"stored_data": [{"_id": "uuid"}]}}
+        o_pe_3 = MagicMock()  # input stored_data match + param not match
+        o_pe_3.get_store_properties.return_value = {"inputs": {"stored_data": [{"_id": "id_1"}, {"_id": "id_2"}]}, "parameters": {"autre": "val"}}
 
-            # mock de upload d'entrée
-            o_mock_upload = MagicMock()
-            o_mock_upload.api_add_tags.return_value = None
-            o_mock_upload.api_add_comment.return_value = None
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+        o_pe_4 = MagicMock()  # input stored_data match + param not match
+        o_pe_4.get_store_properties.return_value = {"inputs": {"stored_data": [{"_id": "id_1"}, {"_id": "id_2"}]}, "parameters": d_action["body_parameters"]["parameters"]}
 
-            # mock de stored_data d'entrée
-            o_mock_stored_data = MagicMock()
-            o_mock_stored_data.api_add_tags.return_value = None
-            o_mock_stored_data.api_add_comment.return_value = None
+        # BEHAVIOR_STOP
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                    o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                    d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
+                    o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                    self.assertEqual(e_err.exception.message, f"Le traitement a déjà été lancée pour mettre à jour cette donnée {o_pe_4}.")
 
-            # résultat de ProcessingExecutionAction."find_stored_data" : stored_data de sortie
-            o_exist_output = None
-            if output_already_exist:
-                o_mock_exist_output = MagicMock()
-                o_mock_exist_output.api_delete.return_value = None
-                o_exist_output = o_mock_exist_output
+        # BEHAVIOR_DELETE
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_DELETE)
+        o_pe_4.get_store_properties.return_value = {
+            "inputs": {"stored_data": [{"_id": "id_1"}, {"_id": "id_2"}]},
+            "parameters": d_action["body_parameters"]["parameters"],
+            "status": ProcessingExecution.STATUS_FAILURE,
+        }
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                self.assertIsNone(o_pea.processing_execution)
+                self.assertIsNone(o_pea.stored_data)
 
-            # suppression de la mise en page forcée pour le with
-            with patch.object(Upload, "api_get", return_value=o_mock_upload) as o_mock_upload_api_get, \
-                patch.object(StoredData, "api_get", return_value=o_mock_stored_data) as o_mock_stored_data_api_get, \
-                patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create, \
-                patch.object(ProcessingExecution, "api_list", return_value=[o_mock_processing_execution]) as o_mock_pe_api_list, \
-                patch.object(ProcessingExecutionAction, "find_stored_data", return_value=o_exist_output) as o_mock_pea_find_stored_data, \
-                patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=output_already_exist), \
-                patch.object(Config, "get_str", return_value="STOP") \
-            :
-                # dans le cas où une entité existe déjà dans la gpf :
-                if output_already_exist:
-                    if not behavior or behavior == "STOP":
-                        # on attend une erreur
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_exist_output} existe déjà.")
-                        return
+        # BEHAVIOR_RESUME + STATUS_FAILURE
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                self.assertIsNone(o_pea.processing_execution)
+                self.assertIsNone(o_pea.stored_data)
 
-                    if behavior == "DELETE":
-                        # suppression de l'existant puis normal
-                        o_pea.run(datastore)
-                        # un appel à find_stored_data
-                        o_mock_pea_find_stored_data.assert_called_once_with(datastore)
-                        o_mock_exist_output.api_delete.assert_called_once_with()
-                    elif behavior == "CONTINUE":
-                        # premier test sur STATUS_UNSTABLE
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_UNSTABLE
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(
-                            o_err.exception.message,
-                            f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_exist_output}. Impossible de lancer le traitement demandé."
-                        )
+        # BEHAVIOR_RESUME + not STATUS_FAILURE
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pe_4.get_store_properties.return_value = {
+            "inputs": {"stored_data": [{"_id": "id_1"}, {"_id": "id_2"}]},
+            "parameters": d_action["body_parameters"]["parameters"],
+            "status": ProcessingExecution.STATUS_CREATED,
+        }
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, o_pe_4)
+                self.assertEqual(o_pea.stored_data, o_mock_api_get.return_value)
 
-                        # deuxième test sur la stored data créée
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_CREATED
-                        o_pea.run(datastore)
-                        o_mock_pe_api_list.assert_called_once_with({"output_stored_data":o_mock_exist_output.id}, datastore=datastore)
-                        self.assertEqual(o_pea.processing_execution, o_mock_processing_execution)
+        # BEHAVIOR_RESUME + not STATUS_FAILURE, stored_data unstable
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                self.assertEqual(
+                    e_err.exception.message,
+                    (
+                        f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. "
+                        "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
+                        "pour faire réinitialiser son statut."
+                    ),
+                )
 
-                        # troisième test sur l'absence de la processing execution
-                        o_mock_pe_api_list.return_value = []
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_exist_output}")
+        # BEHAVIOR_CONTINUE + not STATUS_FAILURE
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, o_pe_4)
+                self.assertEqual(o_pea.stored_data, o_mock_api_get.return_value)
+        # BEHAVIOR_CONTINUE + not STATUS_FAILURE, stored_data unstable
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                self.assertEqual(
+                    e_err.exception.message,
+                    (
+                        f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. "
+                        "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
+                        "pour faire réinitialiser son statut."
+                    ),
+                )
 
-                        return
-                    elif behavior == "RESUME":
-                        # premier test sur la stored data créée
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_CREATED
-                        o_pea.run(datastore)
-                        o_mock_pe_api_list.assert_called_once_with({"output_stored_data":o_mock_exist_output.id}, datastore=datastore)
-                        self.assertEqual(o_pea.processing_execution, o_mock_processing_execution)
+        # behavior non valide
+        s_behavior = "toto"
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                self.assertEqual(
+                    e_err.exception.message, f"Le comportement {s_behavior} n'est pas reconnu ({'|'.join(ProcessingExecutionAction.BEHAVIORS)}), l'exécution de traitement n'est pas possible."
+                )
 
-                        o_mock_exist_output.reset_mock()
-                        o_mock_pea_find_stored_data.reset_mock()
+    def test_init(self) -> None:
+        """test de __init__"""
+        d_action: Dict[str, Any] = {"type": "processing-execution"}
 
-                        # deuxième test sur l'absence de la processing execution
-                        o_mock_pe_api_list.return_value = []
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_exist_output}")
+        # behavior défini et compatibility_cartes défini
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior="STOP", compatibility_cartes=True)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "STOP")
+                self.assertEqual(o_pe._ProcessingExecutionAction__mode_cartes, True)
+                o_mock_get_str.assert_not_called()
+                o_mock_get_bool.assert_not_called()
 
-                        o_mock_exist_output.reset_mock()
-                        o_mock_pea_find_stored_data.reset_mock()
-                        o_mock_processing_execution.api_launch.reset_mock()
+        # behavior config et compatibility_cartes défini
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior=None, compatibility_cartes=True)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "config")
+                self.assertEqual(o_pe._ProcessingExecutionAction__mode_cartes, True)
+                o_mock_get_str.assert_called_once_with("processing_execution", "behavior_if_exists")
+                o_mock_get_bool.assert_not_called()
 
-                        # troisième test sur STATUS_UNSTABLE => suppression puis normal
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_UNSTABLE
-                        o_pea.run(datastore)
-                        # un appel à find_stored_data
-                        o_mock_pea_find_stored_data.assert_called_once_with(datastore)
-                        o_mock_exist_output.api_delete.assert_called_once_with()
-                    else:
-                        # behavior non reconnu. On attend une erreur
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Le comportement {behavior} n'est pas reconnu (STOP|DELETE|CONTINUE|RESUME), l'exécution de traitement n'est pas possible.")
-                        return
+        # behavior config et compatibility_cartes config
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior=None, compatibility_cartes=None)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "config")
+                self.assertEqual(o_pe._ProcessingExecutionAction__mode_cartes, False)
+                o_mock_get_str.assert_called_once_with("processing_execution", "behavior_if_exists")
+                o_mock_get_bool.assert_called_once_with("compatibility_cartes", "activate")
 
-                else:
-                    # on appelle la méthode à tester
-                    o_pea.run(datastore)
-                    o_mock_pea_find_stored_data.assert_not_called()
+    # pylint: disable=protected-access
+    def test_add_tags(self) -> None:
+        """test de __add_tags"""
+        o_processing_execution = MagicMock()
+        d_def: Dict[str, Any] = {"type": "processing-execution"}
+        o_pe = ProcessingExecutionAction("contexte", d_def)
+        o_pe._ProcessingExecutionAction__mode_cartes = False
+        o_pe._ProcessingExecutionAction__processing_execution = o_processing_execution
+        o_pe._ProcessingExecutionAction__no_output = False
 
-                # test de l'appel à ProcessingExecution.api_create
-                o_mock_pe_api_create.assert_called_once_with(d_action['body_parameters'], {"datastore":datastore})
-                # un appel à ProcessingExecution().get_store_properties
-                o_mock_processing_execution.get_store_properties.assert_called_once_with()
+        # pas de tags
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
+                # dict vide
+                d_def["tags"] = {}
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-                # verif appel à Upload/StoredData
-                if "stored_data" in d_store_properties["output"]:
-                    # test  .api_get
-                    o_mock_stored_data_api_get.assert_called_once_with("id", datastore=datastore)
-                    o_mock_upload_api_get.assert_not_called()
+        # pas de output
+        d_tags = {"key": "val"}
+        d_def["tags"] = d_tags
+        o_pe._ProcessingExecutionAction__no_output = True
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-                    # test api_add_tags
-                    if "tags" in d_action and d_action["tags"]:
-                        o_mock_stored_data.api_add_tags.assert_called_once_with(d_action["tags"])
-                    else:
-                        o_mock_stored_data.api_add_tags.assert_not_called()
-                    o_mock_upload.api_add_tags.assert_not_called()
+        # sortie upload
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_called_once_with(d_tags)
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-                    # test commentaires
-                    if "comments" in d_action and d_action["comments"]:
-                        self.assertEqual(len(d_action["comments"]), o_mock_stored_data.api_add_comment.call_count)
-                        for s_comm in d_action["comments"]:
-                            o_mock_stored_data.api_add_comment.assert_any_call({"text": s_comm})
-                    else:
-                        o_mock_stored_data.api_add_comment.assert_not_called()
-                    o_mock_upload.api_add_comment.assert_not_called()
+        # sortie stored_data
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with(d_tags)
 
+        # autre type de sortie => Erreur
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None):
+                with self.assertRaises(StepActionError) as o_err_step:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(o_err_step.exception.message, "ni upload ni stored-data trouvé. Impossible d'ajouter les tags")
 
-                elif "upload" in  d_store_properties["output"]:
-                    # test api_get
-                    o_mock_upload_api_get.assert_called_once_with("id", datastore=datastore)
-                    o_mock_stored_data_api_get.assert_not_called()
+        # compatibility_cartes
+        del d_def["tags"]
+        o_pe._ProcessingExecutionAction__mode_cartes = True
 
-                    # test api_add_tags
-                    if "tags" in d_action and d_action["tags"]:
-                        o_mock_upload.api_add_tags.assert_called_once_with(d_action["tags"])
-                    else:
-                        o_mock_upload.api_add_tags.assert_not_called()
-                    o_mock_stored_data.api_add_tags.assert_not_called()
+        ## pas de tag ajouté (cas traitement non pris en compte)
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-                    # test commentaires
-                    if "comments" in d_action and d_action["comments"]:
-                        self.assertEqual(len(d_action["comments"]), o_mock_upload.api_add_comment.call_count)
-                        for s_comm in d_action["comments"]:
-                            o_mock_upload.api_add_comment.assert_any_call({"text": s_comm})
-                    else:
-                        o_mock_upload.api_add_comment.assert_not_called()
-                    o_mock_stored_data.api_add_comment.assert_not_called()
+        ## mise_en_base : manque datasheet_name
+        d_def["tags"] = d_tags
+        o_processing_execution.get_store_properties.return_value = {"processing": {"_id": "id_mise_en_base"}}
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+        ## mise_en_base : manque inputs
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoires")
+        ## mise_en_base : manque stored_data sortie
+        l_inputs_upload = [MagicMock(id=1), MagicMock(id=2)]
+        o_pe._ProcessingExecutionAction__inputs_upload = l_inputs_upload
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoires")
+        ## mise_en_base : OK
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                # on appelle la méthode privée __add_tags :
+                o_pe._ProcessingExecutionAction__add_tags()
+                for o_upload in l_inputs_upload:
+                    # test sur le nombre d'appels :
+                    self.assertEqual(o_upload.api_add_tags.call_count, 2)
+                    # test sur les paramètres passés :
+                    d_traitement = {"proc_int_id": o_processing_execution.id, "vectordb_id": o_mock_stored_data.return_value.id}
+                    d_etape = {"integration_progress": '{"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}', "integration_current_step": "2"}
+                    o_upload.api_add_tags.assert_has_calls([call(d_traitement), call(d_etape)])
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with({**d_tags, "datasheet_name": "name", "uuid_upload": l_inputs_upload[0].id})
 
-                # un appel à api_launch
-                o_mock_processing_execution.api_launch.assert_called_once_with()
+        ## pyramide_vecteur : manque datasheet_name
+        d_def["tags"] = d_tags
+        o_processing_execution.get_store_properties.return_value = {"processing": {"_id": "id_pyramide_vecteur"}}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+        ## pyramide_vecteur : manque inputs
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+            self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoires")
+        ## pyramide_vecteur : maque stored_data sortie
+        l_inputs_stored_data = [MagicMock(id=1), MagicMock(id=2)]
+        o_pe._ProcessingExecutionAction__inputs_stored_data = l_inputs_stored_data
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+            self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoires")
+
+        ## pyramide_vecteur : OK
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with(
+                    {**d_tags, "datasheet_name": "name", "vectordb_id": l_inputs_stored_data[0].id, "proc_pyr_creat_id": o_processing_execution.id}
+                )
+
+    def test_add_comments(self) -> None:
+        """test de __add_comments"""
+        d_def: Dict[str, Any] = {}
+        o_pe = ProcessingExecutionAction("contexte", d_def)
+        o_pe._ProcessingExecutionAction__no_output = False
+
+        # pas de commentaires
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_comments()
+                o_mock_upload.return_value.api_add_comment.assert_not_called()
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
+
+        # pas de sortie
+        l_comments = ["commentaire1", "commentaire2"]
+        d_def["comments"] = l_comments
+        o_pe._ProcessingExecutionAction__no_output = True
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_comments()
+                o_mock_upload.return_value.api_add_comment.assert_not_called()
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
+
+        # commentaire sur l'upload, pas de commentaire initial
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_upload.return_value.api_list_comments.return_value = []
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_upload.return_value.api_add_comment.assert_any_call({"text": s_comment})
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
+
+        # commentaire sur l'upload, x commentaire initial
+        l_init_comments = ["init1", "init2"]
+        d_def["comments"] = l_comments + l_init_comments
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_upload.return_value.api_list_comments.return_value = [{"text": s_comment} for s_comment in l_init_comments]
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_upload.return_value.api_add_comment.assert_any_call({"text": s_comment})
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
+
+        # commentaire sur l'stored_data, pas de commentaire initial
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_stored_data.return_value.api_list_comments.return_value = []
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_stored_data.return_value.api_add_comment.assert_any_call({"text": s_comment})
+
+        # commentaire sur l'stored_data, x commentaire initial
+        l_init_comments = ["init1", "init2"]
+        d_def["comments"] = l_comments + l_init_comments
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_stored_data.return_value.api_list_comments.return_value = [{"text": s_comment} for s_comment in l_init_comments]
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_stored_data.return_value.api_add_comment.assert_any_call({"text": s_comment})
+
+        # aucune sortie valable
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None):
+                with self.assertRaises(StepActionError) as e_err:
+                    o_pe._ProcessingExecutionAction__add_comments()
+                self.assertEqual(e_err.exception.message, "ni upload ni stored-data trouvé. Impossible d'ajouter les commentaires")
+
+    def test_launch(self) -> None:
+        """test de __launch"""
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_STOP)
+
+        # aucune processing execution
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(StepActionError) as e_err:
+                o_pea._ProcessingExecutionAction__launch()
+            self.assertEqual(e_err.exception.message, "Aucune exécution de traitement trouvée. Impossible de lancer le traitement")
+
+        def get_items_processing(key: str) -> Any:
+            if key == "status":
+                return "CREATED"
+            return MagicMock()
+
+        # pas encore lancé
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_mock_pe.return_value.__getitem__.side_effect = get_items_processing
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_called_once_with()
+
+        # déjà lancé behavior non compatible
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock):
+            with self.assertRaises(StepActionError) as e_err:
+                o_pea._ProcessingExecutionAction__launch()
+            self.assertEqual(e_err.exception.message, "L'exécution de traitement est déjà lancée.")
+
+        # déjà lancé behavior OK
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_not_called()
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_not_called()
+
+    def test_gestion_new_output(self) -> None:
+        """test de __gestion_new_output"""
+        s_datastore = "datastore"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_STOP)
+
+        # pas de stored_data de trouvé
+        with patch.object(ProcessingExecutionAction, "find_stored_data", return_value=None) as o_mock_find_stored_data:
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+
+        # stored_data + behavior STOP
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            self.assertEqual(e_err.exception.message, f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_mock_find_stored_data.return_value} existe déjà.")
+
+        # behavior delete
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_DELETE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            o_mock_find_stored_data.return_value.api_delete.assert_called_once_with()
+            self.assertIsNone(o_pea.processing_execution)
+
+        # behavior continue - unstable
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with patch.object(ProcessingExecution, "api_list") as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                o_mock_api_list.assert_not_called()
+                self.assertEqual(
+                    e_err.exception.message, f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_find_stored_data.return_value}. Impossible de lancer le traitement demandé."
+                )
+
+        # behavior continue - stable - ProcessingExecution non trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe: List[ProcessingExecution] = []
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(e_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_find_stored_data.return_value}")
+
+        # behavior continue - stable - ProcessingExecution trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = [MagicMock(), MagicMock()]
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, l_pe[0])
+
+        # behavior resume - unstable
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            o_mock_find_stored_data.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            o_mock_find_stored_data.return_value.api_delete.assert_called_once_with()
+            self.assertIsNone(o_pea.processing_execution)
+
+        # behavior resume - stable - ProcessingExecution non trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = []
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(e_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_find_stored_data.return_value}")
+
+        # behavior resume - stable - ProcessingExecution trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = [MagicMock(), MagicMock()]
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, l_pe[0])
+
+        # behavior non prévu
+        s_behavior = "NON VALIDE"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=s_behavior)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            self.assertEqual(
+                e_err.exception.message, f"Le comportement {s_behavior} n'est pas reconnu ({'|'.join(ProcessingExecutionAction.BEHAVIORS)}), l'exécution de traitement n'est pas possible."
+            )
+
+    def test_create_processing_execution(self) -> None:
+        """test de __create_processing_execution"""
+        s_datastore = "datastore"
+        d_definition_dict = {"body_parameters": {"key": "val"}}
+        d_data: Dict[str, Any] = {}
+        o_mock_processing_execution = MagicMock()
+        o_mock_processing_execution.get_store_properties.return_value = d_data
+
+        # output_new_entity, creation ProcessingExecution - inputs + output upload
+        d_data["inputs"] = {
+            "upload": [{"_id": f"{i}"} for i in range(3)],
+            "stored_data": [{"_id": f"{i}"} for i in range(3)],
+        }
+        d_data["output"] = {"upload": {"_id": "out"}}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_called_once_with(s_datastore)
+                            o_mock_pe_api_create.assert_called_with(d_definition_dict["body_parameters"], {"datastore": s_datastore})
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            for d_input_upload in d_data["inputs"]["upload"]:
+                                o_mock_upload_api_get.assert_any_call(d_input_upload["_id"], datastore=s_datastore)
+                            self.assertEqual(o_pea.inputs_upload, [o_mock_upload_api_get.return_value] * len(d_data["inputs"]["upload"]))
+                            for d_input_stored_data in d_data["inputs"]["stored_data"]:
+                                o_mock_stored_data_api_get.assert_any_call(d_input_stored_data["_id"], datastore=s_datastore)
+                            o_mock_upload_api_get.assert_any_call(d_data["output"]["upload"]["_id"], datastore=s_datastore)
+                            self.assertEqual(o_pea.inputs_stored_data, [o_mock_stored_data_api_get.return_value] * len(d_data["inputs"]["stored_data"]))
+                            self.assertFalse(o_pea.no_output)
+                            self.assertEqual(o_pea.upload, o_mock_upload_api_get.return_value)
+                            self.assertIsNone(o_pea.stored_data)
+
+        o_mock_processing_execution.reset_mock()
+
+        # pas output_new_entity, creation ProcessingExecution - output stored_data
+        del d_data["inputs"]
+        d_data["output"] = {"stored_data": {"_id": "out"}}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_not_called()
+                            o_mock_pe_api_create.assert_called_with(d_definition_dict["body_parameters"], {"datastore": s_datastore})
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            o_mock_stored_data_api_get.assert_called_once_with(d_data["output"]["stored_data"]["_id"], datastore=s_datastore)
+                            self.assertFalse(o_pea.no_output)
+                            self.assertEqual(o_pea.stored_data, o_mock_stored_data_api_get.return_value)
+                            o_mock_upload_api_get.assert_not_called()
+                            self.assertIsNone(o_pea.upload)
+                            self.assertIsNone(o_pea.inputs_stored_data)
+                            self.assertIsNone(o_pea.inputs_upload)
+
+        o_mock_processing_execution.reset_mock()
+
+        # pas output_new_entity, pas creation ProcessingExecution - no output
+        del d_data["output"]
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create") as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_not_called()
+                            o_mock_pe_api_create.assert_not_called()
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            self.assertTrue(o_pea.no_output)
+                            self.assertIsNone(o_pea.stored_data)
+                            self.assertIsNone(o_pea.upload)
+                            o_mock_upload_api_get.assert_not_called()
+                            o_mock_stored_data_api_get.assert_not_called()
+                            self.assertIsNone(o_pea.inputs_stored_data)
+                            self.assertIsNone(o_pea.inputs_upload)
+
+        # pb sur les output : None
+        d_data["output"] = None
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+            self.assertEqual(e_err.exception.message, "Erreur à la création de l'exécution de traitement : impossible de récupérer l'entité en sortie.")
+
+        # pb sur les output : autre
+        d_data["output"] = {"autre": "val"}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(StepActionError) as e_err_step:
+                o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+            self.assertEqual(e_err_step.exception.message, f"Aucune correspondance pour {d_data['output'].keys()}")
 
     def test_run(self) -> None:
         """test de run"""
-        s_key = "name"
-        # test upload
-        for s_datastore in [None, "datastore"]:
-            for s_type_output in [ "upload", "stored_data"]:
-                ## sans tag + sans commentaire
-                self.run_args(None, None, s_key, s_type_output, s_datastore)
-                ## tag vide + commentaire vide
-                self.run_args({}, [], s_key, s_type_output, s_datastore)
-                ## 1 tag + 1 commentaire
-                self.run_args({"tag1": "val1"}, ["comm1"], s_key, s_type_output, s_datastore)
-                ## 2 tag + 4 commentaire
-                self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore)
 
-        # tests particuliers pour cas ou la sortie existe déjà
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "STOP")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "DELETE")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "CONTINUE")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "RESUME")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "Toto")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, None)
+        s_datastore = "datastore"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
 
-        # cas en erreurs non spécifique
-        d_action: Dict[str, Any] = {"type": "processing-execution", "body_parameters":{"output":{s_key:"test"}}, "tags": {"key":"val"}, "comments": ["comm"]}
-        o_mock_processing_execution = MagicMock()
-        o_mock_processing_execution.get_store_properties.return_value = {"output":None}
-
-        ## processing_execution.get_store_properties vide après création
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution), \
-            patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=False), \
-            patch.object(Config, "get_str", return_value="STOP") \
-        :
-            with self.assertRaises(GpfSdkError) as o_err_gpf:
-                o_pea.run()
-            s_message = "Erreur à la création de l'exécution de traitement : impossible de récupérer l'entité en sortie."
-            self.assertEqual(o_err_gpf.exception.message, s_message)
-
-        ## impossible de récupérer le donnée en sortie depuis processing_execution
-        d_output={"autre": "", "key": ""}
-        o_mock_processing_execution.get_store_properties.return_value = {"output":d_output}
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution), \
-            patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=False), \
-            patch.object(Config, "get_str", return_value="STOP") \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = f"Aucune correspondance pour {d_output.keys()}"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## impossible d'ajouté un tag, pas de donnée en sortie
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None), \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "ni upload ni stored-data trouvé. Impossible d'ajouter les tags"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## impossible d'ajouté un commentaire, pas de donnée en sortie
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None), \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "ni upload ni stored-data trouvé. Impossible d'ajouter les commentaires"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## __launch pas de processing_execution
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "Aucune exécution de traitement trouvée. Impossible de lancer le traitement"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## __launch traitement pas déjà lancé et pas en mode continue ou reprise
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value={"status": "autre"}), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "L'exécution de traitement est déjà lancée."
-            self.assertEqual(o_err_step.exception.message, s_message)
-
+        with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution") as o_mock_create_processing_execution:
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags") as o_mock_add_tags:
+                with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments") as o_mock_add_comments:
+                    with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__launch") as o_mock_launch:
+                        o_pea.run(s_datastore)
+                        o_mock_create_processing_execution.assert_called_once_with(s_datastore)
+                        o_mock_add_tags.assert_called_once_with()
+                        o_mock_add_comments.assert_called_once_with()
+                        o_mock_launch.assert_called_once_with()
 
     def monitoring_until_end_args(self, s_status_end: str, b_waits: bool, b_callback: bool) -> None:
         """lancement + test de ProcessingExecutionAction.monitoring_until_end() selon param
@@ -372,35 +732,35 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             b_callback (bool): si on a une fonction callback
         """
 
-        l_status = [] if not b_waits else [ProcessingExecution.STATUS_CREATED,ProcessingExecution.STATUS_WAITING, ProcessingExecution.STATUS_PROGRESS]
+        l_status = [] if not b_waits else [ProcessingExecution.STATUS_CREATED, ProcessingExecution.STATUS_WAITING, ProcessingExecution.STATUS_PROGRESS]
         f_callback = MagicMock() if b_callback else None
         f_ctrl_c = MagicMock(return_value=True)
 
         # mock de o_mock_processing_execution
         o_mock_processing_execution = MagicMock(name="test")
-        o_mock_processing_execution.get_store_properties.side_effect = [{"status": el} for el in l_status] + [{"status": s_status_end}]*3
+        o_mock_processing_execution.get_store_properties.side_effect = [{"status": el} for el in l_status] + [{"status": s_status_end}] * 3
         o_mock_processing_execution.api_update.return_value = None
 
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value = o_mock_processing_execution), \
-            patch.object(time, "sleep", return_value=None), \
-            patch.object(Config, "get_int", return_value=0) :
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=o_mock_processing_execution):
+            with patch.object(time, "sleep", return_value=None):
+                with patch.object(Config, "get_int", return_value=0):
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", {})
-            s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                    # initialisation de ProcessingExecutionAction
+                    o_pea = ProcessingExecutionAction("contexte", {})
+                    s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-            # vérification valeur de sortie
-            self.assertEqual(s_return, s_status_end)
+                    # vérification valeur de sortie
+                    self.assertEqual(s_return, s_status_end)
 
-            # vérification de l'attente
-            ## update
-            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status)+1)
-            ##log + callback
-            if f_callback is not None:
-                self.assertEqual(f_callback.call_count, len(l_status)+1)
-                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)+1))
+                    # vérification de l'attente
+                    ## update
+                    self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status) + 1)
+                    ##log + callback
+                    if f_callback is not None:
+                        self.assertEqual(f_callback.call_count, len(l_status) + 1)
+                        self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status) + 1))
 
-            f_ctrl_c.assert_not_called()
+                    f_ctrl_c.assert_not_called()
 
     def interrupt_monitoring_until_end_args(self, s_status_end: str, b_waits: bool, b_callback: bool, s_ctrl_c: str, b_upload: bool, b_stored_data: bool, b_new_output: bool) -> None:
         # cas interruption par l'utilisateur.
@@ -427,38 +787,46 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         #     "b_new_output", b_new_output,
         # )
         if b_waits:
-            i_nb_call_back=4
-            l_status = [{"status": ProcessingExecution.STATUS_CREATED}, {"status": ProcessingExecution.STATUS_WAITING}, {"status": ProcessingExecution.STATUS_PROGRESS}, \
-                {"raise": "KeyboardInterrupt"}, {"status": ProcessingExecution.STATUS_PROGRESS}, {"status": ProcessingExecution.STATUS_PROGRESS}, {"status": s_status_end}]
+            i_nb_call_back = 4
+            l_status = [
+                {"status": ProcessingExecution.STATUS_CREATED},
+                {"status": ProcessingExecution.STATUS_WAITING},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"raise": "KeyboardInterrupt"},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"status": s_status_end},
+            ]
         else:
-            i_nb_call_back =2
+            i_nb_call_back = 2
             l_status = [{"status": ProcessingExecution.STATUS_PROGRESS}, {"raise": "KeyboardInterrupt"}, {"status": s_status_end}]
 
         f_callback = MagicMock() if b_callback else None
         if s_ctrl_c == "delete":
             f_ctrl_c = MagicMock(return_value=True)
-        elif s_ctrl_c  == "pass":
+        elif s_ctrl_c == "pass":
             f_ctrl_c = MagicMock(return_value=False)
         else:
             f_ctrl_c = None
 
-        d_definition_dict: Dict[str, Any] = {"body_parameters":{"output":{}}}
+        d_definition_dict: Dict[str, Any] = {"body_parameters": {"output": {}}}
         d_output = {"name": "new"} if b_new_output else {"_id": "ancien"}
-        if b_upload :
+        if b_upload:
             o_mock_upload = MagicMock()
             o_mock_upload.api_delete.return_value = None
             o_mock_stored_data = None
-            d_definition_dict["body_parameters"]["output"]["upload"]=d_output
+            d_definition_dict["body_parameters"]["output"]["upload"] = d_output
         elif b_stored_data:
             o_mock_upload = None
             o_mock_stored_data = MagicMock()
             o_mock_stored_data.api_delete.return_value = None
-            d_definition_dict["body_parameters"]["output"]["stored_data"]=d_output
+            d_definition_dict["body_parameters"]["output"]["stored_data"] = d_output
         else:
             o_mock_upload = None
             o_mock_stored_data = None
 
         i_iter = 0
+
         def status() -> Dict[str, Any]:
             """fonction pour mock de get_store_properties (=> status)
 
@@ -471,7 +839,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             nonlocal i_iter
             s_el = l_status[i_iter]
 
-            i_iter+=1
+            i_iter += 1
             if "raise" in s_el:
                 raise KeyboardInterrupt()
             return s_el
@@ -482,71 +850,69 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_mock_processing_execution.api_update.return_value = None
         o_mock_processing_execution.api_abort.return_value = None
 
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_u:
+                with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_sd:
+                    with patch.object(time, "sleep", return_value=None):
+                        with patch.object(Config, "get_int", return_value=0):
 
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe, \
-            patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_u, \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_sd, \
-            patch.object(time, "sleep", return_value=None), \
-            patch.object(Config, "get_int", return_value=0) :
+                            o_mock_pe.return_value = o_mock_processing_execution
+                            o_mock_u.return_value = o_mock_upload
+                            o_mock_sd.return_value = o_mock_stored_data
 
-            o_mock_pe.return_value = o_mock_processing_execution
-            o_mock_u.return_value = o_mock_upload
-            o_mock_sd.return_value = o_mock_stored_data
+                            # initialisation de ProcessingExecutionAction
+                            o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
+                            # ctrl+C mais continue
+                            if s_ctrl_c == "pass":
+                                s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-            # ctrl+C mais continue
-            if s_ctrl_c  == "pass":
-                s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                                # vérification valeur de sortie
+                                self.assertEqual(s_return, s_status_end)
 
-                # vérification valeur de sortie
-                self.assertEqual(s_return, s_status_end)
+                                # vérification de l'attente
+                                ## update
+                                self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
+                                ##log + callback
+                                if f_callback is not None:
+                                    self.assertEqual(f_callback.call_count, len(l_status))
+                                    self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)))
+                                if f_ctrl_c:
+                                    f_ctrl_c.assert_called_once_with()
+                                return
 
-                # vérification de l'attente
-                ## update
-                self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
-                ##log + callback
-                if f_callback is not None:
-                    self.assertEqual(f_callback.call_count, len(l_status))
-                    self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)))
+                            # vérification sortie en erreur de monitoring_until_end
+                            with self.assertRaises(KeyboardInterrupt):
+                                o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-                if f_ctrl_c:
-                    f_ctrl_c.assert_called_once_with()
-                return
+                            # exécution de abort
+                            if not b_waits:
+                                o_mock_processing_execution.api_abort.assert_not_called()
+                            else:
+                                o_mock_processing_execution.api_abort.assert_called_once_with()
 
-            # vérification sortie en erreur de monitoring_until_end
-            with self.assertRaises(KeyboardInterrupt):
-                o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                            # vérification de l'attente
+                            ## update
+                            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
+                            ##log + callback
+                            if f_callback is not None:
+                                self.assertEqual(f_callback.call_count, i_nb_call_back)
+                                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * i_nb_call_back)
 
-            # exécution de abort
-            if not b_waits:
-                o_mock_processing_execution.api_abort.assert_not_called()
-            else:
-                o_mock_processing_execution.api_abort.assert_called_once_with()
+                            # vérification suppression el de sortie si nouveau
+                            if b_waits and s_status_end == ProcessingExecution.STATUS_ABORTED:
+                                if b_upload and o_mock_upload:
+                                    if b_new_output:
+                                        o_mock_upload.api_delete.assert_called_once_with()
+                                    else:
+                                        o_mock_upload.api_delete.assert_not_called()
+                                elif b_stored_data and o_mock_stored_data:
+                                    if b_new_output:
+                                        o_mock_stored_data.api_delete.assert_called_once_with()
+                                    else:
+                                        o_mock_stored_data.api_delete.assert_not_called()
 
-            # vérification de l'attente
-            ## update
-            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
-            ##log + callback
-            if f_callback is not None:
-                self.assertEqual(f_callback.call_count, i_nb_call_back)
-                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * i_nb_call_back)
-
-            # vérification suppression el de sortie si nouveau
-            if b_waits and s_status_end == ProcessingExecution.STATUS_ABORTED:
-                if b_upload and o_mock_upload:
-                    if b_new_output:
-                        o_mock_upload.api_delete.assert_called_once_with()
-                    else:
-                        o_mock_upload.api_delete.assert_not_called()
-                elif b_stored_data and o_mock_stored_data:
-                    if b_new_output:
-                        o_mock_stored_data.api_delete.assert_called_once_with()
-                    else:
-                        o_mock_stored_data.api_delete.assert_not_called()
-
-    def test_monitoring_until_end(self)-> None:
+    def test_monitoring_until_end(self) -> None:
         """test de monitoring_until_end"""
         for s_status_end in [ProcessingExecution.STATUS_ABORTED, ProcessingExecution.STATUS_SUCCESS, ProcessingExecution.STATUS_FAILURE]:
             for b_waits in [False, True]:
@@ -558,25 +924,69 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                             self.interrupt_monitoring_until_end_args(s_status_end, b_waits, b_callback, s_ctrl_c, False, True, b_new_output)
                             self.interrupt_monitoring_until_end_args(s_status_end, b_waits, b_callback, s_ctrl_c, False, False, b_new_output)
         # cas sans processing execution => impossible
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value = None):
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None):
             o_pea = ProcessingExecutionAction("contexte", {})
             # on attend une erreur
             with self.assertRaises(StepActionError) as o_err:
                 o_pea.monitoring_until_end()
             self.assertEqual(o_err.exception.message, "Aucune processing-execution trouvée. Impossible de suivre le déroulement du traitement")
-            return
 
+        # compatibility_cartes et mise_en_base
+        o_pea = ProcessingExecutionAction("contexte", {})
+        o_mock_processing_execution = MagicMock(id="id_mise_en_base")
+        o_mock_processing_execution.get_store_properties.return_value = {"status": ProcessingExecution.STATUS_SUCCESS}
+        o_pea._ProcessingExecutionAction__mode_cartes = True
+        l_inputs = [MagicMock(), MagicMock()]
 
-    def test_output_new_entity(self)-> None:
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=o_mock_processing_execution):
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                # manque input
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea.monitoring_until_end()
+                self.assertEqual(e_err.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoires")
+                # statu ok
+                o_pea._ProcessingExecutionAction__inputs_upload = l_inputs
+                o_pea.monitoring_until_end()
+                for o_upload in l_inputs:
+                    o_upload.api_add_tags({"integration_progress": "execution_end_ok_integration_progress"})
+                    o_upload.reset_mock()
+                # status ko
+                o_pea.monitoring_until_end()
+                o_mock_processing_execution.get_store_properties.return_value = {"status": ProcessingExecution.STATUS_ABORTED}
+                for o_upload in l_inputs:
+                    o_upload.api_add_tags({"integration_progress": "execution_end_ko_integration_progress"})
+
+    def test_output_new_entity(self) -> None:
         """test de output_new_entity"""
         for s_output in ["upload", "stored_data"]:
             for b_new in [True, False]:
                 d_output = {"name": "new"} if b_new else {"_id": "ancien"}
-                d_definition_dict: Dict[str, Any] = {"body_parameters":{"output":{s_output:d_output}}}
+                d_definition_dict: Dict[str, Any] = {"body_parameters": {"output": {s_output: d_output}}}
                 # initialisation de ProcessingExecutionAction
                 o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
                 self.assertEqual(o_pea.output_new_entity, b_new)
+        # pas de sortie
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters": {}})
+        self.assertFalse(o_pea.output_new_entity)
+        # sortie non stored_data ou upload
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters": {"output": {}}})
+        self.assertFalse(o_pea.output_new_entity)
 
+    def test_output_update_entity(self) -> None:
+        """test de output_update_entity"""
+        for s_output in ["upload", "stored_data"]:
+            for b_update in [True, False]:
+                d_output = {"_id": "ancien"} if b_update else {"name": "new"}
+                d_definition_dict: Dict[str, Any] = {"body_parameters": {"output": {s_output: d_output}}}
+                # initialisation de ProcessingExecutionAction
+                o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
+                self.assertEqual(o_pea.output_update_entity, b_update)
+        # pas de sortie
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters": {}})
+        self.assertFalse(o_pea.output_update_entity)
+        # sortie non stored_data ou upload
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters": {"output": {}}})
+        self.assertFalse(o_pea.output_update_entity)
 
     def test_str(self) -> None:
         """test de __str__"""
@@ -585,6 +995,6 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_action = ProcessingExecutionAction("nom", d_definition)
         self.assertEqual("ProcessingExecutionAction(workflow=nom)", str(o_action))
         # test avec processing execution
-        with patch('sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction.ProcessingExecutionAction.processing_execution', new_callable=PropertyMock) as o_mock_processing_execution:
-            o_mock_processing_execution.return_value = MagicMock(id='test uuid')
+        with patch("sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction.ProcessingExecutionAction.processing_execution", new_callable=PropertyMock) as o_mock_processing_execution:
+            o_mock_processing_execution.return_value = MagicMock(id="test uuid")
             self.assertEqual("ProcessingExecutionAction(workflow=nom, processing_execution=test uuid)", str(o_action))

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -1,5 +1,6 @@
+# mypy: disable-error-code="attr-defined"
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from unittest.mock import PropertyMock, call, patch, MagicMock
 
@@ -18,7 +19,6 @@ from tests.GpfTestCase import GpfTestCase
 # pylint:disable=too-many-locals
 # pylint:disable=too-many-branches
 # pylint:disable=too-many-statements
-# fmt: off
 class ProcessingExecutionActionTestCase(GpfTestCase):
     """Tests ProcessingExecutionAction class.
 
@@ -32,14 +32,14 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_pe1 = ProcessingExecution({"_id": "pe_1"})
         o_pe2 = ProcessingExecution({"_id": "pe_2"})
         # création du dict décrivant l'action
-        d_action:Dict[str, Any] = {
+        d_action: Dict[str, Any] = {
             "type": "processing-execution",
             "body_parameters": {
                 "output": {
-                    "stored_data": {"name": "name_stored_data"}
-                }
+                    "stored_data": {"name": "name_stored_data"},
+                },
             },
-            "tags": {"tag": "val"}
+            "tags": {"tag": "val"},
         }
         # exécution de ProcessingExecutionAction
         o_ua = ProcessingExecutionAction("contexte", d_action)
@@ -47,326 +47,523 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         for s_datastore in [None, "datastore"]:
             ## execution sans datastore
             # Mock de ActionAbstract.get_filters et Upload.api_list
-            with patch.object(ActionAbstract, "get_filters", return_value=({"info":"val"}, {"tag":"val"})) as o_mock_get_filters:
-                with patch.object(StoredData, "api_list", return_value=[o_pe1, o_pe2]) as o_mock_api_list :
+            with patch.object(ActionAbstract, "get_filters", return_value=({"info": "val"}, {"tag": "val"})) as o_mock_get_filters:
+                with patch.object(StoredData, "api_list", return_value=[o_pe1, o_pe2]) as o_mock_api_list:
                     # Appel de la fonction find_stored_data
                     o_stored_data = o_ua.find_stored_data(s_datastore)
                     # Vérifications
                     o_mock_get_filters.assert_called_once_with("processing_execution", d_action["body_parameters"]["output"]["stored_data"], d_action["tags"])
-                    o_mock_api_list.assert_called_once_with(infos_filter={"info":"val"}, tags_filter={"tag":"val"}, datastore=s_datastore)
+                    o_mock_api_list.assert_called_once_with(infos_filter={"info": "val"}, tags_filter={"tag": "val"}, datastore=s_datastore)
                     self.assertEqual(o_stored_data, o_pe1)
         # pas de stored data trouvé
-        with patch.object(ActionAbstract, "get_filters", return_value=({"info":"val"}, {"tag":"val"})) as o_mock_get_filters:
-            with patch.object(StoredData, "api_list", return_value=[]) as o_mock_api_list :
+        with patch.object(ActionAbstract, "get_filters", return_value=({"info": "val"}, {"tag": "val"})) as o_mock_get_filters:
+            with patch.object(StoredData, "api_list", return_value=[]) as o_mock_api_list:
                 # Appel de la fonction find_stored_data
                 o_stored_data = o_ua.find_stored_data(s_datastore)
                 # Vérifications
                 o_mock_get_filters.assert_called_once_with("processing_execution", d_action["body_parameters"]["output"]["stored_data"], d_action["tags"])
-                o_mock_api_list.assert_called_once_with(infos_filter={"info":"val"}, tags_filter={"tag":"val"}, datastore=s_datastore)
+                o_mock_api_list.assert_called_once_with(infos_filter={"info": "val"}, tags_filter={"tag": "val"}, datastore=s_datastore)
                 self.assertEqual(o_stored_data, None)
 
-    def run_args(self,
-        tags: Optional[Dict[str,Any]],
-        comments: Optional[List[str]],
-        s_key: str,
-        s_type_output: str,
-        datastore: Optional[str],
-        output_already_exist: bool = False,
-        behavior: Optional[str] = None,
-        message:str = "",
-    ) -> None:
-        """lancement + test de ProcessingExecutionAction.run selon param
+    # pylint: disable=protected-access
+    def test_init(self) -> None:
+        """test de __init__"""
+        d_action: Dict[str, Any] = {"type": "processing-execution"}
 
-        Args:
-            tags (Optional[Dict[str, Any]]): dictionnaire des tags ou None
-            comments (Optional[List]): liste des commentaires ou None
-            s_type_output (str): type de l'output (stored_data ou upload)
-        """
-        self.i += 1
-        with self.subTest(message=message):
-            d_action: Dict[str, Any] = {"type": "processing-execution", "body_parameters":{"output":{s_key:"test"}}}
-            if tags is not None:
-                d_action["tags"] = tags
-            if comments is not None:
-                d_action["comments"] = comments
+        # behavior défini et compatibility_cartes défini
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior="STOP", compatibility_cartes=True)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "STOP")
+                self.assertEqual(o_pe._ProcessingExecutionAction__compatibility_cartes, True)
+                o_mock_get_str.assert_not_called()
+                o_mock_get_bool.assert_not_called()
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", d_action, behavior=behavior)
+        # behavior config et compatibility_cartes défini
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior=None, compatibility_cartes=True)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "config")
+                self.assertEqual(o_pe._ProcessingExecutionAction__compatibility_cartes, True)
+                o_mock_get_str.assert_called_once_with("processing_execution", "behavior_if_exists")
+                o_mock_get_bool.assert_not_called()
 
-            # mock de processing execution
-            d_store_properties = {"output": {s_type_output: {"_id": "id"}}}
-            o_mock_processing_execution = MagicMock()
-            o_mock_processing_execution.get_store_properties.return_value = d_store_properties
-            o_mock_processing_execution.api_launch.return_value = None
-            # o_mock_processing_execution.__getitem__.return_value = ProcessingExecution.STATUS_CREATED
-            # ça veut dire que : o_mock_processing_execution["quelchechose"] = "CREATED"
-            def get_items_processing(key:str) -> Any:
-                if key == "status":
-                    return "CREATED"
-                return MagicMock()
-            o_mock_processing_execution.__getitem__.side_effect = get_items_processing
+        # behavior config et compatibility_cartes config
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior=None, compatibility_cartes=None)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "config")
+                self.assertEqual(o_pe._ProcessingExecutionAction__compatibility_cartes, False)
+                o_mock_get_str.assert_called_once_with("processing_execution", "behavior_if_exists")
+                o_mock_get_bool.assert_called_once_with("compatibility_cartes", "activate")
 
-            # mock de upload d'entrée
-            o_mock_upload = MagicMock()
-            o_mock_upload.api_add_tags.return_value = None
-            o_mock_upload.api_add_comment.return_value = None
+    # pylint: disable=protected-access
+    def test_add_tags(self) -> None:
+        """test de __add_tags"""
+        o_processing_execution = MagicMock()
+        d_def: Dict[str, Any] = {"type": "processing-execution"}
+        o_pe = ProcessingExecutionAction("contexte", d_def)
+        o_pe._ProcessingExecutionAction__compatibility_cartes = False
+        o_pe._ProcessingExecutionAction__processing_execution = o_processing_execution
+        o_pe._ProcessingExecutionAction__no_output = False
 
-            # mock de stored_data d'entrée
-            o_mock_stored_data = MagicMock()
-            o_mock_stored_data.api_add_tags.return_value = None
-            o_mock_stored_data.api_add_comment.return_value = None
+        # pas de tags
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
+                # dict vide
+                d_def["tags"] = {}
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-            # résultat de ProcessingExecutionAction."find_stored_data" : stored_data de sortie
-            o_exist_output = None
-            if output_already_exist:
-                o_mock_exist_output = MagicMock()
-                o_mock_exist_output.api_delete.return_value = None
-                o_exist_output = o_mock_exist_output
+        # pas de output
+        d_tags = {"key": "val"}
+        d_def["tags"] = d_tags
+        o_pe._ProcessingExecutionAction__no_output = True
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-            # suppression de la mise en page forcée pour le with
-            with patch.object(Upload, "api_get", return_value=o_mock_upload) as o_mock_upload_api_get, \
-                patch.object(StoredData, "api_get", return_value=o_mock_stored_data) as o_mock_stored_data_api_get, \
-                patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create, \
-                patch.object(ProcessingExecution, "api_list", return_value=[o_mock_processing_execution]) as o_mock_pe_api_list, \
-                patch.object(ProcessingExecutionAction, "find_stored_data", return_value=o_exist_output) as o_mock_pea_find_stored_data, \
-                patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=output_already_exist), \
-                patch.object(Config, "get_str", return_value="STOP") \
-            :
-                # dans le cas où une entité existe déjà dans la gpf :
-                if output_already_exist:
-                    if not behavior or behavior == "STOP":
-                        # on attend une erreur
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_exist_output} existe déjà.")
-                        return
+        # sortie upload
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_called_once_with(d_tags)
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-                    if behavior == "DELETE":
-                        # suppression de l'existant puis normal
-                        o_pea.run(datastore)
-                        # un appel à find_stored_data
-                        o_mock_pea_find_stored_data.assert_called_once_with(datastore)
-                        o_mock_exist_output.api_delete.assert_called_once_with()
-                    elif behavior == "CONTINUE":
-                        # premier test sur STATUS_UNSTABLE
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_UNSTABLE
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(
-                            o_err.exception.message,
-                            f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_exist_output}. Impossible de lancer le traitement demandé."
-                        )
+        # sortie stored_data
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with(d_tags)
 
-                        # deuxième test sur la stored data créée
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_CREATED
-                        o_pea.run(datastore)
-                        o_mock_pe_api_list.assert_called_once_with({"output_stored_data":o_mock_exist_output.id}, datastore=datastore)
-                        self.assertEqual(o_pea.processing_execution, o_mock_processing_execution)
+        # autre type de sortie => Erreur
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None):
+                with self.assertRaises(StepActionError) as o_err_step:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(o_err_step.exception.message, "ni upload ni stored-data trouvé. Impossible d'ajouter les tags")
 
-                        # troisième test sur l'absence de la processing execution
-                        o_mock_pe_api_list.return_value = []
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_exist_output}")
+        # compatibility_cartes
+        del d_def["tags"]
+        o_pe._ProcessingExecutionAction__compatibility_cartes = True
 
-                        return
-                    elif behavior == "RESUME":
-                        # premier test sur la stored data créée
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_CREATED
-                        o_pea.run(datastore)
-                        o_mock_pe_api_list.assert_called_once_with({"output_stored_data":o_mock_exist_output.id}, datastore=datastore)
-                        self.assertEqual(o_pea.processing_execution, o_mock_processing_execution)
+        ## pas de tag ajouté (cas traitement non pris en compte)
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-                        o_mock_exist_output.reset_mock()
-                        o_mock_pea_find_stored_data.reset_mock()
+        ## mise_en_base : manque datasheet_name
+        d_def["tags"] = d_tags
+        o_processing_execution.id = "id_mise_en_base"
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+        ## mise_en_base : manque inputs
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
+        ## mise_en_base : maque stored_data sortie
+        l_inputs_upload = [MagicMock(id=1), MagicMock(id=2)]
+        o_pe._ProcessingExecutionAction__inputs_upload = l_inputs_upload
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
+        ## mise_en_base : OK
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_progress")
+                o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_current_step")
+                for o_offering in l_inputs_upload:
+                    o_offering.api_add_tags.assert_called_once_with(
+                        {
+                            "integration_progress": "execution_start_integration_progress",
+                            "integration_current_step": "execution_start_integration_current_step",
+                            "proc_int_id": o_processing_execution.id,
+                            "vectordb_id": o_mock_stored_data.return_value.id,
+                        }
+                    )
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with({**d_tags, "datasheet_name": "name", "uuid_upload": l_inputs_upload[0].id})
 
-                        # deuxième test sur l'absence de la processing execution
-                        o_mock_pe_api_list.return_value = []
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_exist_output}")
+        ## pyramide_vecteur : manque datasheet_name
+        d_def["tags"] = d_tags
+        o_processing_execution.id = "id_pyramide_vecteur"
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+        ## pyramide_vecteur : manque inputs
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoire")
+        ## pyramide_vecteur : maque stored_data sortie
+        l_inputs_stored_data = [MagicMock(id=1), MagicMock(id=2)]
+        o_pe._ProcessingExecutionAction__inputs_stored_data = l_inputs_stored_data
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoire")
 
-                        o_mock_exist_output.reset_mock()
-                        o_mock_pea_find_stored_data.reset_mock()
-                        o_mock_processing_execution.api_launch.reset_mock()
-                        o_mock_processing_execution.get_store_properties.reset_mock()
-                        o_mock_stored_data_api_get.reset_mock()
-                        o_mock_upload_api_get.reset_mock()
+        ## pyramide_vecteur : OK
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with(
+                    {**d_tags, "datasheet_name": "name", "vectordb_id": l_inputs_stored_data[0].id, "proc_pyr_creat_id": o_processing_execution.id}
+                )
 
-                        # troisième test sur STATUS_UNSTABLE => suppression puis normal
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_UNSTABLE
-                        o_pea.run(datastore)
-                        # un appel à find_stored_data
-                        o_mock_pea_find_stored_data.assert_called_once_with(datastore)
-                        o_mock_exist_output.api_delete.assert_called_once_with()
-                    else:
-                        # behavior non reconnu. On attend une erreur
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Le comportement {behavior} n'est pas reconnu (STOP|DELETE|CONTINUE|RESUME), l'exécution de traitement n'est pas possible.")
-                        return
+    def test_add_comments(self) -> None:
+        """test de __add_comments"""
+        d_def: Dict[str, Any] = {}
+        o_pe = ProcessingExecutionAction("contexte", d_def)
+        o_pe._ProcessingExecutionAction__no_output = False
 
-                else:
-                    # on appelle la méthode à tester
-                    o_pea.run(datastore)
-                    o_mock_pea_find_stored_data.assert_not_called()
+        # pas de commentaires
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_comments()
+                o_mock_upload.return_value.api_add_comment.assert_not_called()
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
 
-                # test de l'appel à ProcessingExecution.api_create
-                o_mock_pe_api_create.assert_called_once_with(d_action['body_parameters'], {"datastore":datastore})
-                # un appel à ProcessingExecution().get_store_properties
-                o_mock_processing_execution.get_store_properties.assert_called_once_with()
+        # pas de sortie
+        l_comments = ["commentaire1", "commentaire2"]
+        d_def["comments"] = l_comments
+        o_pe._ProcessingExecutionAction__no_output = True
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_comments()
+                o_mock_upload.return_value.api_add_comment.assert_not_called()
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
 
-                # verif appel à Upload/StoredData
-                if "stored_data" in d_store_properties["output"]:
-                    # test  .api_get
-                    o_mock_stored_data_api_get.assert_called_once_with("id", datastore=datastore)
-                    o_mock_upload_api_get.assert_not_called()
+        # commentaire sur l'upload, pas de commentaire initial
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_upload.return_value.api_list_comments.return_value = []
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_upload.return_value.api_add_comment.assert_any_call({"text": s_comment})
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
 
-                    # test api_add_tags
-                    if "tags" in d_action and d_action["tags"]:
-                        o_mock_stored_data.api_add_tags.assert_called_once_with(d_action["tags"])
-                    else:
-                        o_mock_stored_data.api_add_tags.assert_not_called()
-                    o_mock_upload.api_add_tags.assert_not_called()
+        # commentaire sur l'upload, x commentaire initial
+        l_init_comments = ["init1", "init2"]
+        d_def["comments"] = l_comments + l_init_comments
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_upload.return_value.api_list_comments.return_value = [{"text": s_comment} for s_comment in l_init_comments]
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_upload.return_value.api_add_comment.assert_any_call({"text": s_comment})
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
 
-                    # test commentaires
-                    if "comments" in d_action and d_action["comments"]:
-                        self.assertEqual(len(d_action["comments"]), o_mock_stored_data.api_add_comment.call_count)
-                        for s_comm in d_action["comments"]:
-                            o_mock_stored_data.api_add_comment.assert_any_call({"text": s_comm})
-                    else:
-                        o_mock_stored_data.api_add_comment.assert_not_called()
-                    o_mock_upload.api_add_comment.assert_not_called()
+        # commentaire sur l'stored_data, pas de commentaire initial
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_stored_data.return_value.api_list_comments.return_value = []
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_stored_data.return_value.api_add_comment.assert_any_call({"text": s_comment})
 
+        # commentaire sur l'stored_data, x commentaire initial
+        l_init_comments = ["init1", "init2"]
+        d_def["comments"] = l_comments + l_init_comments
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_stored_data.return_value.api_list_comments.return_value = [{"text": s_comment} for s_comment in l_init_comments]
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_stored_data.return_value.api_add_comment.assert_any_call({"text": s_comment})
 
-                elif "upload" in  d_store_properties["output"]:
-                    # test api_get
-                    o_mock_upload_api_get.assert_called_once_with("id", datastore=datastore)
-                    o_mock_stored_data_api_get.assert_not_called()
+        # aucune sortie valable
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None):
+                with self.assertRaises(StepActionError) as e_err:
+                    o_pe._ProcessingExecutionAction__add_comments()
+                self.assertEqual(e_err.exception.message, "ni upload ni stored-data trouvé. Impossible d'ajouter les commentaires")
 
-                    # test api_add_tags
-                    if "tags" in d_action and d_action["tags"]:
-                        o_mock_upload.api_add_tags.assert_called_once_with(d_action["tags"])
-                    else:
-                        o_mock_upload.api_add_tags.assert_not_called()
-                    o_mock_stored_data.api_add_tags.assert_not_called()
+    def test_launch(self) -> None:
+        """test de __launch"""
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_STOP)
 
-                    # test commentaires
-                    if "comments" in d_action and d_action["comments"]:
-                        self.assertEqual(len(d_action["comments"]), o_mock_upload.api_add_comment.call_count)
-                        for s_comm in d_action["comments"]:
-                            o_mock_upload.api_add_comment.assert_any_call({"text": s_comm})
-                    else:
-                        o_mock_upload.api_add_comment.assert_not_called()
-                    o_mock_stored_data.api_add_comment.assert_not_called()
+        # aucune processing execution
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(StepActionError) as e_err:
+                o_pea._ProcessingExecutionAction__launch()
+            self.assertEqual(e_err.exception.message, "Aucune exécution de traitement trouvée. Impossible de lancer le traitement")
 
-                # un appel à api_launch
-                o_mock_processing_execution.api_launch.assert_called_once_with()
+        def get_items_processing(key: str) -> Any:
+            if key == "status":
+                return "CREATED"
+            return MagicMock()
+
+        # pas encore lancé
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_mock_pe.return_value.__getitem__.side_effect = get_items_processing
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_called_once_with()
+
+        # déjà lancé behavior non compatible
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock):
+            with self.assertRaises(StepActionError) as e_err:
+                o_pea._ProcessingExecutionAction__launch()
+            self.assertEqual(e_err.exception.message, "L'exécution de traitement est déjà lancée.")
+
+        # déjà lancé behavior OK
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_not_called()
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_not_called()
+
+    def test_gestion_new_output(self) -> None:
+        """test de __gestion_new_output"""
+        s_datastore = "datastore"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_STOP)
+
+        # pas de stored_data de trouvé
+        with patch.object(ProcessingExecutionAction, "find_stored_data", return_value=None) as o_mock_find_stored_data:
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+
+        # stored_data + behavior STOP
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            self.assertEqual(e_err.exception.message, f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_mock_find_stored_data.return_value} existe déjà.")
+
+        # behavior delete
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_DELETE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            o_mock_find_stored_data.return_value.api_delete.assert_called_once_with()
+            self.assertIsNone(o_pea.processing_execution)
+
+        # behavior continue - unstable
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with patch.object(ProcessingExecution, "api_list") as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                o_mock_api_list.assert_not_called()
+                self.assertEqual(
+                    e_err.exception.message, f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_find_stored_data.return_value}. Impossible de lancer le traitement demandé."
+                )
+
+        # behavior continue - stable - ProcessingExecution non trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe: List[ProcessingExecution] = []
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(e_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_find_stored_data.return_value}")
+
+        # behavior continue - stable - ProcessingExecution trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = [MagicMock(), MagicMock()]
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, l_pe[0])
+
+        # behavior resume - unstable
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            o_mock_find_stored_data.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            o_mock_find_stored_data.return_value.api_delete.assert_called_once_with()
+            self.assertIsNone(o_pea.processing_execution)
+
+        # behavior resume - stable - ProcessingExecution non trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = []
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(e_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_find_stored_data.return_value}")
+
+        # behavior resume - stable - ProcessingExecution trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = [MagicMock(), MagicMock()]
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, l_pe[0])
+
+        # behavior non prévu
+        s_behavior = "NON VALIDE"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=s_behavior)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            self.assertEqual(
+                e_err.exception.message, f"Le comportement {s_behavior} n'est pas reconnu ({'|'.join(ProcessingExecutionAction.BEHAVIORS)}), l'exécution de traitement n'est pas possible."
+            )
+
+    def test_create_processing_execution(self) -> None:
+        """test de __create_processing_execution"""
+        s_datastore = "datastore"
+        d_definition_dict = {"body_parameters": {"key": "val"}}
+        d_data: Dict[str, Any] = {}
+        o_mock_processing_execution = MagicMock()
+        o_mock_processing_execution.get_store_properties.return_value = d_data
+
+        # output_new_entity, creation ProcessingExecution - inputs + output upload
+        d_data["inputs"] = {
+            "upload": [{"_id": f"{i}"} for i in range(3)],
+            "stored_data": [{"_id": f"{i}"} for i in range(3)],
+        }
+        d_data["output"] = {"upload": {"_id": "out"}}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_called_once_with(s_datastore)
+                            o_mock_pe_api_create.assert_called_with(d_definition_dict["body_parameters"], {"datastore": s_datastore})
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            for d_input_upload in d_data["inputs"]["upload"]:
+                                o_mock_upload_api_get.assert_any_call(d_input_upload["_id"], datastore=s_datastore)
+                            self.assertEqual(o_pea.inputs_upload, [o_mock_upload_api_get.return_value] * len(d_data["inputs"]["upload"]))
+                            for d_input_stored_data in d_data["inputs"]["stored_data"]:
+                                o_mock_stored_data_api_get.assert_any_call(d_input_stored_data["_id"], datastore=s_datastore)
+                            o_mock_upload_api_get.assert_any_call(d_data["output"]["upload"]["_id"], datastore=s_datastore)
+                            self.assertEqual(o_pea.inputs_stored_data, [o_mock_stored_data_api_get.return_value] * len(d_data["inputs"]["stored_data"]))
+                            self.assertFalse(o_pea.no_output)
+                            self.assertEqual(o_pea.upload, o_mock_upload_api_get.return_value)
+                            self.assertIsNone(o_pea.stored_data)
+
+        o_mock_processing_execution.reset_mock()
+
+        # pas output_new_entity, creation ProcessingExecution - output stored_data
+        del d_data["inputs"]
+        d_data["output"] = {"stored_data": {"_id": "out"}}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_not_called()
+                            o_mock_pe_api_create.assert_called_with(d_definition_dict["body_parameters"], {"datastore": s_datastore})
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            o_mock_stored_data_api_get.assert_called_once_with(d_data["output"]["stored_data"]["_id"], datastore=s_datastore)
+                            self.assertFalse(o_pea.no_output)
+                            self.assertEqual(o_pea.stored_data, o_mock_stored_data_api_get.return_value)
+                            o_mock_upload_api_get.assert_not_called()
+                            self.assertIsNone(o_pea.upload)
+                            self.assertIsNone(o_pea.inputs_stored_data)
+                            self.assertIsNone(o_pea.inputs_upload)
+
+        o_mock_processing_execution.reset_mock()
+
+        # pas output_new_entity, pas creation ProcessingExecution - no output
+        del d_data["output"]
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create") as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_not_called()
+                            o_mock_pe_api_create.assert_not_called()
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            self.assertTrue(o_pea.no_output)
+                            self.assertIsNone(o_pea.stored_data)
+                            self.assertIsNone(o_pea.upload)
+                            o_mock_upload_api_get.assert_not_called()
+                            o_mock_stored_data_api_get.assert_not_called()
+                            self.assertIsNone(o_pea.inputs_stored_data)
+                            self.assertIsNone(o_pea.inputs_upload)
+
+        # pb sur les output : None
+        d_data["output"] = None
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+            self.assertEqual(e_err.exception.message, "Erreur à la création de l'exécution de traitement : impossible de récupérer l'entité en sortie.")
+
+        # pb sur les output : autre
+        d_data["output"] = {"autre": "val"}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(StepActionError) as e_err_step:
+                o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+            self.assertEqual(e_err_step.exception.message, f"Aucune correspondance pour {d_data['output'].keys()}")
 
     def test_run(self) -> None:
         """test de run"""
-        s_key = "name"
-        # test upload
-        for s_datastore in [None, "datastore"]:
-            for s_type_output in [ "upload", "stored_data"]:
-                ## sans tag + sans commentaire
-                self.run_args(None, None, s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - no tag - no comment")
-                ## tag vide + commentaire vide
-                self.run_args({}, [], s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - vide tag - vide comment")
-                ## 1 tag + 1 commentaire
-                self.run_args({"tag1": "val1"}, ["comm1"], s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 1 tag - 1 comment")
-                ## 2 tag + 4 commentaire
-                self.run_args(
-                    {"tag1": "val1", "tag2": "val2"},
-                    ["comm1", "comm2", "comm3", "comm4"],
-                    s_key, s_type_output, s_datastore,
-                    message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 2 tag - 4 comment",
-                )
 
-        # tests particuliers pour cas ou la sortie existe déjà
-        for s_beavior in ["STOP","DELETE","CONTINUE","RESUME","Toto",None] :
-            self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, s_beavior, message=f"beavior {s_beavior}")
+        s_datastore = "datastore"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
 
-        # cas en erreurs non spécifique
-        d_action: Dict[str, Any] = {"type": "processing-execution", "body_parameters":{"output":{s_key:"test"}}, "tags": {"key":"val"}, "comments": ["comm"]}
-        o_mock_processing_execution = MagicMock()
-        o_mock_processing_execution.get_store_properties.return_value = {"output":None}
-
-        ## processing_execution.get_store_properties vide après création
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution), \
-            patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=False), \
-            patch.object(Config, "get_str", return_value="STOP") \
-        :
-            with self.assertRaises(GpfSdkError) as o_err_gpf:
-                o_pea.run()
-            s_message = "Erreur à la création de l'exécution de traitement : impossible de récupérer l'entité en sortie."
-            self.assertEqual(o_err_gpf.exception.message, s_message)
-
-        ## impossible de récupérer le donnée en sortie depuis processing_execution
-        d_output={"autre": "", "key": ""}
-        o_mock_processing_execution.get_store_properties.return_value = {"output":d_output}
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution), \
-            patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=False), \
-            patch.object(Config, "get_str", return_value="STOP") \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = f"Aucune correspondance pour {d_output.keys()}"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## impossible d'ajouté un tag, pas de donnée en sortie
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None), \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "ni upload ni stored-data trouvé. Impossible d'ajouter les tags"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## impossible d'ajouté un commentaire, pas de donnée en sortie
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None), \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "ni upload ni stored-data trouvé. Impossible d'ajouter les commentaires"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## __launch pas de processing_execution
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "Aucune exécution de traitement trouvée. Impossible de lancer le traitement"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## __launch traitement pas déjà lancé et pas en mode continue ou reprise
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value={"status": "autre"}), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "L'exécution de traitement est déjà lancée."
-            self.assertEqual(o_err_step.exception.message, s_message)
-
+        with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution") as o_mock_create_processing_execution:
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags") as o_mock_add_tags:
+                with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments") as o_mock_add_comments:
+                    with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__launch") as o_mock_launch:
+                        o_pea.run(s_datastore)
+                        o_mock_create_processing_execution.assert_called_once_with(s_datastore)
+                        o_mock_add_tags.assert_called_once_with()
+                        o_mock_add_comments.assert_called_once_with()
+                        o_mock_launch.assert_called_once_with()
 
     def monitoring_until_end_args(self, s_status_end: str, b_waits: bool, b_callback: bool) -> None:
         """lancement + test de ProcessingExecutionAction.monitoring_until_end() selon param
@@ -377,35 +574,35 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             b_callback (bool): si on a une fonction callback
         """
 
-        l_status = [] if not b_waits else [ProcessingExecution.STATUS_CREATED,ProcessingExecution.STATUS_WAITING, ProcessingExecution.STATUS_PROGRESS]
+        l_status = [] if not b_waits else [ProcessingExecution.STATUS_CREATED, ProcessingExecution.STATUS_WAITING, ProcessingExecution.STATUS_PROGRESS]
         f_callback = MagicMock() if b_callback else None
         f_ctrl_c = MagicMock(return_value=True)
 
         # mock de o_mock_processing_execution
         o_mock_processing_execution = MagicMock(name="test")
-        o_mock_processing_execution.get_store_properties.side_effect = [{"status": el} for el in l_status] + [{"status": s_status_end}]*3
+        o_mock_processing_execution.get_store_properties.side_effect = [{"status": el} for el in l_status] + [{"status": s_status_end}] * 3
         o_mock_processing_execution.api_update.return_value = None
 
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value = o_mock_processing_execution), \
-            patch.object(time, "sleep", return_value=None), \
-            patch.object(Config, "get_int", return_value=0) :
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=o_mock_processing_execution):
+            with patch.object(time, "sleep", return_value=None):
+                with patch.object(Config, "get_int", return_value=0):
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", {})
-            s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                    # initialisation de ProcessingExecutionAction
+                    o_pea = ProcessingExecutionAction("contexte", {})
+                    s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-            # vérification valeur de sortie
-            self.assertEqual(s_return, s_status_end)
+                    # vérification valeur de sortie
+                    self.assertEqual(s_return, s_status_end)
 
-            # vérification de l'attente
-            ## update
-            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status)+1)
-            ##log + callback
-            if f_callback is not None:
-                self.assertEqual(f_callback.call_count, len(l_status)+1)
-                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)+1))
+                    # vérification de l'attente
+                    ## update
+                    self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status) + 1)
+                    ##log + callback
+                    if f_callback is not None:
+                        self.assertEqual(f_callback.call_count, len(l_status) + 1)
+                        self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status) + 1))
 
-            f_ctrl_c.assert_not_called()
+                    f_ctrl_c.assert_not_called()
 
     def interrupt_monitoring_until_end_args(self, s_status_end: str, b_waits: bool, b_callback: bool, s_ctrl_c: str, b_upload: bool, b_stored_data: bool, b_new_output: bool) -> None:
         # cas interruption par l'utilisateur.
@@ -432,38 +629,46 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         #     "b_new_output", b_new_output,
         # )
         if b_waits:
-            i_nb_call_back=4
-            l_status = [{"status": ProcessingExecution.STATUS_CREATED}, {"status": ProcessingExecution.STATUS_WAITING}, {"status": ProcessingExecution.STATUS_PROGRESS}, \
-                {"raise": "KeyboardInterrupt"}, {"status": ProcessingExecution.STATUS_PROGRESS}, {"status": ProcessingExecution.STATUS_PROGRESS}, {"status": s_status_end}]
+            i_nb_call_back = 4
+            l_status = [
+                {"status": ProcessingExecution.STATUS_CREATED},
+                {"status": ProcessingExecution.STATUS_WAITING},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"raise": "KeyboardInterrupt"},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"status": s_status_end},
+            ]
         else:
-            i_nb_call_back =2
+            i_nb_call_back = 2
             l_status = [{"status": ProcessingExecution.STATUS_PROGRESS}, {"raise": "KeyboardInterrupt"}, {"status": s_status_end}]
 
         f_callback = MagicMock() if b_callback else None
         if s_ctrl_c == "delete":
             f_ctrl_c = MagicMock(return_value=True)
-        elif s_ctrl_c  == "pass":
+        elif s_ctrl_c == "pass":
             f_ctrl_c = MagicMock(return_value=False)
         else:
             f_ctrl_c = None
 
-        d_definition_dict: Dict[str, Any] = {"body_parameters":{"output":{}}}
+        d_definition_dict: Dict[str, Any] = {"body_parameters": {"output": {}}}
         d_output = {"name": "new"} if b_new_output else {"_id": "ancien"}
-        if b_upload :
+        if b_upload:
             o_mock_upload = MagicMock()
             o_mock_upload.api_delete.return_value = None
             o_mock_stored_data = None
-            d_definition_dict["body_parameters"]["output"]["upload"]=d_output
+            d_definition_dict["body_parameters"]["output"]["upload"] = d_output
         elif b_stored_data:
             o_mock_upload = None
             o_mock_stored_data = MagicMock()
             o_mock_stored_data.api_delete.return_value = None
-            d_definition_dict["body_parameters"]["output"]["stored_data"]=d_output
+            d_definition_dict["body_parameters"]["output"]["stored_data"] = d_output
         else:
             o_mock_upload = None
             o_mock_stored_data = None
 
         i_iter = 0
+
         def status() -> Dict[str, Any]:
             """fonction pour mock de get_store_properties (=> status)
 
@@ -476,7 +681,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             nonlocal i_iter
             s_el = l_status[i_iter]
 
-            i_iter+=1
+            i_iter += 1
             if "raise" in s_el:
                 raise KeyboardInterrupt()
             return s_el
@@ -487,71 +692,69 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_mock_processing_execution.api_update.return_value = None
         o_mock_processing_execution.api_abort.return_value = None
 
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_u:
+                with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_sd:
+                    with patch.object(time, "sleep", return_value=None):
+                        with patch.object(Config, "get_int", return_value=0):
 
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe, \
-            patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_u, \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_sd, \
-            patch.object(time, "sleep", return_value=None), \
-            patch.object(Config, "get_int", return_value=0) :
+                            o_mock_pe.return_value = o_mock_processing_execution
+                            o_mock_u.return_value = o_mock_upload
+                            o_mock_sd.return_value = o_mock_stored_data
 
-            o_mock_pe.return_value = o_mock_processing_execution
-            o_mock_u.return_value = o_mock_upload
-            o_mock_sd.return_value = o_mock_stored_data
+                            # initialisation de ProcessingExecutionAction
+                            o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
+                            # ctrl+C mais continue
+                            if s_ctrl_c == "pass":
+                                s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-            # ctrl+C mais continue
-            if s_ctrl_c  == "pass":
-                s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                                # vérification valeur de sortie
+                                self.assertEqual(s_return, s_status_end)
 
-                # vérification valeur de sortie
-                self.assertEqual(s_return, s_status_end)
+                                # vérification de l'attente
+                                ## update
+                                self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
+                                ##log + callback
+                                if f_callback is not None:
+                                    self.assertEqual(f_callback.call_count, len(l_status))
+                                    self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)))
+                                if f_ctrl_c:
+                                    f_ctrl_c.assert_called_once_with()
+                                return
 
-                # vérification de l'attente
-                ## update
-                self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
-                ##log + callback
-                if f_callback is not None:
-                    self.assertEqual(f_callback.call_count, len(l_status))
-                    self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)))
+                            # vérification sortie en erreur de monitoring_until_end
+                            with self.assertRaises(KeyboardInterrupt):
+                                o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-                if f_ctrl_c:
-                    f_ctrl_c.assert_called_once_with()
-                return
+                            # exécution de abort
+                            if not b_waits:
+                                o_mock_processing_execution.api_abort.assert_not_called()
+                            else:
+                                o_mock_processing_execution.api_abort.assert_called_once_with()
 
-            # vérification sortie en erreur de monitoring_until_end
-            with self.assertRaises(KeyboardInterrupt):
-                o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                            # vérification de l'attente
+                            ## update
+                            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
+                            ##log + callback
+                            if f_callback is not None:
+                                self.assertEqual(f_callback.call_count, i_nb_call_back)
+                                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * i_nb_call_back)
 
-            # exécution de abort
-            if not b_waits:
-                o_mock_processing_execution.api_abort.assert_not_called()
-            else:
-                o_mock_processing_execution.api_abort.assert_called_once_with()
+                            # vérification suppression el de sortie si nouveau
+                            if b_waits and s_status_end == ProcessingExecution.STATUS_ABORTED:
+                                if b_upload and o_mock_upload:
+                                    if b_new_output:
+                                        o_mock_upload.api_delete.assert_called_once_with()
+                                    else:
+                                        o_mock_upload.api_delete.assert_not_called()
+                                elif b_stored_data and o_mock_stored_data:
+                                    if b_new_output:
+                                        o_mock_stored_data.api_delete.assert_called_once_with()
+                                    else:
+                                        o_mock_stored_data.api_delete.assert_not_called()
 
-            # vérification de l'attente
-            ## update
-            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
-            ##log + callback
-            if f_callback is not None:
-                self.assertEqual(f_callback.call_count, i_nb_call_back)
-                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * i_nb_call_back)
-
-            # vérification suppression el de sortie si nouveau
-            if b_waits and s_status_end == ProcessingExecution.STATUS_ABORTED:
-                if b_upload and o_mock_upload:
-                    if b_new_output:
-                        o_mock_upload.api_delete.assert_called_once_with()
-                    else:
-                        o_mock_upload.api_delete.assert_not_called()
-                elif b_stored_data and o_mock_stored_data:
-                    if b_new_output:
-                        o_mock_stored_data.api_delete.assert_called_once_with()
-                    else:
-                        o_mock_stored_data.api_delete.assert_not_called()
-
-    def test_monitoring_until_end(self)-> None:
+    def test_monitoring_until_end(self) -> None:
         """test de monitoring_until_end"""
         for s_status_end in [ProcessingExecution.STATUS_ABORTED, ProcessingExecution.STATUS_SUCCESS, ProcessingExecution.STATUS_FAILURE]:
             for b_waits in [False, True]:
@@ -563,25 +766,47 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                             self.interrupt_monitoring_until_end_args(s_status_end, b_waits, b_callback, s_ctrl_c, False, True, b_new_output)
                             self.interrupt_monitoring_until_end_args(s_status_end, b_waits, b_callback, s_ctrl_c, False, False, b_new_output)
         # cas sans processing execution => impossible
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value = None):
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None):
             o_pea = ProcessingExecutionAction("contexte", {})
             # on attend une erreur
             with self.assertRaises(StepActionError) as o_err:
                 o_pea.monitoring_until_end()
             self.assertEqual(o_err.exception.message, "Aucune processing-execution trouvée. Impossible de suivre le déroulement du traitement")
-            return
 
+        # compatibility_cartes et mise_en_base
+        o_pea = ProcessingExecutionAction("contexte", {})
+        o_mock_processing_execution = MagicMock(id="id_mise_en_base")
+        o_mock_processing_execution.get_store_properties.return_value = {"status": ProcessingExecution.STATUS_SUCCESS}
+        o_pea._ProcessingExecutionAction__compatibility_cartes = True
+        l_inputs = [MagicMock(), MagicMock()]
 
-    def test_output_new_entity(self)-> None:
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=o_mock_processing_execution):
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                # manque input
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea.monitoring_until_end()
+                self.assertEqual(e_err.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
+                # statu ok
+                o_pea._ProcessingExecutionAction__inputs_upload = l_inputs
+                o_pea.monitoring_until_end()
+                for o_upload in l_inputs:
+                    o_upload.api_add_tags({"integration_progress": "execution_end_ok_integration_progress"})
+                    o_upload.reset_mock()
+                # status ko
+                o_pea.monitoring_until_end()
+                o_mock_processing_execution.get_store_properties.return_value = {"status": ProcessingExecution.STATUS_ABORTED}
+                for o_upload in l_inputs:
+                    o_upload.api_add_tags({"integration_progress": "execution_end_ko_integration_progress"})
+
+    def test_output_new_entity(self) -> None:
         """test de output_new_entity"""
         for s_output in ["upload", "stored_data"]:
             for b_new in [True, False]:
                 d_output = {"name": "new"} if b_new else {"_id": "ancien"}
-                d_definition_dict: Dict[str, Any] = {"body_parameters":{"output":{s_output:d_output}}}
+                d_definition_dict: Dict[str, Any] = {"body_parameters": {"output": {s_output: d_output}}}
                 # initialisation de ProcessingExecutionAction
                 o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
                 self.assertEqual(o_pea.output_new_entity, b_new)
-
 
     def test_str(self) -> None:
         """test de __str__"""
@@ -590,6 +815,6 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_action = ProcessingExecutionAction("nom", d_definition)
         self.assertEqual("ProcessingExecutionAction(workflow=nom)", str(o_action))
         # test avec processing execution
-        with patch('sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction.ProcessingExecutionAction.processing_execution', new_callable=PropertyMock) as o_mock_processing_execution:
-            o_mock_processing_execution.return_value = MagicMock(id='test uuid')
+        with patch("sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction.ProcessingExecutionAction.processing_execution", new_callable=PropertyMock) as o_mock_processing_execution:
+            o_mock_processing_execution.return_value = MagicMock(id="test uuid")
             self.assertEqual("ProcessingExecutionAction(workflow=nom, processing_execution=test uuid)", str(o_action))

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -276,7 +276,12 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                 ## 1 tag + 1 commentaire
                 self.run_args({"tag1": "val1"}, ["comm1"], s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 1 tag - 1 comment")
                 ## 2 tag + 4 commentaire
-                self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 2 tag - 4 comment")
+                self.run_args(
+                    {"tag1": "val1", "tag2": "val2"},
+                    ["comm1", "comm2", "comm3", "comm4"],
+                    s_key, s_type_output, s_datastore,
+                    message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 2 tag - 4 comment",
+                )
 
         # tests particuliers pour cas ou la sortie existe déjà
         for s_beavior in ["STOP","DELETE","CONTINUE","RESUME","Toto",None] :

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -65,6 +65,200 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                 o_mock_api_list.assert_called_once_with(infos_filter={"info":"val"}, tags_filter={"tag":"val"}, datastore=s_datastore)
                 self.assertEqual(o_stored_data, None)
 
+    # pylint: disable=protected-access
+    def test_gestion_update_entity(self)-> None:
+        """test de __gestion_update_entity"""
+        s_datastore="update"
+        s_behavior = ProcessingExecutionAction.BEHAVIOR_STOP
+
+        # cas non pris en compte
+        l_action : List[Dict[str, Any]]=[
+            {"body_parameters":{}},
+            {"body_parameters":{"output":{}}},
+            {"body_parameters":{"output":{"upload": {}}}},
+            {"body_parameters":{"output":{"stored_data": {"name": ""}}}},
+        ]
+        for d_action in l_action:
+            o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
+            with patch.object(StoredData, "api_get") as  o_mock_api_get:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                o_mock_api_get.assert_not_called()
+
+        # pas de stored_data
+        s_id = "uuid"
+        d_action = {"body_parameters":{
+            "output":{"stored_data": {"_id": s_id}},
+            "processing": "id_processing",
+            "inputs":{"stored_data": ["id_1", "id_2"]},
+            "parameters" : {"param1": "val1"}
+
+        }}
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
+        with patch.object(StoredData, "api_get", return_value = None) as  o_mock_api_get:
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)# type: ignore
+            o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+            self.assertEqual(e_err.exception.message, "La donnée en sortie est introuvable, impossible de faire la mise à jour.")
+
+        # pas de traitement correspondant trouvé
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[]) as  o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {
+                    "output_stored_data": o_mock_api_get.return_value.id,
+                    "processing": d_action["body_parameters"]["processing"],
+                    'input_stored_data': 'id_1'
+                }
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+        # les traitements ne correspondent pas
+        o_pe_1=MagicMock() # input upload
+        o_pe_1.get_store_properties.return_value = {"inputs":{"upload":[{"_id" : "uuid"}]}}
+        o_pe_2=MagicMock() # input stored_data not match
+        o_pe_2.get_store_properties.return_value = {"inputs":{"stored_data":[{"_id" : "uuid"}]}}
+        o_pe_3=MagicMock()# input stored_data match + param not match
+        o_pe_3.get_store_properties.return_value = {"inputs":{"stored_data":[{"_id" : "id_1"},{"_id" : "id_2"}]}, "parameters": {"autre": "val"}}
+
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3]) as  o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {
+                    "output_stored_data": o_mock_api_get.return_value.id,
+                    "processing": d_action["body_parameters"]["processing"],
+                    'input_stored_data': 'id_1'
+                }
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+        o_pe_4=MagicMock()# input stored_data match + param not match
+        o_pe_4.get_store_properties.return_value = {"inputs":{"stored_data":[{"_id" : "id_1"},{"_id" : "id_2"}]}, "parameters": d_action["body_parameters"]["parameters"]}
+
+        # BEHAVIOR_STOP
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                    o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                    d_filter = {
+                        "output_stored_data": o_mock_api_get.return_value.id,
+                        "processing": d_action["body_parameters"]["processing"],
+                        'input_stored_data': 'id_1'
+                    }
+                    o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                    self.assertEqual(e_err.exception.message, f"Le traitement a déjà été lancée pour mettre à jour cette donnée {o_pe_4}.")
+
+        # BEHAVIOR_DELETE
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_DELETE)
+        o_pe_4.get_store_properties.return_value = {
+            "inputs":{"stored_data":[{"_id" : "id_1"},{"_id" : "id_2"}]},
+            "parameters": d_action["body_parameters"]["parameters"],
+            "status": ProcessingExecution.STATUS_FAILURE,
+        }
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {
+                    "output_stored_data": o_mock_api_get.return_value.id,
+                    "processing": d_action["body_parameters"]["processing"],
+                    'input_stored_data': 'id_1'
+                }
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                self.assertIsNone(o_pea.processing_execution)
+                self.assertIsNone(o_pea.stored_data)
+
+        # BEHAVIOR_RESUME + STATUS_FAILURE
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {
+                    "output_stored_data": o_mock_api_get.return_value.id,
+                    "processing": d_action["body_parameters"]["processing"],
+                    'input_stored_data': 'id_1'
+                }
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                self.assertIsNone(o_pea.processing_execution)
+                self.assertIsNone(o_pea.stored_data)
+
+        # BEHAVIOR_RESUME + not STATUS_FAILURE
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pe_4.get_store_properties.return_value = {
+            "inputs":{"stored_data":[{"_id" : "id_1"},{"_id" : "id_2"}]},
+            "parameters": d_action["body_parameters"]["parameters"],
+            "status": ProcessingExecution.STATUS_CREATED,
+        }
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {
+                    "output_stored_data": o_mock_api_get.return_value.id,
+                    "processing": d_action["body_parameters"]["processing"],
+                    'input_stored_data': 'id_1'
+                }
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, o_pe_4)
+                self.assertEqual(o_pea.stored_data, o_mock_api_get.return_value)
+
+        # BEHAVIOR_RESUME + not STATUS_FAILURE, stored_data unstable
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value=StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                self.assertEqual(e_err.exception.message,
+                    (
+                        f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. "
+                        "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
+                        "pour faire réinitialiser son statut."
+                    )
+                )
+
+
+        # BEHAVIOR_CONTINUE + not STATUS_FAILURE
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
+                d_filter = {
+                    "output_stored_data": o_mock_api_get.return_value.id,
+                    "processing": d_action["body_parameters"]["processing"],
+                    'input_stored_data': 'id_1'
+                }
+                o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, o_pe_4)
+                self.assertEqual(o_pea.stored_data, o_mock_api_get.return_value)
+        # BEHAVIOR_CONTINUE + not STATUS_FAILURE, stored_data unstable
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value=StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                self.assertEqual(e_err.exception.message,
+                    (
+                        f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. "
+                        "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
+                        "pour faire réinitialiser son statut."
+                    )
+                )
+
+        # behavior non valide
+        s_behavior="toto"
+        o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
+        with patch.object(StoredData, "api_get") as  o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value=StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                self.assertEqual(
+                    e_err.exception.message,
+                    f"Le comportement {s_behavior} n'est pas reconnu ({'|'.join(ProcessingExecutionAction.BEHAVIORS)}), l'exécution de traitement n'est pas possible."
+                )
+
     def run_args(self,
         tags: Optional[Dict[str,Any]],
         comments: Optional[List[str]],
@@ -99,7 +293,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             o_mock_processing_execution.get_store_properties.return_value = d_store_properties
             o_mock_processing_execution.api_launch.return_value = None
             # o_mock_processing_execution.__getitem__.return_value = ProcessingExecution.STATUS_CREATED
-            # ça veut dire que : o_mock_processing_execution["quelchechose"] = "CREATED"
+            # ça veut dire que : o_mock_processing_execution["quelque_chose"] = "CREATED"
             def get_items_processing(key:str) -> Any:
                 if key == "status":
                     return "CREATED"
@@ -581,7 +775,29 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                 # initialisation de ProcessingExecutionAction
                 o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
                 self.assertEqual(o_pea.output_new_entity, b_new)
+        # pas de sortie
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters":{}})
+        self.assertFalse(o_pea.output_new_entity)
+        # sortie non stored_data ou upload
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters":{"output":{}}})
+        self.assertFalse(o_pea.output_new_entity)
 
+
+    def test_output_update_entity(self)-> None:
+        """test de output_update_entity"""
+        for s_output in ["upload", "stored_data"]:
+            for b_update in [True, False]:
+                d_output = {"_id": "ancien"} if b_update else {"name": "new"}
+                d_definition_dict: Dict[str, Any] = {"body_parameters":{"output":{s_output:d_output}}}
+                # initialisation de ProcessingExecutionAction
+                o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
+                self.assertEqual(o_pea.output_update_entity, b_update)
+        # pas de sortie
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters":{}})
+        self.assertFalse(o_pea.output_update_entity)
+        # sortie non stored_data ou upload
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters":{"output":{}}})
+        self.assertFalse(o_pea.output_update_entity)
 
     def test_str(self) -> None:
         """test de __str__"""

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -12,7 +12,6 @@ from sdk_entrepot_gpf.workflow.Errors import StepActionError
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
 from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import ProcessingExecutionAction
 from sdk_entrepot_gpf.Errors import GpfSdkError
-from sdk_entrepot_gpf.workflow.action.UploadAction import UploadAction
 from tests.GpfTestCase import GpfTestCase
 
 # cSpell:ignore datasheet vectordb creat specifique

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -1,5 +1,6 @@
+# mypy: disable-error-code="attr-defined"
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from unittest.mock import PropertyMock, call, patch, MagicMock
 
@@ -17,8 +18,7 @@ from tests.GpfTestCase import GpfTestCase
 # pylint:disable=too-many-arguments
 # pylint:disable=too-many-locals
 # pylint:disable=too-many-branches
-# pylint:disable=too-many-statements
-# fmt: off
+# pylint:disable=too-many-statements, too-many-lines
 class ProcessingExecutionActionTestCase(GpfTestCase):
     """Tests ProcessingExecutionAction class.
 
@@ -32,14 +32,14 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_pe1 = ProcessingExecution({"_id": "pe_1"})
         o_pe2 = ProcessingExecution({"_id": "pe_2"})
         # création du dict décrivant l'action
-        d_action:Dict[str, Any] = {
+        d_action: Dict[str, Any] = {
             "type": "processing-execution",
             "body_parameters": {
                 "output": {
-                    "stored_data": {"name": "name_stored_data"}
-                }
+                    "stored_data": {"name": "name_stored_data"},
+                },
             },
-            "tags": {"tag": "val"}
+            "tags": {"tag": "val"},
         }
         # exécution de ProcessingExecutionAction
         o_ua = ProcessingExecutionAction("contexte", d_action)
@@ -47,136 +47,110 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         for s_datastore in [None, "datastore"]:
             ## execution sans datastore
             # Mock de ActionAbstract.get_filters et Upload.api_list
-            with patch.object(ActionAbstract, "get_filters", return_value=({"info":"val"}, {"tag":"val"})) as o_mock_get_filters:
-                with patch.object(StoredData, "api_list", return_value=[o_pe1, o_pe2]) as o_mock_api_list :
+            with patch.object(ActionAbstract, "get_filters", return_value=({"info": "val"}, {"tag": "val"})) as o_mock_get_filters:
+                with patch.object(StoredData, "api_list", return_value=[o_pe1, o_pe2]) as o_mock_api_list:
                     # Appel de la fonction find_stored_data
                     o_stored_data = o_ua.find_stored_data(s_datastore)
                     # Vérifications
                     o_mock_get_filters.assert_called_once_with("processing_execution", d_action["body_parameters"]["output"]["stored_data"], d_action["tags"])
-                    o_mock_api_list.assert_called_once_with(infos_filter={"info":"val"}, tags_filter={"tag":"val"}, datastore=s_datastore)
+                    o_mock_api_list.assert_called_once_with(infos_filter={"info": "val"}, tags_filter={"tag": "val"}, datastore=s_datastore)
                     self.assertEqual(o_stored_data, o_pe1)
         # pas de stored data trouvé
-        with patch.object(ActionAbstract, "get_filters", return_value=({"info":"val"}, {"tag":"val"})) as o_mock_get_filters:
-            with patch.object(StoredData, "api_list", return_value=[]) as o_mock_api_list :
+        with patch.object(ActionAbstract, "get_filters", return_value=({"info": "val"}, {"tag": "val"})) as o_mock_get_filters:
+            with patch.object(StoredData, "api_list", return_value=[]) as o_mock_api_list:
                 # Appel de la fonction find_stored_data
                 o_stored_data = o_ua.find_stored_data(s_datastore)
                 # Vérifications
                 o_mock_get_filters.assert_called_once_with("processing_execution", d_action["body_parameters"]["output"]["stored_data"], d_action["tags"])
-                o_mock_api_list.assert_called_once_with(infos_filter={"info":"val"}, tags_filter={"tag":"val"}, datastore=s_datastore)
+                o_mock_api_list.assert_called_once_with(infos_filter={"info": "val"}, tags_filter={"tag": "val"}, datastore=s_datastore)
                 self.assertEqual(o_stored_data, None)
 
     # pylint: disable=protected-access
-    def test_gestion_update_entity(self)-> None:
+    def test_gestion_update_entity(self) -> None:
         """test de __gestion_update_entity"""
-        s_datastore="update"
+        s_datastore = "update"
         s_behavior = ProcessingExecutionAction.BEHAVIOR_STOP
 
         # cas non pris en compte
-        l_action : List[Dict[str, Any]]=[
-            {"body_parameters":{}},
-            {"body_parameters":{"output":{}}},
-            {"body_parameters":{"output":{"upload": {}}}},
-            {"body_parameters":{"output":{"stored_data": {"name": ""}}}},
+        l_action: List[Dict[str, Any]] = [
+            {"body_parameters": {}},
+            {"body_parameters": {"output": {}}},
+            {"body_parameters": {"output": {"upload": {}}}},
+            {"body_parameters": {"output": {"stored_data": {"name": ""}}}},
         ]
         for d_action in l_action:
             o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
-            with patch.object(StoredData, "api_get") as  o_mock_api_get:
-                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+            with patch.object(StoredData, "api_get") as o_mock_api_get:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                 o_mock_api_get.assert_not_called()
 
         # pas de stored_data
         s_id = "uuid"
-        d_action = {"body_parameters":{
-            "output":{"stored_data": {"_id": s_id}},
-            "processing": "id_processing",
-            "inputs":{"stored_data": ["id_1", "id_2"]},
-            "parameters" : {"param1": "val1"}
-
-        }}
+        d_action = {"body_parameters": {"output": {"stored_data": {"_id": s_id}}, "processing": "id_processing", "inputs": {"stored_data": ["id_1", "id_2"]}, "parameters": {"param1": "val1"}}}
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
-        with patch.object(StoredData, "api_get", return_value = None) as  o_mock_api_get:
+        with patch.object(StoredData, "api_get", return_value=None) as o_mock_api_get:
             with self.assertRaises(GpfSdkError) as e_err:
-                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)# type: ignore
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
             o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
             self.assertEqual(e_err.exception.message, "La donnée en sortie est introuvable, impossible de faire la mise à jour.")
 
         # pas de traitement correspondant trouvé
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            with patch.object(ProcessingExecution, "api_list", return_value=[]) as  o_mock_api_list:
-                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                 o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
-                d_filter = {
-                    "output_stored_data": o_mock_api_get.return_value.id,
-                    "processing": d_action["body_parameters"]["processing"],
-                    'input_stored_data': 'id_1'
-                }
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
                 o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
         # les traitements ne correspondent pas
-        o_pe_1=MagicMock() # input upload
-        o_pe_1.get_store_properties.return_value = {"inputs":{"upload":[{"_id" : "uuid"}]}}
-        o_pe_2=MagicMock() # input stored_data not match
-        o_pe_2.get_store_properties.return_value = {"inputs":{"stored_data":[{"_id" : "uuid"}]}}
-        o_pe_3=MagicMock()# input stored_data match + param not match
-        o_pe_3.get_store_properties.return_value = {"inputs":{"stored_data":[{"_id" : "id_1"},{"_id" : "id_2"}]}, "parameters": {"autre": "val"}}
+        o_pe_1 = MagicMock()  # input upload
+        o_pe_1.get_store_properties.return_value = {"inputs": {"upload": [{"_id": "uuid"}]}}
+        o_pe_2 = MagicMock()  # input stored_data not match
+        o_pe_2.get_store_properties.return_value = {"inputs": {"stored_data": [{"_id": "uuid"}]}}
+        o_pe_3 = MagicMock()  # input stored_data match + param not match
+        o_pe_3.get_store_properties.return_value = {"inputs": {"stored_data": [{"_id": "id_1"}, {"_id": "id_2"}]}, "parameters": {"autre": "val"}}
 
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3]) as  o_mock_api_list:
-                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                 o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
-                d_filter = {
-                    "output_stored_data": o_mock_api_get.return_value.id,
-                    "processing": d_action["body_parameters"]["processing"],
-                    'input_stored_data': 'id_1'
-                }
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
                 o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
-        o_pe_4=MagicMock()# input stored_data match + param not match
-        o_pe_4.get_store_properties.return_value = {"inputs":{"stored_data":[{"_id" : "id_1"},{"_id" : "id_2"}]}, "parameters": d_action["body_parameters"]["parameters"]}
+        o_pe_4 = MagicMock()  # input stored_data match + param not match
+        o_pe_4.get_store_properties.return_value = {"inputs": {"stored_data": [{"_id": "id_1"}, {"_id": "id_2"}]}, "parameters": d_action["body_parameters"]["parameters"]}
 
         # BEHAVIOR_STOP
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
                 with self.assertRaises(GpfSdkError) as e_err:
-                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                     o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
-                    d_filter = {
-                        "output_stored_data": o_mock_api_get.return_value.id,
-                        "processing": d_action["body_parameters"]["processing"],
-                        'input_stored_data': 'id_1'
-                    }
+                    d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
                     o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
                     self.assertEqual(e_err.exception.message, f"Le traitement a déjà été lancée pour mettre à jour cette donnée {o_pe_4}.")
 
         # BEHAVIOR_DELETE
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_DELETE)
         o_pe_4.get_store_properties.return_value = {
-            "inputs":{"stored_data":[{"_id" : "id_1"},{"_id" : "id_2"}]},
+            "inputs": {"stored_data": [{"_id": "id_1"}, {"_id": "id_2"}]},
             "parameters": d_action["body_parameters"]["parameters"],
             "status": ProcessingExecution.STATUS_FAILURE,
         }
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
-                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                 o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
-                d_filter = {
-                    "output_stored_data": o_mock_api_get.return_value.id,
-                    "processing": d_action["body_parameters"]["processing"],
-                    'input_stored_data': 'id_1'
-                }
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
                 o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
                 self.assertIsNone(o_pea.processing_execution)
                 self.assertIsNone(o_pea.stored_data)
 
         # BEHAVIOR_RESUME + STATUS_FAILURE
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
-                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                 o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
-                d_filter = {
-                    "output_stored_data": o_mock_api_get.return_value.id,
-                    "processing": d_action["body_parameters"]["processing"],
-                    'input_stored_data': 'id_1'
-                }
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
                 o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
                 self.assertIsNone(o_pea.processing_execution)
                 self.assertIsNone(o_pea.stored_data)
@@ -184,383 +158,571 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         # BEHAVIOR_RESUME + not STATUS_FAILURE
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
         o_pe_4.get_store_properties.return_value = {
-            "inputs":{"stored_data":[{"_id" : "id_1"},{"_id" : "id_2"}]},
+            "inputs": {"stored_data": [{"_id": "id_1"}, {"_id": "id_2"}]},
             "parameters": d_action["body_parameters"]["parameters"],
             "status": ProcessingExecution.STATUS_CREATED,
         }
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
-                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                 o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
-                d_filter = {
-                    "output_stored_data": o_mock_api_get.return_value.id,
-                    "processing": d_action["body_parameters"]["processing"],
-                    'input_stored_data': 'id_1'
-                }
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
                 o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
                 self.assertEqual(o_pea.processing_execution, o_pe_4)
                 self.assertEqual(o_pea.stored_data, o_mock_api_get.return_value)
 
         # BEHAVIOR_RESUME + not STATUS_FAILURE, stored_data unstable
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            o_mock_api_get.return_value.__getitem__.return_value=StoredData.STATUS_UNSTABLE
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
                 with self.assertRaises(GpfSdkError) as e_err:
-                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
-                self.assertEqual(e_err.exception.message,
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                self.assertEqual(
+                    e_err.exception.message,
                     (
                         f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. "
                         "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
                         "pour faire réinitialiser son statut."
-                    )
+                    ),
                 )
-
 
         # BEHAVIOR_CONTINUE + not STATUS_FAILURE
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
-                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
+                o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                 o_mock_api_get.assert_called_once_with(s_id, datastore=s_datastore)
-                d_filter = {
-                    "output_stored_data": o_mock_api_get.return_value.id,
-                    "processing": d_action["body_parameters"]["processing"],
-                    'input_stored_data': 'id_1'
-                }
+                d_filter = {"output_stored_data": o_mock_api_get.return_value.id, "processing": d_action["body_parameters"]["processing"], "input_stored_data": "id_1"}
                 o_mock_api_list.assert_called_once_with(d_filter, datastore=s_datastore)
                 self.assertEqual(o_pea.processing_execution, o_pe_4)
                 self.assertEqual(o_pea.stored_data, o_mock_api_get.return_value)
         # BEHAVIOR_CONTINUE + not STATUS_FAILURE, stored_data unstable
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            o_mock_api_get.return_value.__getitem__.return_value=StoredData.STATUS_UNSTABLE
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
                 with self.assertRaises(GpfSdkError) as e_err:
-                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
-                self.assertEqual(e_err.exception.message,
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
+                self.assertEqual(
+                    e_err.exception.message,
                     (
                         f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. "
                         "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
                         "pour faire réinitialiser son statut."
-                    )
+                    ),
                 )
 
         # behavior non valide
-        s_behavior="toto"
+        s_behavior = "toto"
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
-        with patch.object(StoredData, "api_get") as  o_mock_api_get:
-            o_mock_api_get.return_value.__getitem__.return_value=StoredData.STATUS_UNSTABLE
-            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
+        with patch.object(StoredData, "api_get") as o_mock_api_get:
+            o_mock_api_get.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as o_mock_api_list:
                 with self.assertRaises(GpfSdkError) as e_err:
-                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
+                    o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore)  # type: ignore
                 self.assertEqual(
-                    e_err.exception.message,
-                    f"Le comportement {s_behavior} n'est pas reconnu ({'|'.join(ProcessingExecutionAction.BEHAVIORS)}), l'exécution de traitement n'est pas possible."
+                    e_err.exception.message, f"Le comportement {s_behavior} n'est pas reconnu ({'|'.join(ProcessingExecutionAction.BEHAVIORS)}), l'exécution de traitement n'est pas possible."
                 )
 
-    def run_args(self,
-        tags: Optional[Dict[str,Any]],
-        comments: Optional[List[str]],
-        s_key: str,
-        s_type_output: str,
-        datastore: Optional[str],
-        output_already_exist: bool = False,
-        behavior: Optional[str] = None,
-        message:str = "",
-    ) -> None:
-        """lancement + test de ProcessingExecutionAction.run selon param
+    def test_init(self) -> None:
+        """test de __init__"""
+        d_action: Dict[str, Any] = {"type": "processing-execution"}
 
-        Args:
-            tags (Optional[Dict[str, Any]]): dictionnaire des tags ou None
-            comments (Optional[List]): liste des commentaires ou None
-            s_type_output (str): type de l'output (stored_data ou upload)
-        """
-        self.i += 1
-        with self.subTest(message=message):
-            d_action: Dict[str, Any] = {"type": "processing-execution", "body_parameters":{"output":{s_key:"test"}}}
-            if tags is not None:
-                d_action["tags"] = tags
-            if comments is not None:
-                d_action["comments"] = comments
+        # behavior défini et compatibility_cartes défini
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior="STOP", compatibility_cartes=True)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "STOP")
+                self.assertEqual(o_pe._ProcessingExecutionAction__mode_cartes, True)
+                o_mock_get_str.assert_not_called()
+                o_mock_get_bool.assert_not_called()
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", d_action, behavior=behavior)
+        # behavior config et compatibility_cartes défini
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior=None, compatibility_cartes=True)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "config")
+                self.assertEqual(o_pe._ProcessingExecutionAction__mode_cartes, True)
+                o_mock_get_str.assert_called_once_with("processing_execution", "behavior_if_exists")
+                o_mock_get_bool.assert_not_called()
 
-            # mock de processing execution
-            d_store_properties = {"output": {s_type_output: {"_id": "id"}}}
-            o_mock_processing_execution = MagicMock()
-            o_mock_processing_execution.get_store_properties.return_value = d_store_properties
-            o_mock_processing_execution.api_launch.return_value = None
-            # o_mock_processing_execution.__getitem__.return_value = ProcessingExecution.STATUS_CREATED
-            # ça veut dire que : o_mock_processing_execution["quelque_chose"] = "CREATED"
-            def get_items_processing(key:str) -> Any:
-                if key == "status":
-                    return "CREATED"
-                return MagicMock()
-            o_mock_processing_execution.__getitem__.side_effect = get_items_processing
+        # behavior config et compatibility_cartes config
+        with patch.object(Config, "get_str", return_value="config") as o_mock_get_str:
+            with patch.object(Config, "get_bool", return_value=False) as o_mock_get_bool:
+                o_pe = ProcessingExecutionAction("contexte", d_action, behavior=None, compatibility_cartes=None)
+                self.assertEqual(o_pe._ProcessingExecutionAction__behavior, "config")
+                self.assertEqual(o_pe._ProcessingExecutionAction__mode_cartes, False)
+                o_mock_get_str.assert_called_once_with("processing_execution", "behavior_if_exists")
+                o_mock_get_bool.assert_called_once_with("compatibility_cartes", "activate")
 
-            # mock de upload d'entrée
-            o_mock_upload = MagicMock()
-            o_mock_upload.api_add_tags.return_value = None
-            o_mock_upload.api_add_comment.return_value = None
+    # pylint: disable=protected-access
+    def test_add_tags(self) -> None:
+        """test de __add_tags"""
+        o_processing_execution = MagicMock()
+        d_def: Dict[str, Any] = {"type": "processing-execution"}
+        o_pe = ProcessingExecutionAction("contexte", d_def)
+        o_pe._ProcessingExecutionAction__mode_cartes = False
+        o_pe._ProcessingExecutionAction__processing_execution = o_processing_execution
+        o_pe._ProcessingExecutionAction__no_output = False
 
-            # mock de stored_data d'entrée
-            o_mock_stored_data = MagicMock()
-            o_mock_stored_data.api_add_tags.return_value = None
-            o_mock_stored_data.api_add_comment.return_value = None
+        # pas de tags
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
+                # dict vide
+                d_def["tags"] = {}
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-            # résultat de ProcessingExecutionAction."find_stored_data" : stored_data de sortie
-            o_exist_output = None
-            if output_already_exist:
-                o_mock_exist_output = MagicMock()
-                o_mock_exist_output.api_delete.return_value = None
-                o_exist_output = o_mock_exist_output
+        # pas de output
+        d_tags = {"key": "val"}
+        d_def["tags"] = d_tags
+        o_pe._ProcessingExecutionAction__no_output = True
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-            # suppression de la mise en page forcée pour le with
-            with patch.object(Upload, "api_get", return_value=o_mock_upload) as o_mock_upload_api_get, \
-                patch.object(StoredData, "api_get", return_value=o_mock_stored_data) as o_mock_stored_data_api_get, \
-                patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create, \
-                patch.object(ProcessingExecution, "api_list", return_value=[o_mock_processing_execution]) as o_mock_pe_api_list, \
-                patch.object(ProcessingExecutionAction, "find_stored_data", return_value=o_exist_output) as o_mock_pea_find_stored_data, \
-                patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=output_already_exist), \
-                patch.object(Config, "get_str", return_value="STOP") \
-            :
-                # dans le cas où une entité existe déjà dans la gpf :
-                if output_already_exist:
-                    if not behavior or behavior == "STOP":
-                        # on attend une erreur
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_exist_output} existe déjà.")
-                        return
+        # sortie upload
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_called_once_with(d_tags)
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-                    if behavior == "DELETE":
-                        # suppression de l'existant puis normal
-                        o_pea.run(datastore)
-                        # un appel à find_stored_data
-                        o_mock_pea_find_stored_data.assert_called_once_with(datastore)
-                        o_mock_exist_output.api_delete.assert_called_once_with()
-                    elif behavior == "CONTINUE":
-                        # premier test sur STATUS_UNSTABLE
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_UNSTABLE
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(
-                            o_err.exception.message,
-                            f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_exist_output}. Impossible de lancer le traitement demandé."
-                        )
+        # sortie stored_data
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with(d_tags)
 
-                        # deuxième test sur la stored data créée
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_CREATED
-                        o_pea.run(datastore)
-                        o_mock_pe_api_list.assert_called_once_with({"output_stored_data":o_mock_exist_output.id}, datastore=datastore)
-                        self.assertEqual(o_pea.processing_execution, o_mock_processing_execution)
+        # autre type de sortie => Erreur
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None):
+                with self.assertRaises(StepActionError) as o_err_step:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(o_err_step.exception.message, "ni upload ni stored-data trouvé. Impossible d'ajouter les tags")
 
-                        # troisième test sur l'absence de la processing execution
-                        o_mock_pe_api_list.return_value = []
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_exist_output}")
+        # compatibility_cartes
+        del d_def["tags"]
+        o_pe._ProcessingExecutionAction__mode_cartes = True
 
-                        return
-                    elif behavior == "RESUME":
-                        # premier test sur la stored data créée
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_CREATED
-                        o_pea.run(datastore)
-                        o_mock_pe_api_list.assert_called_once_with({"output_stored_data":o_mock_exist_output.id}, datastore=datastore)
-                        self.assertEqual(o_pea.processing_execution, o_mock_processing_execution)
+        ## pas de tag ajouté (cas traitement non pris en compte)
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_upload.return_value.api_add_tags.assert_not_called()
+                o_mock_stored_data.return_value.api_add_tags.assert_not_called()
 
-                        o_mock_exist_output.reset_mock()
-                        o_mock_pea_find_stored_data.reset_mock()
+        ## mise_en_base : manque datasheet_name
+        d_def["tags"] = d_tags
+        o_processing_execution.id = "id_mise_en_base"
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+        ## mise_en_base : manque inputs
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
+        ## mise_en_base : maque stored_data sortie
+        l_inputs_upload = [MagicMock(id=1), MagicMock(id=2)]
+        o_pe._ProcessingExecutionAction__inputs_upload = l_inputs_upload
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
+        ## mise_en_base : OK
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_progress")
+                o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_current_step")
+                for o_offering in l_inputs_upload:
+                    o_offering.api_add_tags.assert_called_once_with(
+                        {
+                            "integration_progress": "execution_start_integration_progress",
+                            "integration_current_step": "execution_start_integration_current_step",
+                            "proc_int_id": o_processing_execution.id,
+                            "vectordb_id": o_mock_stored_data.return_value.id,
+                        }
+                    )
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with({**d_tags, "datasheet_name": "name", "uuid_upload": l_inputs_upload[0].id})
 
-                        # deuxième test sur l'absence de la processing execution
-                        o_mock_pe_api_list.return_value = []
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_exist_output}")
+        ## pyramide_vecteur : manque datasheet_name
+        d_def["tags"] = d_tags
+        o_processing_execution.id = "id_pyramide_vecteur"
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
+        ## pyramide_vecteur : manque inputs
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoire")
+        ## pyramide_vecteur : maque stored_data sortie
+        l_inputs_stored_data = [MagicMock(id=1), MagicMock(id=2)]
+        o_pe._ProcessingExecutionAction__inputs_stored_data = l_inputs_stored_data
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                with self.assertRaises(GpfSdkError) as e_err_comp:
+                    o_pe._ProcessingExecutionAction__add_tags()
+                self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoire")
 
-                        o_mock_exist_output.reset_mock()
-                        o_mock_pea_find_stored_data.reset_mock()
-                        o_mock_processing_execution.api_launch.reset_mock()
-                        o_mock_processing_execution.get_store_properties.reset_mock()
-                        o_mock_stored_data_api_get.reset_mock()
-                        o_mock_upload_api_get.reset_mock()
+        ## pyramide_vecteur : OK
+        d_def["tags"] = {**d_tags, "datasheet_name": "name"}
+        with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+                o_pe._ProcessingExecutionAction__add_tags()
+                o_mock_stored_data.return_value.api_add_tags.assert_called_once_with(
+                    {**d_tags, "datasheet_name": "name", "vectordb_id": l_inputs_stored_data[0].id, "proc_pyr_creat_id": o_processing_execution.id}
+                )
 
-                        # troisième test sur STATUS_UNSTABLE => suppression puis normal
-                        o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_UNSTABLE
-                        o_pea.run(datastore)
-                        # un appel à find_stored_data
-                        o_mock_pea_find_stored_data.assert_called_once_with(datastore)
-                        o_mock_exist_output.api_delete.assert_called_once_with()
-                    else:
-                        # behavior non reconnu. On attend une erreur
-                        with self.assertRaises(GpfSdkError) as o_err:
-                            o_pea.run(datastore)
-                        self.assertEqual(o_err.exception.message, f"Le comportement {behavior} n'est pas reconnu (STOP|DELETE|CONTINUE|RESUME), l'exécution de traitement n'est pas possible.")
-                        return
+    def test_add_comments(self) -> None:
+        """test de __add_comments"""
+        d_def: Dict[str, Any] = {}
+        o_pe = ProcessingExecutionAction("contexte", d_def)
+        o_pe._ProcessingExecutionAction__no_output = False
 
-                else:
-                    # on appelle la méthode à tester
-                    o_pea.run(datastore)
-                    o_mock_pea_find_stored_data.assert_not_called()
+        # pas de commentaires
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_comments()
+                o_mock_upload.return_value.api_add_comment.assert_not_called()
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
 
-                # test de l'appel à ProcessingExecution.api_create
-                o_mock_pe_api_create.assert_called_once_with(d_action['body_parameters'], {"datastore":datastore})
-                # un appel à ProcessingExecution().get_store_properties
-                o_mock_processing_execution.get_store_properties.assert_called_once_with()
+        # pas de sortie
+        l_comments = ["commentaire1", "commentaire2"]
+        d_def["comments"] = l_comments
+        o_pe._ProcessingExecutionAction__no_output = True
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_pe._ProcessingExecutionAction__add_comments()
+                o_mock_upload.return_value.api_add_comment.assert_not_called()
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
 
-                # verif appel à Upload/StoredData
-                if "stored_data" in d_store_properties["output"]:
-                    # test  .api_get
-                    o_mock_stored_data_api_get.assert_called_once_with("id", datastore=datastore)
-                    o_mock_upload_api_get.assert_not_called()
+        # commentaire sur l'upload, pas de commentaire initial
+        o_pe._ProcessingExecutionAction__no_output = False
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_upload.return_value.api_list_comments.return_value = []
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_upload.return_value.api_add_comment.assert_any_call({"text": s_comment})
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
 
-                    # test api_add_tags
-                    if "tags" in d_action and d_action["tags"]:
-                        o_mock_stored_data.api_add_tags.assert_called_once_with(d_action["tags"])
-                    else:
-                        o_mock_stored_data.api_add_tags.assert_not_called()
-                    o_mock_upload.api_add_tags.assert_not_called()
+        # commentaire sur l'upload, x commentaire initial
+        l_init_comments = ["init1", "init2"]
+        d_def["comments"] = l_comments + l_init_comments
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_upload.return_value.api_list_comments.return_value = [{"text": s_comment} for s_comment in l_init_comments]
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_upload.return_value.api_add_comment.assert_any_call({"text": s_comment})
+                o_mock_stored_data.return_value.api_add_comment.assert_not_called()
 
-                    # test commentaires
-                    if "comments" in d_action and d_action["comments"]:
-                        self.assertEqual(len(d_action["comments"]), o_mock_stored_data.api_add_comment.call_count)
-                        for s_comm in d_action["comments"]:
-                            o_mock_stored_data.api_add_comment.assert_any_call({"text": s_comm})
-                    else:
-                        o_mock_stored_data.api_add_comment.assert_not_called()
-                    o_mock_upload.api_add_comment.assert_not_called()
+        # commentaire sur l'stored_data, pas de commentaire initial
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_stored_data.return_value.api_list_comments.return_value = []
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_stored_data.return_value.api_add_comment.assert_any_call({"text": s_comment})
 
+        # commentaire sur l'stored_data, x commentaire initial
+        l_init_comments = ["init1", "init2"]
+        d_def["comments"] = l_comments + l_init_comments
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None) as o_mock_upload:
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
+                o_mock_stored_data.return_value.api_list_comments.return_value = [{"text": s_comment} for s_comment in l_init_comments]
+                o_pe._ProcessingExecutionAction__add_comments()
+                for s_comment in l_comments:
+                    o_mock_stored_data.return_value.api_add_comment.assert_any_call({"text": s_comment})
 
-                elif "upload" in  d_store_properties["output"]:
-                    # test api_get
-                    o_mock_upload_api_get.assert_called_once_with("id", datastore=datastore)
-                    o_mock_stored_data_api_get.assert_not_called()
+        # aucune sortie valable
+        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None):
+                with self.assertRaises(StepActionError) as e_err:
+                    o_pe._ProcessingExecutionAction__add_comments()
+                self.assertEqual(e_err.exception.message, "ni upload ni stored-data trouvé. Impossible d'ajouter les commentaires")
 
-                    # test api_add_tags
-                    if "tags" in d_action and d_action["tags"]:
-                        o_mock_upload.api_add_tags.assert_called_once_with(d_action["tags"])
-                    else:
-                        o_mock_upload.api_add_tags.assert_not_called()
-                    o_mock_stored_data.api_add_tags.assert_not_called()
+    def test_launch(self) -> None:
+        """test de __launch"""
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_STOP)
 
-                    # test commentaires
-                    if "comments" in d_action and d_action["comments"]:
-                        self.assertEqual(len(d_action["comments"]), o_mock_upload.api_add_comment.call_count)
-                        for s_comm in d_action["comments"]:
-                            o_mock_upload.api_add_comment.assert_any_call({"text": s_comm})
-                    else:
-                        o_mock_upload.api_add_comment.assert_not_called()
-                    o_mock_stored_data.api_add_comment.assert_not_called()
+        # aucune processing execution
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(StepActionError) as e_err:
+                o_pea._ProcessingExecutionAction__launch()
+            self.assertEqual(e_err.exception.message, "Aucune exécution de traitement trouvée. Impossible de lancer le traitement")
 
-                # un appel à api_launch
-                o_mock_processing_execution.api_launch.assert_called_once_with()
+        def get_items_processing(key: str) -> Any:
+            if key == "status":
+                return "CREATED"
+            return MagicMock()
+
+        # pas encore lancé
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_mock_pe.return_value.__getitem__.side_effect = get_items_processing
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_called_once_with()
+
+        # déjà lancé behavior non compatible
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock):
+            with self.assertRaises(StepActionError) as e_err:
+                o_pea._ProcessingExecutionAction__launch()
+            self.assertEqual(e_err.exception.message, "L'exécution de traitement est déjà lancée.")
+
+        # déjà lancé behavior OK
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_not_called()
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            o_pea._ProcessingExecutionAction__launch()
+            o_mock_pe.return_value.api_launch.assert_not_called()
+
+    def test_gestion_new_output(self) -> None:
+        """test de __gestion_new_output"""
+        s_datastore = "datastore"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_STOP)
+
+        # pas de stored_data de trouvé
+        with patch.object(ProcessingExecutionAction, "find_stored_data", return_value=None) as o_mock_find_stored_data:
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+
+        # stored_data + behavior STOP
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            self.assertEqual(e_err.exception.message, f"Impossible de créer l’exécution de traitement, une donnée stockée en sortie équivalente {o_mock_find_stored_data.return_value} existe déjà.")
+
+        # behavior delete
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_DELETE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            o_mock_find_stored_data.return_value.api_delete.assert_called_once_with()
+            self.assertIsNone(o_pea.processing_execution)
+
+        # behavior continue - unstable
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with patch.object(ProcessingExecution, "api_list") as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                o_mock_api_list.assert_not_called()
+                self.assertEqual(
+                    e_err.exception.message, f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_find_stored_data.return_value}. Impossible de lancer le traitement demandé."
+                )
+
+        # behavior continue - stable - ProcessingExecution non trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe: List[ProcessingExecution] = []
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(e_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_find_stored_data.return_value}")
+
+        # behavior continue - stable - ProcessingExecution trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_CONTINUE)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = [MagicMock(), MagicMock()]
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, l_pe[0])
+
+        # behavior resume - unstable
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            o_mock_find_stored_data.return_value.__getitem__.return_value = StoredData.STATUS_UNSTABLE
+            o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            o_mock_find_stored_data.assert_called_once_with(s_datastore)
+            o_mock_find_stored_data.return_value.api_delete.assert_called_once_with()
+            self.assertIsNone(o_pea.processing_execution)
+
+        # behavior resume - stable - ProcessingExecution non trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = []
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(e_err.exception.message, f"Impossible de trouver l'exécution de traitement liée à la donnée stockée {o_mock_find_stored_data.return_value}")
+
+        # behavior resume - stable - ProcessingExecution trouvé
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            l_pe = [MagicMock(), MagicMock()]
+            with patch.object(ProcessingExecution, "api_list", return_value=l_pe) as o_mock_api_list:
+                o_mock_find_stored_data.return_value.__getitem__.return_value = "OK"
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+                o_mock_find_stored_data.assert_called_once_with(s_datastore)
+                self.assertEqual(o_pea.stored_data, o_mock_find_stored_data.return_value)
+                o_mock_api_list.assert_called_once_with({"output_stored_data": o_mock_find_stored_data.return_value.id}, datastore=s_datastore)
+                self.assertEqual(o_pea.processing_execution, l_pe[0])
+
+        # behavior non prévu
+        s_behavior = "NON VALIDE"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=s_behavior)
+        with patch.object(ProcessingExecutionAction, "find_stored_data") as o_mock_find_stored_data:
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__gestion_new_output(s_datastore)
+            self.assertEqual(
+                e_err.exception.message, f"Le comportement {s_behavior} n'est pas reconnu ({'|'.join(ProcessingExecutionAction.BEHAVIORS)}), l'exécution de traitement n'est pas possible."
+            )
+
+    def test_create_processing_execution(self) -> None:
+        """test de __create_processing_execution"""
+        s_datastore = "datastore"
+        d_definition_dict = {"body_parameters": {"key": "val"}}
+        d_data: Dict[str, Any] = {}
+        o_mock_processing_execution = MagicMock()
+        o_mock_processing_execution.get_store_properties.return_value = d_data
+
+        # output_new_entity, creation ProcessingExecution - inputs + output upload
+        d_data["inputs"] = {
+            "upload": [{"_id": f"{i}"} for i in range(3)],
+            "stored_data": [{"_id": f"{i}"} for i in range(3)],
+        }
+        d_data["output"] = {"upload": {"_id": "out"}}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_called_once_with(s_datastore)
+                            o_mock_pe_api_create.assert_called_with(d_definition_dict["body_parameters"], {"datastore": s_datastore})
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            for d_input_upload in d_data["inputs"]["upload"]:
+                                o_mock_upload_api_get.assert_any_call(d_input_upload["_id"], datastore=s_datastore)
+                            self.assertEqual(o_pea.inputs_upload, [o_mock_upload_api_get.return_value] * len(d_data["inputs"]["upload"]))
+                            for d_input_stored_data in d_data["inputs"]["stored_data"]:
+                                o_mock_stored_data_api_get.assert_any_call(d_input_stored_data["_id"], datastore=s_datastore)
+                            o_mock_upload_api_get.assert_any_call(d_data["output"]["upload"]["_id"], datastore=s_datastore)
+                            self.assertEqual(o_pea.inputs_stored_data, [o_mock_stored_data_api_get.return_value] * len(d_data["inputs"]["stored_data"]))
+                            self.assertFalse(o_pea.no_output)
+                            self.assertEqual(o_pea.upload, o_mock_upload_api_get.return_value)
+                            self.assertIsNone(o_pea.stored_data)
+
+        o_mock_processing_execution.reset_mock()
+
+        # pas output_new_entity, creation ProcessingExecution - output stored_data
+        del d_data["inputs"]
+        d_data["output"] = {"stored_data": {"_id": "out"}}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution) as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_not_called()
+                            o_mock_pe_api_create.assert_called_with(d_definition_dict["body_parameters"], {"datastore": s_datastore})
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            o_mock_stored_data_api_get.assert_called_once_with(d_data["output"]["stored_data"]["_id"], datastore=s_datastore)
+                            self.assertFalse(o_pea.no_output)
+                            self.assertEqual(o_pea.stored_data, o_mock_stored_data_api_get.return_value)
+                            o_mock_upload_api_get.assert_not_called()
+                            self.assertIsNone(o_pea.upload)
+                            self.assertIsNone(o_pea.inputs_stored_data)
+                            self.assertIsNone(o_pea.inputs_upload)
+
+        o_mock_processing_execution.reset_mock()
+
+        # pas output_new_entity, pas creation ProcessingExecution - no output
+        del d_data["output"]
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__gestion_new_output") as o_mock_gestion_new_output:
+                with patch.object(ProcessingExecution, "api_create") as o_mock_pe_api_create:
+                    with patch.object(Upload, "api_get") as o_mock_upload_api_get:
+                        with patch.object(StoredData, "api_get") as o_mock_stored_data_api_get:
+                            o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+                            o_mock_gestion_new_output.assert_not_called()
+                            o_mock_pe_api_create.assert_not_called()
+                            o_mock_processing_execution.get_store_properties.assert_called_once_with()
+                            self.assertTrue(o_pea.no_output)
+                            self.assertIsNone(o_pea.stored_data)
+                            self.assertIsNone(o_pea.upload)
+                            o_mock_upload_api_get.assert_not_called()
+                            o_mock_stored_data_api_get.assert_not_called()
+                            self.assertIsNone(o_pea.inputs_stored_data)
+                            self.assertIsNone(o_pea.inputs_upload)
+
+        # pb sur les output : None
+        d_data["output"] = None
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(GpfSdkError) as e_err:
+                o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+            self.assertEqual(e_err.exception.message, "Erreur à la création de l'exécution de traitement : impossible de récupérer l'entité en sortie.")
+
+        # pb sur les output : autre
+        d_data["output"] = {"autre": "val"}
+        o_pea = ProcessingExecutionAction("contexte", d_definition_dict, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
+        o_pea._ProcessingExecutionAction__processing_execution = o_mock_processing_execution
+        with patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=None):
+            with self.assertRaises(StepActionError) as e_err_step:
+                o_pea._ProcessingExecutionAction__create_processing_execution(s_datastore)
+            self.assertEqual(e_err_step.exception.message, f"Aucune correspondance pour {d_data['output'].keys()}")
 
     def test_run(self) -> None:
         """test de run"""
-        s_key = "name"
-        # test upload
-        for s_datastore in [None, "datastore"]:
-            for s_type_output in [ "upload", "stored_data"]:
-                ## sans tag + sans commentaire
-                self.run_args(None, None, s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - no tag - no comment")
-                ## tag vide + commentaire vide
-                self.run_args({}, [], s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - vide tag - vide comment")
-                ## 1 tag + 1 commentaire
-                self.run_args({"tag1": "val1"}, ["comm1"], s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 1 tag - 1 comment")
-                ## 2 tag + 4 commentaire
-                self.run_args(
-                    {"tag1": "val1", "tag2": "val2"},
-                    ["comm1", "comm2", "comm3", "comm4"],
-                    s_key, s_type_output, s_datastore,
-                    message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 2 tag - 4 comment",
-                )
 
-        # tests particuliers pour cas ou la sortie existe déjà
-        for s_beavior in ["STOP","DELETE","CONTINUE","RESUME","Toto",None] :
-            self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, s_beavior, message=f"beavior {s_beavior}")
+        s_datastore = "datastore"
+        o_pea = ProcessingExecutionAction("contexte", {}, behavior=ProcessingExecutionAction.BEHAVIOR_RESUME)
 
-        # cas en erreurs non spécifique
-        d_action: Dict[str, Any] = {"type": "processing-execution", "body_parameters":{"output":{s_key:"test"}}, "tags": {"key":"val"}, "comments": ["comm"]}
-        o_mock_processing_execution = MagicMock()
-        o_mock_processing_execution.get_store_properties.return_value = {"output":None}
-
-        ## processing_execution.get_store_properties vide après création
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution), \
-            patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=False), \
-            patch.object(Config, "get_str", return_value="STOP") \
-        :
-            with self.assertRaises(GpfSdkError) as o_err_gpf:
-                o_pea.run()
-            s_message = "Erreur à la création de l'exécution de traitement : impossible de récupérer l'entité en sortie."
-            self.assertEqual(o_err_gpf.exception.message, s_message)
-
-        ## impossible de récupérer le donnée en sortie depuis processing_execution
-        d_output={"autre": "", "key": ""}
-        o_mock_processing_execution.get_store_properties.return_value = {"output":d_output}
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecution, "api_create", return_value=o_mock_processing_execution), \
-            patch.object(ProcessingExecutionAction, "output_new_entity", new_callable=PropertyMock, return_value=False), \
-            patch.object(Config, "get_str", return_value="STOP") \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = f"Aucune correspondance pour {d_output.keys()}"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## impossible d'ajouté un tag, pas de donnée en sortie
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None), \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "ni upload ni stored-data trouvé. Impossible d'ajouter les tags"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## impossible d'ajouté un commentaire, pas de donnée en sortie
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock, return_value=None), \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "ni upload ni stored-data trouvé. Impossible d'ajouter les commentaires"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## __launch pas de processing_execution
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "Aucune exécution de traitement trouvée. Impossible de lancer le traitement"
-            self.assertEqual(o_err_step.exception.message, s_message)
-
-        ## __launch traitement pas déjà lancé et pas en mode continue ou reprise
-        o_pea = ProcessingExecutionAction("contexte", d_action, behavior="STOP")
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value={"status": "autre"}), \
-            patch.object(Config, "get_str", return_value="STOP"), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags", return_value=None), \
-            patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments", return_value=None) \
-        :
-            with self.assertRaises(StepActionError) as o_err_step:
-                o_pea.run()
-            s_message = "L'exécution de traitement est déjà lancée."
-            self.assertEqual(o_err_step.exception.message, s_message)
-
+        with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__create_processing_execution") as o_mock_create_processing_execution:
+            with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_tags") as o_mock_add_tags:
+                with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__add_comments") as o_mock_add_comments:
+                    with patch.object(ProcessingExecutionAction, "_ProcessingExecutionAction__launch") as o_mock_launch:
+                        o_pea.run(s_datastore)
+                        o_mock_create_processing_execution.assert_called_once_with(s_datastore)
+                        o_mock_add_tags.assert_called_once_with()
+                        o_mock_add_comments.assert_called_once_with()
+                        o_mock_launch.assert_called_once_with()
 
     def monitoring_until_end_args(self, s_status_end: str, b_waits: bool, b_callback: bool) -> None:
         """lancement + test de ProcessingExecutionAction.monitoring_until_end() selon param
@@ -571,35 +733,35 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             b_callback (bool): si on a une fonction callback
         """
 
-        l_status = [] if not b_waits else [ProcessingExecution.STATUS_CREATED,ProcessingExecution.STATUS_WAITING, ProcessingExecution.STATUS_PROGRESS]
+        l_status = [] if not b_waits else [ProcessingExecution.STATUS_CREATED, ProcessingExecution.STATUS_WAITING, ProcessingExecution.STATUS_PROGRESS]
         f_callback = MagicMock() if b_callback else None
         f_ctrl_c = MagicMock(return_value=True)
 
         # mock de o_mock_processing_execution
         o_mock_processing_execution = MagicMock(name="test")
-        o_mock_processing_execution.get_store_properties.side_effect = [{"status": el} for el in l_status] + [{"status": s_status_end}]*3
+        o_mock_processing_execution.get_store_properties.side_effect = [{"status": el} for el in l_status] + [{"status": s_status_end}] * 3
         o_mock_processing_execution.api_update.return_value = None
 
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value = o_mock_processing_execution), \
-            patch.object(time, "sleep", return_value=None), \
-            patch.object(Config, "get_int", return_value=0) :
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=o_mock_processing_execution):
+            with patch.object(time, "sleep", return_value=None):
+                with patch.object(Config, "get_int", return_value=0):
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", {})
-            s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                    # initialisation de ProcessingExecutionAction
+                    o_pea = ProcessingExecutionAction("contexte", {})
+                    s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-            # vérification valeur de sortie
-            self.assertEqual(s_return, s_status_end)
+                    # vérification valeur de sortie
+                    self.assertEqual(s_return, s_status_end)
 
-            # vérification de l'attente
-            ## update
-            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status)+1)
-            ##log + callback
-            if f_callback is not None:
-                self.assertEqual(f_callback.call_count, len(l_status)+1)
-                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)+1))
+                    # vérification de l'attente
+                    ## update
+                    self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status) + 1)
+                    ##log + callback
+                    if f_callback is not None:
+                        self.assertEqual(f_callback.call_count, len(l_status) + 1)
+                        self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status) + 1))
 
-            f_ctrl_c.assert_not_called()
+                    f_ctrl_c.assert_not_called()
 
     def interrupt_monitoring_until_end_args(self, s_status_end: str, b_waits: bool, b_callback: bool, s_ctrl_c: str, b_upload: bool, b_stored_data: bool, b_new_output: bool) -> None:
         # cas interruption par l'utilisateur.
@@ -626,38 +788,46 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         #     "b_new_output", b_new_output,
         # )
         if b_waits:
-            i_nb_call_back=4
-            l_status = [{"status": ProcessingExecution.STATUS_CREATED}, {"status": ProcessingExecution.STATUS_WAITING}, {"status": ProcessingExecution.STATUS_PROGRESS}, \
-                {"raise": "KeyboardInterrupt"}, {"status": ProcessingExecution.STATUS_PROGRESS}, {"status": ProcessingExecution.STATUS_PROGRESS}, {"status": s_status_end}]
+            i_nb_call_back = 4
+            l_status = [
+                {"status": ProcessingExecution.STATUS_CREATED},
+                {"status": ProcessingExecution.STATUS_WAITING},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"raise": "KeyboardInterrupt"},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"status": ProcessingExecution.STATUS_PROGRESS},
+                {"status": s_status_end},
+            ]
         else:
-            i_nb_call_back =2
+            i_nb_call_back = 2
             l_status = [{"status": ProcessingExecution.STATUS_PROGRESS}, {"raise": "KeyboardInterrupt"}, {"status": s_status_end}]
 
         f_callback = MagicMock() if b_callback else None
         if s_ctrl_c == "delete":
             f_ctrl_c = MagicMock(return_value=True)
-        elif s_ctrl_c  == "pass":
+        elif s_ctrl_c == "pass":
             f_ctrl_c = MagicMock(return_value=False)
         else:
             f_ctrl_c = None
 
-        d_definition_dict: Dict[str, Any] = {"body_parameters":{"output":{}}}
+        d_definition_dict: Dict[str, Any] = {"body_parameters": {"output": {}}}
         d_output = {"name": "new"} if b_new_output else {"_id": "ancien"}
-        if b_upload :
+        if b_upload:
             o_mock_upload = MagicMock()
             o_mock_upload.api_delete.return_value = None
             o_mock_stored_data = None
-            d_definition_dict["body_parameters"]["output"]["upload"]=d_output
+            d_definition_dict["body_parameters"]["output"]["upload"] = d_output
         elif b_stored_data:
             o_mock_upload = None
             o_mock_stored_data = MagicMock()
             o_mock_stored_data.api_delete.return_value = None
-            d_definition_dict["body_parameters"]["output"]["stored_data"]=d_output
+            d_definition_dict["body_parameters"]["output"]["stored_data"] = d_output
         else:
             o_mock_upload = None
             o_mock_stored_data = None
 
         i_iter = 0
+
         def status() -> Dict[str, Any]:
             """fonction pour mock de get_store_properties (=> status)
 
@@ -670,7 +840,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             nonlocal i_iter
             s_el = l_status[i_iter]
 
-            i_iter+=1
+            i_iter += 1
             if "raise" in s_el:
                 raise KeyboardInterrupt()
             return s_el
@@ -681,71 +851,69 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_mock_processing_execution.api_update.return_value = None
         o_mock_processing_execution.api_abort.return_value = None
 
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe:
+            with patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_u:
+                with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_sd:
+                    with patch.object(time, "sleep", return_value=None):
+                        with patch.object(Config, "get_int", return_value=0):
 
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock) as o_mock_pe, \
-            patch.object(ProcessingExecutionAction, "upload", new_callable=PropertyMock) as o_mock_u, \
-            patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_sd, \
-            patch.object(time, "sleep", return_value=None), \
-            patch.object(Config, "get_int", return_value=0) :
+                            o_mock_pe.return_value = o_mock_processing_execution
+                            o_mock_u.return_value = o_mock_upload
+                            o_mock_sd.return_value = o_mock_stored_data
 
-            o_mock_pe.return_value = o_mock_processing_execution
-            o_mock_u.return_value = o_mock_upload
-            o_mock_sd.return_value = o_mock_stored_data
+                            # initialisation de ProcessingExecutionAction
+                            o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
 
-            # initialisation de ProcessingExecutionAction
-            o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
+                            # ctrl+C mais continue
+                            if s_ctrl_c == "pass":
+                                s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-            # ctrl+C mais continue
-            if s_ctrl_c  == "pass":
-                s_return = o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                                # vérification valeur de sortie
+                                self.assertEqual(s_return, s_status_end)
 
-                # vérification valeur de sortie
-                self.assertEqual(s_return, s_status_end)
+                                # vérification de l'attente
+                                ## update
+                                self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
+                                ##log + callback
+                                if f_callback is not None:
+                                    self.assertEqual(f_callback.call_count, len(l_status))
+                                    self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)))
+                                if f_ctrl_c:
+                                    f_ctrl_c.assert_called_once_with()
+                                return
 
-                # vérification de l'attente
-                ## update
-                self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
-                ##log + callback
-                if f_callback is not None:
-                    self.assertEqual(f_callback.call_count, len(l_status))
-                    self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * (len(l_status)))
+                            # vérification sortie en erreur de monitoring_until_end
+                            with self.assertRaises(KeyboardInterrupt):
+                                o_pea.monitoring_until_end(f_callback, f_ctrl_c)
 
-                if f_ctrl_c:
-                    f_ctrl_c.assert_called_once_with()
-                return
+                            # exécution de abort
+                            if not b_waits:
+                                o_mock_processing_execution.api_abort.assert_not_called()
+                            else:
+                                o_mock_processing_execution.api_abort.assert_called_once_with()
 
-            # vérification sortie en erreur de monitoring_until_end
-            with self.assertRaises(KeyboardInterrupt):
-                o_pea.monitoring_until_end(f_callback, f_ctrl_c)
+                            # vérification de l'attente
+                            ## update
+                            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
+                            ##log + callback
+                            if f_callback is not None:
+                                self.assertEqual(f_callback.call_count, i_nb_call_back)
+                                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * i_nb_call_back)
 
-            # exécution de abort
-            if not b_waits:
-                o_mock_processing_execution.api_abort.assert_not_called()
-            else:
-                o_mock_processing_execution.api_abort.assert_called_once_with()
+                            # vérification suppression el de sortie si nouveau
+                            if b_waits and s_status_end == ProcessingExecution.STATUS_ABORTED:
+                                if b_upload and o_mock_upload:
+                                    if b_new_output:
+                                        o_mock_upload.api_delete.assert_called_once_with()
+                                    else:
+                                        o_mock_upload.api_delete.assert_not_called()
+                                elif b_stored_data and o_mock_stored_data:
+                                    if b_new_output:
+                                        o_mock_stored_data.api_delete.assert_called_once_with()
+                                    else:
+                                        o_mock_stored_data.api_delete.assert_not_called()
 
-            # vérification de l'attente
-            ## update
-            self.assertEqual(o_mock_processing_execution.api_update.call_count, len(l_status))
-            ##log + callback
-            if f_callback is not None:
-                self.assertEqual(f_callback.call_count, i_nb_call_back)
-                self.assertEqual(f_callback.mock_calls, [call(o_mock_processing_execution)] * i_nb_call_back)
-
-            # vérification suppression el de sortie si nouveau
-            if b_waits and s_status_end == ProcessingExecution.STATUS_ABORTED:
-                if b_upload and o_mock_upload:
-                    if b_new_output:
-                        o_mock_upload.api_delete.assert_called_once_with()
-                    else:
-                        o_mock_upload.api_delete.assert_not_called()
-                elif b_stored_data and o_mock_stored_data:
-                    if b_new_output:
-                        o_mock_stored_data.api_delete.assert_called_once_with()
-                    else:
-                        o_mock_stored_data.api_delete.assert_not_called()
-
-    def test_monitoring_until_end(self)-> None:
+    def test_monitoring_until_end(self) -> None:
         """test de monitoring_until_end"""
         for s_status_end in [ProcessingExecution.STATUS_ABORTED, ProcessingExecution.STATUS_SUCCESS, ProcessingExecution.STATUS_FAILURE]:
             for b_waits in [False, True]:
@@ -757,46 +925,68 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                             self.interrupt_monitoring_until_end_args(s_status_end, b_waits, b_callback, s_ctrl_c, False, True, b_new_output)
                             self.interrupt_monitoring_until_end_args(s_status_end, b_waits, b_callback, s_ctrl_c, False, False, b_new_output)
         # cas sans processing execution => impossible
-        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value = None):
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=None):
             o_pea = ProcessingExecutionAction("contexte", {})
             # on attend une erreur
             with self.assertRaises(StepActionError) as o_err:
                 o_pea.monitoring_until_end()
             self.assertEqual(o_err.exception.message, "Aucune processing-execution trouvée. Impossible de suivre le déroulement du traitement")
-            return
 
+        # compatibility_cartes et mise_en_base
+        o_pea = ProcessingExecutionAction("contexte", {})
+        o_mock_processing_execution = MagicMock(id="id_mise_en_base")
+        o_mock_processing_execution.get_store_properties.return_value = {"status": ProcessingExecution.STATUS_SUCCESS}
+        o_pea._ProcessingExecutionAction__mode_cartes = True
+        l_inputs = [MagicMock(), MagicMock()]
 
-    def test_output_new_entity(self)-> None:
+        with patch.object(ProcessingExecutionAction, "processing_execution", new_callable=PropertyMock, return_value=o_mock_processing_execution):
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                # manque input
+                with self.assertRaises(GpfSdkError) as e_err:
+                    o_pea.monitoring_until_end()
+                self.assertEqual(e_err.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
+                # statu ok
+                o_pea._ProcessingExecutionAction__inputs_upload = l_inputs
+                o_pea.monitoring_until_end()
+                for o_upload in l_inputs:
+                    o_upload.api_add_tags({"integration_progress": "execution_end_ok_integration_progress"})
+                    o_upload.reset_mock()
+                # status ko
+                o_pea.monitoring_until_end()
+                o_mock_processing_execution.get_store_properties.return_value = {"status": ProcessingExecution.STATUS_ABORTED}
+                for o_upload in l_inputs:
+                    o_upload.api_add_tags({"integration_progress": "execution_end_ko_integration_progress"})
+
+    def test_output_new_entity(self) -> None:
         """test de output_new_entity"""
         for s_output in ["upload", "stored_data"]:
             for b_new in [True, False]:
                 d_output = {"name": "new"} if b_new else {"_id": "ancien"}
-                d_definition_dict: Dict[str, Any] = {"body_parameters":{"output":{s_output:d_output}}}
+                d_definition_dict: Dict[str, Any] = {"body_parameters": {"output": {s_output: d_output}}}
                 # initialisation de ProcessingExecutionAction
                 o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
                 self.assertEqual(o_pea.output_new_entity, b_new)
         # pas de sortie
-        o_pea = ProcessingExecutionAction("contexte", {"body_parameters":{}})
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters": {}})
         self.assertFalse(o_pea.output_new_entity)
         # sortie non stored_data ou upload
-        o_pea = ProcessingExecutionAction("contexte", {"body_parameters":{"output":{}}})
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters": {"output": {}}})
         self.assertFalse(o_pea.output_new_entity)
 
-
-    def test_output_update_entity(self)-> None:
+    def test_output_update_entity(self) -> None:
         """test de output_update_entity"""
         for s_output in ["upload", "stored_data"]:
             for b_update in [True, False]:
                 d_output = {"_id": "ancien"} if b_update else {"name": "new"}
-                d_definition_dict: Dict[str, Any] = {"body_parameters":{"output":{s_output:d_output}}}
+                d_definition_dict: Dict[str, Any] = {"body_parameters": {"output": {s_output: d_output}}}
                 # initialisation de ProcessingExecutionAction
                 o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
                 self.assertEqual(o_pea.output_update_entity, b_update)
         # pas de sortie
-        o_pea = ProcessingExecutionAction("contexte", {"body_parameters":{}})
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters": {}})
         self.assertFalse(o_pea.output_update_entity)
         # sortie non stored_data ou upload
-        o_pea = ProcessingExecutionAction("contexte", {"body_parameters":{"output":{}}})
+        o_pea = ProcessingExecutionAction("contexte", {"body_parameters": {"output": {}}})
         self.assertFalse(o_pea.output_update_entity)
 
     def test_str(self) -> None:
@@ -806,6 +996,6 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_action = ProcessingExecutionAction("nom", d_definition)
         self.assertEqual("ProcessingExecutionAction(workflow=nom)", str(o_action))
         # test avec processing execution
-        with patch('sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction.ProcessingExecutionAction.processing_execution', new_callable=PropertyMock) as o_mock_processing_execution:
-            o_mock_processing_execution.return_value = MagicMock(id='test uuid')
+        with patch("sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction.ProcessingExecutionAction.processing_execution", new_callable=PropertyMock) as o_mock_processing_execution:
+            o_mock_processing_execution.return_value = MagicMock(id="test uuid")
             self.assertEqual("ProcessingExecutionAction(workflow=nom, processing_execution=test uuid)", str(o_action))

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -73,6 +73,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         datastore: Optional[str],
         output_already_exist: bool = False,
         behavior: Optional[str] = None,
+        message:str = "",
     ) -> None:
         """lancement + test de ProcessingExecutionAction.run selon param
 
@@ -82,7 +83,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             s_type_output (str): type de l'output (stored_data ou upload)
         """
         self.i += 1
-        with self.subTest(i=self.i):
+        with self.subTest(message=message):
             d_action: Dict[str, Any] = {"type": "processing-execution", "body_parameters":{"output":{s_key:"test"}}}
             if tags is not None:
                 d_action["tags"] = tags
@@ -188,6 +189,9 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                         o_mock_exist_output.reset_mock()
                         o_mock_pea_find_stored_data.reset_mock()
                         o_mock_processing_execution.api_launch.reset_mock()
+                        o_mock_processing_execution.get_store_properties.reset_mock()
+                        o_mock_stored_data_api_get.reset_mock()
+                        o_mock_upload_api_get.reset_mock()
 
                         # troisième test sur STATUS_UNSTABLE => suppression puis normal
                         o_mock_exist_output.__getitem__.return_value = StoredData.STATUS_UNSTABLE
@@ -266,21 +270,22 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         for s_datastore in [None, "datastore"]:
             for s_type_output in [ "upload", "stored_data"]:
                 ## sans tag + sans commentaire
-                self.run_args(None, None, s_key, s_type_output, s_datastore)
+                self.run_args(None, None, s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - no tag - no comment")
                 ## tag vide + commentaire vide
-                self.run_args({}, [], s_key, s_type_output, s_datastore)
+                self.run_args({}, [], s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - vide tag - vide comment")
                 ## 1 tag + 1 commentaire
-                self.run_args({"tag1": "val1"}, ["comm1"], s_key, s_type_output, s_datastore)
+                self.run_args({"tag1": "val1"}, ["comm1"], s_key, s_type_output, s_datastore, message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 1 tag - 1 comment")
                 ## 2 tag + 4 commentaire
-                self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore)
+                self.run_args(
+                    {"tag1": "val1", "tag2": "val2"},
+                    ["comm1", "comm2", "comm3", "comm4"],
+                    s_key, s_type_output, s_datastore,
+                    message=f"{'no 'if not s_datastore else ''}datastore - {s_type_output} - 2 tag - 4 comment",
+                )
 
         # tests particuliers pour cas ou la sortie existe déjà
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "STOP")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "DELETE")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "CONTINUE")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "RESUME")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, "Toto")
-        self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, None)
+        for s_beavior in ["STOP","DELETE","CONTINUE","RESUME","Toto",None] :
+            self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], s_key, s_type_output, s_datastore, True, s_beavior, message=f"beavior {s_beavior}")
 
         # cas en erreurs non spécifique
         d_action: Dict[str, Any] = {"type": "processing-execution", "body_parameters":{"output":{s_key:"test"}}, "tags": {"key":"val"}, "comments": ["comm"]}

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -325,7 +325,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
 
         ## mise_en_base : manque datasheet_name
         d_def["tags"] = d_tags
-        o_processing_execution.id = "id_mise_en_base"
+        o_processing_execution.get_store_properties.return_value = {"processing": {"_id": "id_mise_en_base"}}
         o_pe._ProcessingExecutionAction__no_output = False
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
             with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
@@ -364,7 +364,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
 
         ## pyramide_vecteur : manque datasheet_name
         d_def["tags"] = d_tags
-        o_processing_execution.id = "id_pyramide_vecteur"
+        o_processing_execution.get_store_properties.return_value = {"processing": {"_id": "id_pyramide_vecteur"}}
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
             with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
                 with self.assertRaises(GpfSdkError) as e_err_comp:

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -14,6 +14,8 @@ from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import Processin
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from tests.GpfTestCase import GpfTestCase
 
+# cSpell:ignore datasheet vectordb creat
+
 
 # pylint:disable=too-many-arguments
 # pylint:disable=too-many-locals
@@ -326,71 +328,67 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
         o_processing_execution.id = "id_mise_en_base"
         o_pe._ProcessingExecutionAction__no_output = False
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
-            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
                 with self.assertRaises(GpfSdkError) as e_err_comp:
                     o_pe._ProcessingExecutionAction__add_tags()
                 self.assertEqual(e_err_comp.exception.message, "Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
         ## mise_en_base : manque inputs
         d_def["tags"] = {**d_tags, "datasheet_name": "name"}
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
-            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
                 with self.assertRaises(GpfSdkError) as e_err_comp:
                     o_pe._ProcessingExecutionAction__add_tags()
-                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
-        ## mise_en_base : maque stored_data sortie
+                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoires")
+        ## mise_en_base : manque stored_data sortie
         l_inputs_upload = [MagicMock(id=1), MagicMock(id=2)]
         o_pe._ProcessingExecutionAction__inputs_upload = l_inputs_upload
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None) as o_mock_stored_data:
-            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
                 with self.assertRaises(GpfSdkError) as e_err_comp:
                     o_pe._ProcessingExecutionAction__add_tags()
-                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
+                self.assertEqual(e_err_comp.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoires")
         ## mise_en_base : OK
         d_def["tags"] = {**d_tags, "datasheet_name": "name"}
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
-            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
-                o_pe._ProcessingExecutionAction__add_tags()
-                o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_progress")
-                o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_current_step")
-                for o_offering in l_inputs_upload:
-                    o_offering.api_add_tags.assert_called_once_with(
-                        {
-                            "integration_progress": "execution_start_integration_progress",
-                            "integration_current_step": "execution_start_integration_current_step",
-                            "proc_int_id": o_processing_execution.id,
-                            "vectordb_id": o_mock_stored_data.return_value.id,
-                        }
-                    )
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
+                o_pe._ProcessingExecutionAction__add_tags()  # appelle la méthode privée __add_tags
+                # o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_progress")
+                # o_mock_config.assert_any_call("compatibility_cartes", "execution_start_integration_current_step")
+                for o_upload in l_inputs_upload:
+                    self.assertEqual(o_upload.api_add_tags.call_count, 2)
+                    # TODO Alain ? tester l'appel avec successivement :
+                    # {"proc_int_id": o_processing_execution.id, "vectordb_id": o_mock_stored_data.return_value.id}
+                    # {'integration_progress': '{"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}', 'integration_current_step': '2'}
                 o_mock_stored_data.return_value.api_add_tags.assert_called_once_with({**d_tags, "datasheet_name": "name", "uuid_upload": l_inputs_upload[0].id})
 
         ## pyramide_vecteur : manque datasheet_name
         d_def["tags"] = d_tags
         o_processing_execution.id = "id_pyramide_vecteur"
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
-            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
                 with self.assertRaises(GpfSdkError) as e_err_comp:
                     o_pe._ProcessingExecutionAction__add_tags()
                 self.assertEqual(e_err_comp.exception.message, "Mode compatibility_cartes activé, il faut obligatoirement définir le tag 'datasheet_name'")
         ## pyramide_vecteur : manque inputs
         d_def["tags"] = {**d_tags, "datasheet_name": "name"}
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
-            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
                 with self.assertRaises(GpfSdkError) as e_err_comp:
                     o_pe._ProcessingExecutionAction__add_tags()
-                self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoire")
+            self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoires")
         ## pyramide_vecteur : maque stored_data sortie
         l_inputs_stored_data = [MagicMock(id=1), MagicMock(id=2)]
         o_pe._ProcessingExecutionAction__inputs_stored_data = l_inputs_stored_data
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock, return_value=None) as o_mock_stored_data:
-            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
                 with self.assertRaises(GpfSdkError) as e_err_comp:
                     o_pe._ProcessingExecutionAction__add_tags()
-                self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoire")
+            self.assertEqual(e_err_comp.exception.message, "Création de pyramide vecteur : input and output obligatoires")
 
         ## pyramide_vecteur : OK
         d_def["tags"] = {**d_tags, "datasheet_name": "name"}
         with patch.object(ProcessingExecutionAction, "stored_data", new_callable=PropertyMock) as o_mock_stored_data:
-            with patch.object(Config(), "get_str", side_effect=lambda x, y: y) as o_mock_config:
+            with patch.object(Config(), "get_str", side_effect=lambda x, y: y):
                 o_pe._ProcessingExecutionAction__add_tags()
                 o_mock_stored_data.return_value.api_add_tags.assert_called_once_with(
                     {**d_tags, "datasheet_name": "name", "vectordb_id": l_inputs_stored_data[0].id, "proc_pyr_creat_id": o_processing_execution.id}
@@ -944,7 +942,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                 # manque input
                 with self.assertRaises(GpfSdkError) as e_err:
                     o_pea.monitoring_until_end()
-                self.assertEqual(e_err.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoire")
+                self.assertEqual(e_err.exception.message, "Intégration de données vecteur livrées en base : input and output obligatoires")
                 # statu ok
                 o_pea._ProcessingExecutionAction__inputs_upload = l_inputs
                 o_pea.monitoring_until_end()

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -208,7 +208,13 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
                 with self.assertRaises(GpfSdkError) as e_err:
                     o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
-                self.assertEqual(e_err.exception.message,f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. Impossible de lancer le traitement demandé.")
+                self.assertEqual(e_err.exception.message,
+                    (
+                        f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. "
+                        "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
+                        "pour faire réinitialiser son statut."
+                    )
+                )
 
 
         # BEHAVIOR_CONTINUE + not STATUS_FAILURE
@@ -232,9 +238,15 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             with patch.object(ProcessingExecution, "api_list", return_value=[o_pe_1, o_pe_2, o_pe_3, o_pe_4]) as  o_mock_api_list:
                 with self.assertRaises(GpfSdkError) as e_err:
                     o_pea._ProcessingExecutionAction__gestion_update_entity(s_datastore) # type: ignore
-                self.assertEqual(e_err.exception.message,f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. Impossible de lancer le traitement demandé.")
+                self.assertEqual(e_err.exception.message,
+                    (
+                        f"Le traitement précédent a échoué sur la donnée stockée en sortie {o_mock_api_get.return_value}. "
+                        "Impossible de lancer le traitement demandé : contactez le support de l'Entrepôt Géoplateforme "
+                        "pour faire réinitialiser son statut."
+                    )
+                )
 
-        # beavior non valide
+        # behavior non valide
         s_behavior="toto"
         o_pea = ProcessingExecutionAction("contexte", d_action, behavior=s_behavior)
         with patch.object(StoredData, "api_get") as  o_mock_api_get:
@@ -281,7 +293,7 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
             o_mock_processing_execution.get_store_properties.return_value = d_store_properties
             o_mock_processing_execution.api_launch.return_value = None
             # o_mock_processing_execution.__getitem__.return_value = ProcessingExecution.STATUS_CREATED
-            # ça veut dire que : o_mock_processing_execution["quelchechose"] = "CREATED"
+            # ça veut dire que : o_mock_processing_execution["quelque_chose"] = "CREATED"
             def get_items_processing(key:str) -> Any:
                 if key == "status":
                     return "CREATED"

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -14,7 +14,7 @@ from sdk_entrepot_gpf.workflow.action.ProcessingExecutionAction import Processin
 from sdk_entrepot_gpf.Errors import GpfSdkError
 from tests.GpfTestCase import GpfTestCase
 
-# cSpell:ignore datasheet vectordb creat specifique
+# cSpell:ignore datasheet vectordb creat
 
 
 # pylint:disable=too-many-arguments
@@ -357,9 +357,9 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                     # test sur le nombre d'appels :
                     self.assertEqual(o_upload.api_add_tags.call_count, 2)
                     # test sur les paramètres passés :
-                    d_general = {"proc_int_id": o_processing_execution.id, "vectordb_id": o_mock_stored_data.return_value.id}
-                    d_specifique = {"integration_progress": '{"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}', "integration_current_step": "2"}
-                    o_upload.api_add_tags.assert_has_calls([call(d_general), call(d_specifique)])
+                    d_traitement = {"proc_int_id": o_processing_execution.id, "vectordb_id": o_mock_stored_data.return_value.id}
+                    d_etape = {"integration_progress": '{"send_files_api": "successful", "wait_checks": "successful","integration_processing": "in_progress"}', "integration_current_step": "2"}
+                    o_upload.api_add_tags.assert_has_calls([call(d_traitement), call(d_etape)])
                 o_mock_stored_data.return_value.api_add_tags.assert_called_once_with({**d_tags, "datasheet_name": "name", "uuid_upload": l_inputs_upload[0].id})
 
         ## pyramide_vecteur : manque datasheet_name

--- a/tests/workflow/action/UploadActionTestCase.py
+++ b/tests/workflow/action/UploadActionTestCase.py
@@ -115,7 +115,8 @@ class UploadActionTestCase(GpfTestCase):
         super().setUpClass()
         # On détruit le Singleton Config
         Config._instance = None
-        # On charge une config spéciale pour les tests d'upload
+        # On surcharge la config de base pour les tests d'upload : nb_sec_between_check_updates=0 au lieu de =10
+        # pour ne pas attendre entre 2 m-à-j du statut de vérification)
         o_config = Config()
         o_config.read(GpfTestCase.conf_dir_path / "test_upload.ini")
         o_config.set_output_manager(MagicMock())

--- a/tests/workflow/action/UploadActionTestCase.py
+++ b/tests/workflow/action/UploadActionTestCase.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, call, patch
 
 import requests
 from sdk_entrepot_gpf.io.Errors import ConflictError
@@ -175,6 +175,7 @@ class UploadActionTestCase(GpfTestCase):
         # upload fermé
         with patch.object(UploadAction, "_UploadAction__create_upload") as o_mock__create_upload, \
             patch.object(UploadAction, "_UploadAction__add_tags") as o_mock__add_tags, \
+            patch.object(UploadAction, "_UploadAction__add_carte_tags") as o_mock__add_carte_tags, \
             patch.object(UploadAction, "_UploadAction__add_comments") as o_mock__add_comments, \
             patch.object(UploadAction, "_UploadAction__push_data_files") as o_mock__push_data_files, \
             patch.object(UploadAction, "_UploadAction__push_md5_files") as o_mock__push_md5_files, \
@@ -190,15 +191,16 @@ class UploadActionTestCase(GpfTestCase):
             self.assertEqual(o_upload, o_mock_upload)
             o_mock__create_upload.assert_called_once_with(s_datastore)
             o_mock__add_tags.assert_not_called()
+            o_mock__add_carte_tags.assert_not_called()
             o_mock__add_comments.assert_not_called()
             o_mock__push_data_files.assert_not_called()
             o_mock__push_md5_files.assert_not_called()
             o_mock__check_file_uploaded.assert_not_called()
             o_mock__close.assert_not_called()
-
         # upload ouvert sans vérification avant fermeture
         with patch.object(UploadAction, "_UploadAction__create_upload") as o_mock__create_upload, \
             patch.object(UploadAction, "_UploadAction__add_tags") as o_mock__add_tags, \
+            patch.object(UploadAction, "_UploadAction__add_carte_tags") as o_mock__add_carte_tags, \
             patch.object(UploadAction, "_UploadAction__add_comments") as o_mock__add_comments, \
             patch.object(UploadAction, "_UploadAction__push_data_files") as o_mock__push_data_files, \
             patch.object(UploadAction, "_UploadAction__push_md5_files") as o_mock__push_md5_files, \
@@ -214,6 +216,16 @@ class UploadActionTestCase(GpfTestCase):
             self.assertEqual(o_upload, o_mock_upload)
             o_mock__create_upload.assert_called_once_with(s_datastore)
             o_mock__add_tags.assert_called_once_with()
+            # vérification que o_mock__add_carte_tags a été appelé 3 fois avec les 3 mots clés
+            self.assertEqual(o_mock__add_carte_tags.call_count, 3)
+            self.assertListEqual(
+                o_mock__add_carte_tags.call_args_list,
+                [
+                    call("upload_creation"),
+                    call("upload_upload_start"),
+                    call("upload_upload_end"),
+                ],
+            )
             o_mock__add_comments.assert_called_once_with()
             o_mock__push_data_files.assert_called_once_with(True)
             o_mock__push_md5_files.assert_called_once_with(True)
@@ -223,6 +235,7 @@ class UploadActionTestCase(GpfTestCase):
         # upload ouvert avec vérification avant fermeture ok
         with patch.object(UploadAction, "_UploadAction__create_upload") as o_mock__create_upload, \
             patch.object(UploadAction, "_UploadAction__add_tags") as o_mock__add_tags, \
+            patch.object(UploadAction, "_UploadAction__add_carte_tags") as o_mock__add_carte_tags, \
             patch.object(UploadAction, "_UploadAction__add_comments") as o_mock__add_comments, \
             patch.object(UploadAction, "_UploadAction__push_data_files") as o_mock__push_data_files, \
             patch.object(UploadAction, "_UploadAction__push_md5_files") as o_mock__push_md5_files, \
@@ -244,6 +257,16 @@ class UploadActionTestCase(GpfTestCase):
             self.assertEqual(o_upload, o_mock_upload)
             o_mock__create_upload.assert_called_once_with(s_datastore)
             o_mock__add_tags.assert_called_once_with()
+            # vérification que o_mock__add_carte_tags a été appelé 3 fois avec les 3 mots clés
+            self.assertEqual(o_mock__add_carte_tags.call_count, 3)
+            self.assertListEqual(
+                o_mock__add_carte_tags.call_args_list,
+                [
+                    call("upload_creation"),
+                    call("upload_upload_start"),
+                    call("upload_upload_end"),
+                ],
+            )
             o_mock__add_comments.assert_called_once_with()
             o_mock__push_data_files.assert_called_once_with(False)
             o_mock__push_md5_files.assert_called_once_with(False)
@@ -261,6 +284,7 @@ class UploadActionTestCase(GpfTestCase):
         # upload ouvert avec vérification avant fermeture ko
         with patch.object(UploadAction, "_UploadAction__create_upload") as o_mock__create_upload, \
             patch.object(UploadAction, "_UploadAction__add_tags") as o_mock__add_tags, \
+            patch.object(UploadAction, "_UploadAction__add_carte_tags") as o_mock__add_carte_tags, \
             patch.object(UploadAction, "_UploadAction__add_comments") as o_mock__add_comments, \
             patch.object(UploadAction, "_UploadAction__push_data_files") as o_mock__push_data_files, \
             patch.object(UploadAction, "_UploadAction__push_md5_files") as o_mock__push_md5_files, \
@@ -285,6 +309,15 @@ class UploadActionTestCase(GpfTestCase):
             self.assertEqual(l_error, o_err.exception.files)
             o_mock__create_upload.assert_called_once_with(s_datastore)
             o_mock__add_tags.assert_called_once_with()
+            # vérification que o_mock__add_carte_tags a été appelé 2 fois avec les 2 mots clés
+            self.assertEqual(o_mock__add_carte_tags.call_count, 2)
+            self.assertListEqual(
+                o_mock__add_carte_tags.call_args_list,
+                [
+                    call("upload_creation"),
+                    call("upload_upload_start"),
+                ],
+            )
             o_mock__add_comments.assert_called_once_with()
             o_mock__push_data_files.assert_called_once_with(False)
             o_mock__push_md5_files.assert_called_once_with(False)
@@ -675,23 +708,26 @@ class UploadActionTestCase(GpfTestCase):
         # elle renvoie une liste avec des traitements en attente 2 fois puis une liste avec que des succès
         l_returns = [d_list_checks_wait_1, d_list_checks_wait_2, d_list_checks_ok]
         with patch.object(Upload, "api_list_checks", side_effect=l_returns) as o_mock_list_checks:
-            # On instancie un Upload
-            o_upload = Upload({"_id": "id_upload_monitor"})
-            # On instancie un faux callback
-            f_callback = MagicMock()
-            f_ctrl_c = MagicMock(return_value=False)
-            # On effectue le monitoring
-            b_result = UploadAction.monitor_until_end(o_upload, f_callback, f_ctrl_c)
-            # Vérification sur o_mock_list_checks et f_callback: ont dû être appelés 3 fois
-            self.assertEqual(o_mock_list_checks.call_count, 3)
-            self.assertEqual(f_callback.call_count, 3)
-            f_callback.assert_any_call("Vérifications : 2 en attente, 0 en cours, 0 en échec, 0 en succès")
-            f_callback.assert_any_call("Vérifications : 1 en attente, 1 en cours, 0 en échec, 0 en succès")
-            f_callback.assert_any_call("Vérifications : 0 en attente, 0 en cours, 0 en échec, 2 en succès")
-            # Vérification sur f_ctrl_c : n'a pas dû être appelée
-            f_ctrl_c.assert_not_called()
-            # Vérifications sur b_result : doit être finalement ok
-            self.assertTrue(b_result)
+            with patch.object(UploadAction, "add_carte_tags") as o_mock_add_carte_tags:
+                # On instancie un Upload
+                o_upload = Upload({"_id": "id_upload_monitor"})
+                # On instancie un faux callback
+                f_callback = MagicMock()
+                f_ctrl_c = MagicMock(return_value=False)
+                # On effectue le monitoring
+                b_result = UploadAction.monitor_until_end(o_upload, f_callback, f_ctrl_c)
+                # Vérification sur o_mock_list_checks et f_callback: ont dû être appelés 3 fois
+                self.assertEqual(o_mock_list_checks.call_count, 3)
+                self.assertEqual(f_callback.call_count, 3)
+                f_callback.assert_any_call("Vérifications : 2 en attente, 0 en cours, 0 en échec, 0 en succès")
+                f_callback.assert_any_call("Vérifications : 1 en attente, 1 en cours, 0 en échec, 0 en succès")
+                f_callback.assert_any_call("Vérifications : 0 en attente, 0 en cours, 0 en échec, 2 en succès")
+                # Vérification sur f_ctrl_c : n'a pas dû être appelée
+                f_ctrl_c.assert_not_called()
+                # Vérifications sur b_result : doit être finalement ok
+                self.assertTrue(b_result)
+                # Vérification sur add_carte_tags() : on devrait avoir "upload_check_ok"
+                o_mock_add_carte_tags.assert_called_once_with(True, o_upload, "upload_check_ok")
 
     def test_monitor_until_end_ko(self) -> None:
         """Vérifie le bon fonctionnement de monitor_until_end si à la fin c'est ko."""
@@ -703,23 +739,26 @@ class UploadActionTestCase(GpfTestCase):
         # elle renvoie une liste avec des traitements en attente 2 fois puis une liste avec des erreurs
         l_returns = [d_list_checks_wait_1, d_list_checks_wait_2, d_list_checks_ko]
         with patch.object(Upload, "api_list_checks", side_effect=l_returns) as o_mock_list_checks:
-            # On instancie un Upload
-            o_upload = Upload({"_id": "id_upload_monitor"})
-            # On instancie un faux callback
-            f_callback = MagicMock()
-            f_ctrl_c = MagicMock(return_value=False)
-            # On effectue le monitoring
-            b_result = UploadAction.monitor_until_end(o_upload, f_callback, f_ctrl_c)
-            # Vérification sur o_mock_list_checks et f_callback: ont dû être appelés 3 fois
-            self.assertEqual(o_mock_list_checks.call_count, 3)
-            self.assertEqual(f_callback.call_count, 3)
-            f_callback.assert_any_call("Vérifications : 2 en attente, 0 en cours, 0 en échec, 0 en succès")
-            f_callback.assert_any_call("Vérifications : 1 en attente, 1 en cours, 0 en échec, 0 en succès")
-            f_callback.assert_any_call("Vérifications : 0 en attente, 0 en cours, 1 en échec, 1 en succès")
-            # Vérification sur f_ctrl_c : n'a pas dû être appelée
-            f_ctrl_c.assert_not_called()
-            # Vérifications sur b_result : doit être finalement ko
-            self.assertFalse(b_result)
+            with patch.object(UploadAction, "add_carte_tags") as o_mock_add_carte_tags:
+                # On instancie un Upload
+                o_upload = Upload({"_id": "id_upload_monitor"})
+                # On instancie un faux callback
+                f_callback = MagicMock()
+                f_ctrl_c = MagicMock(return_value=False)
+                # On effectue le monitoring
+                b_result = UploadAction.monitor_until_end(o_upload, f_callback, f_ctrl_c)
+                # Vérification sur o_mock_list_checks et f_callback: ont dû être appelés 3 fois
+                self.assertEqual(o_mock_list_checks.call_count, 3)
+                self.assertEqual(f_callback.call_count, 3)
+                f_callback.assert_any_call("Vérifications : 2 en attente, 0 en cours, 0 en échec, 0 en succès")
+                f_callback.assert_any_call("Vérifications : 1 en attente, 1 en cours, 0 en échec, 0 en succès")
+                f_callback.assert_any_call("Vérifications : 0 en attente, 0 en cours, 1 en échec, 1 en succès")
+                # Vérification sur f_ctrl_c : n'a pas dû être appelée
+                f_ctrl_c.assert_not_called()
+                # Vérifications sur b_result : doit être finalement ko
+                self.assertFalse(b_result)
+                # Vérification sur add_carte_tags() : on devrait avoir "upload_check_ko"
+                o_mock_add_carte_tags.assert_called_once_with(True, o_upload, "upload_check_ko")
 
     def test_interrupt_monitor_until_end(self) -> None:
         """Vérifie le bon fonctionnement de monitor_until_end si il y a interruption en cours de route."""

--- a/tests/workflow/action/UploadActionTestCase.py
+++ b/tests/workflow/action/UploadActionTestCase.py
@@ -708,7 +708,7 @@ class UploadActionTestCase(GpfTestCase):
         # elle renvoie une liste avec des traitements en attente 2 fois puis une liste avec que des succès
         l_returns = [d_list_checks_wait_1, d_list_checks_wait_2, d_list_checks_ok]
         with patch.object(Upload, "api_list_checks", side_effect=l_returns) as o_mock_list_checks:
-            with patch.object(UploadAction, "add_carte_tags") as o_mock_add_carte_tags:
+            with patch.object(UploadAction, "add_carte_tags") as o_mock__add_carte_tags:
                 # On instancie un Upload
                 o_upload = Upload({"_id": "id_upload_monitor"})
                 # On instancie un faux callback
@@ -727,7 +727,7 @@ class UploadActionTestCase(GpfTestCase):
                 # Vérifications sur b_result : doit être finalement ok
                 self.assertTrue(b_result)
                 # Vérification sur add_carte_tags() : on devrait avoir "upload_check_ok"
-                o_mock_add_carte_tags.assert_called_once_with(True, o_upload, "upload_check_ok")
+                o_mock__add_carte_tags.assert_called_once_with(True, o_upload, "upload_check_ok")
 
     def test_monitor_until_end_ko(self) -> None:
         """Vérifie le bon fonctionnement de monitor_until_end si à la fin c'est ko."""
@@ -739,7 +739,7 @@ class UploadActionTestCase(GpfTestCase):
         # elle renvoie une liste avec des traitements en attente 2 fois puis une liste avec des erreurs
         l_returns = [d_list_checks_wait_1, d_list_checks_wait_2, d_list_checks_ko]
         with patch.object(Upload, "api_list_checks", side_effect=l_returns) as o_mock_list_checks:
-            with patch.object(UploadAction, "add_carte_tags") as o_mock_add_carte_tags:
+            with patch.object(UploadAction, "add_carte_tags") as o_mock__add_carte_tags:
                 # On instancie un Upload
                 o_upload = Upload({"_id": "id_upload_monitor"})
                 # On instancie un faux callback
@@ -758,7 +758,7 @@ class UploadActionTestCase(GpfTestCase):
                 # Vérifications sur b_result : doit être finalement ko
                 self.assertFalse(b_result)
                 # Vérification sur add_carte_tags() : on devrait avoir "upload_check_ko"
-                o_mock_add_carte_tags.assert_called_once_with(True, o_upload, "upload_check_ko")
+                o_mock__add_carte_tags.assert_called_once_with(True, o_upload, "upload_check_ko")
 
     def test_interrupt_monitor_until_end(self) -> None:
         """Vérifie le bon fonctionnement de monitor_until_end si il y a interruption en cours de route."""


### PR DESCRIPTION
## v0.1.29

### [Added]

* Création/consultation des clefs depuis la ligne de commande #96
* doc/docs/comme-executable.md : Ajout de la documentation pour la suppression, les annexe, les fichiers statics, les fichiers de métadonnées et les clefs
* ApiRequester, Authentifier: gestion de l'erreur ConnectionError #168
* ProcessingExecutionAction: Prise en compte des behaviors pour les exécutions mettant à jour une donnée #166
* OutputManager: ajout option force_flush pour info, warning, error et critical. Permet de forcer la remontée des logs. Utilisation dans les différentes actions où cela est pertinent.
* Mode Compatibilité avec cartes.gouv : ce mode permet au SDK de manipuler les entités de l'API en ajoutant les tags qui permettent d'assurer la compatibilité avec l'interface d'alimentation en ligne cartes.gouv.
* EditAction: possibilité de supprimer les tags et les commentaires #180

### [Changed]

* Config :
  * gestion des fichiers `toml` ;
  * suppression de la fonction `get_parser` remplacée par `get_config` ;
  * les fonctions de récupération typées (`get_str`, `get_int`, `get_float`, `get_bool`) renvoient une valeur valide ou lèvent une exception.

### [Fixed]

* ProcessingExecutionAction: output non obligatoire dans l'étape et dans la processing exécution #165
* Annexe, Metadata: amélioration de l'affichage des entités
* `ReUploadFileInterface` : ajout de `route_params` pour modifier l'entité. (fix #178)
* PermissionAction: il faut utiliser `api_create` et non `api_create_list` pour créer les permissions.