### PR TITLE
v0.1.32

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.8
+    - name: "check version same as tag (${{ github.ref_name }})"
+      run : grep -q $(echo ${{ github.ref_name }} | sed 's/t//') sdk_entrepot_gpf/__init__.py
     - name: Install dependencies
       run: |
         pip install --upgrade pip setuptools flit

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.8
+    - name: "check version same as tag (${{ github.ref_name }})"
+      run : grep -q $(echo ${{ github.ref_name }} | sed 's/v//') sdk_entrepot_gpf/__init__.py
     - name: Install dependencies
       run: |
         pip install --upgrade pip setuptools flit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### [Fixed]
 
 * upload_descriptor_file.json: plus de restriction dans upload_infos #198
+* Workflows génériques : les storages n'ont plus a être tagués "IGN" #201
 
 
 ## v0.1.31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### [Changed]
 
+* Flit : utilisation de `flit_core` pour effectuer la publication (cf. [ce ticket](https://github.com/pypa/flit/issues/698)).
+
 
 ### [Fixed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * upload_descriptor_file.json: plus de restriction dans upload_infos #198
 * Workflows génériques : les storages n'ont plus a être tagués "IGN" #201
+* UserResolver : si la clef `last_name` n'est pas définie, on renvoi `last_name`
 
 
 ## v0.1.31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 * Flit : utilisation de `flit_core` pour effectuer la publication (cf. [ce ticket](https://github.com/pypa/flit/issues/698)).
 
-
 ### [Fixed]
+
+* upload_descriptor_file.json: plus de restriction dans upload_infos #198
 
 
 ## v0.1.31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGE LOG
 
+## v0.1.32
+
+### [Added]
+
+
+### [Changed]
+
+
+### [Fixed]
+
+
 ## v0.1.31
 
 ### [Added]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit >=3.7,<4"]
-build-backend = "flit.buildapi"
+requires = ["flit_core >=3.7,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "sdk_entrepot_gpf"

--- a/sdk_entrepot_gpf/__init__.py
+++ b/sdk_entrepot_gpf/__init__.py
@@ -1,3 +1,3 @@
 """Python API to simplify the use of the GPF Warehouse HTTPS API."""
 
-__version__ = "0.1.31"
+__version__ = "0.1.32"

--- a/sdk_entrepot_gpf/_conf/json_schemas/upload_descriptor_file.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/upload_descriptor_file.json
@@ -33,7 +33,6 @@
                             "srs",
                             "type"
                         ],
-                        "additionalProperties": false,
                         "properties": {
                             "description": {
                                 "type": "string"

--- a/sdk_entrepot_gpf/_data/workflows/generic_vecteur.jsonc
+++ b/sdk_entrepot_gpf/_data/workflows/generic_vecteur.jsonc
@@ -20,7 +20,7 @@
                                 "stored_data": {
                                     // On crée une nouvelle Donnée Stockée nommée "UserLastName__Base_intermédiaire"
                                     "name": "{user.last_name}__Base_intermédiaire",
-                                    "storage_tags": ["IGN", "VECTEUR"]
+                                    "storage_tags": ["VECTEUR"]
                                 }
                             },
                             "parameters": {}
@@ -185,7 +185,7 @@
                                 "stored_data": {
                                     // On crée une nouvelle Donnée Stockée nommée "UserLastName__Pyramide_vecteur"
                                     "name": "{user.last_name}__Pyramide_vecteur",
-                                    "storage_tags": ["IGN", "PYRAMIDE"]
+                                    "storage_tags": ["PYRAMIDE"]
                                 }
                             },
                             "parameters": {

--- a/sdk_entrepot_gpf/auth/Authentifier.py
+++ b/sdk_entrepot_gpf/auth/Authentifier.py
@@ -121,7 +121,7 @@ class Authentifier(metaclass=Singleton):
                 Config().om.warning(e_error.args[0])
             elif isinstance(e_error, requests.exceptions.ConnectionError):
                 Config().om.warning(
-                    f"Le serveur d'authentification ({self.__token_url}) n'est pas joignable. Cela peut être dû à un problème de configuration si elle a changée récemment."
+                    f"Le serveur d'authentification ({self.__token_url}) n'est pas joignable. Cela peut être dû à un problème de configuration si elle a changé récemment."
                     + " Sinon, c'est un problème sur le service d’authentification : consultez l'état du service pour en savoir plus "
                     + f": {Config().get_str('store_authentification', 'check_status_url')}."
                 )

--- a/sdk_entrepot_gpf/io/ApiRequester.py
+++ b/sdk_entrepot_gpf/io/ApiRequester.py
@@ -162,7 +162,7 @@ class ApiRequester(metaclass=Singleton):
                 raise e_error
             except requests.exceptions.ConnectionError as e_connexion:
                 s_message = (
-                    f"Le serveur de l'API Entrepôt ({url}) n'est pas joignable. Cela peut être dû à un problème de configuration si elle a changée récemment."
+                    f"Le serveur de l'API Entrepôt ({url}) n'est pas joignable. Cela peut être dû à un problème de configuration si elle a changé récemment."
                     + " Sinon, c'est un problème sur l'API Entrepôt : consultez l'état du service pour en savoir plus "
                     + f": {Config().get_str('store_api', 'check_status_url')}."
                 )

--- a/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
+++ b/sdk_entrepot_gpf/workflow/resolver/UserResolver.py
@@ -42,6 +42,11 @@ class UserResolver(AbstractResolver):
         """
         # La chaîne à résoudre est en fait la clé, donc il suffit de renvoyer la valeur associée
         try:
+            # Si l'utilisateur a demandé la clef "last_name" et qu'elle n'est pas défini,
+            if string_to_solve == "last_name" and "last_name" not in self.__user_data:
+                # on gère un truc propre pour pas que le tuto pose problème...
+                return "last_name"
+            # Sinon on renvoi la valeur demandée
             return str(self.get(self.__user_data, string_to_solve))
         except KeyError as e:
             # Sinon on lève une exception

--- a/tests/io/ApiRequesterTestCase.py
+++ b/tests/io/ApiRequesterTestCase.py
@@ -336,7 +336,7 @@ class ApiRequesterTestCase(GpfTestCase):
             # On doit avoir un message d'erreur
             self.assertEqual(
                 o_arc.exception.message,
-                f"Le serveur de l'API Entrepôt ({self.url}) n'est pas joignable. Cela peut être dû à un problème de configuration si elle a changée récemment."
+                f"Le serveur de l'API Entrepôt ({self.url}) n'est pas joignable. Cela peut être dû à un problème de configuration si elle a changé récemment."
                 + " Sinon, c'est un problème sur l'API Entrepôt : consultez l'état du service pour en savoir plus "
                 + f": {Config().get_str('store_api', 'check_status_url')}.",
             )


### PR DESCRIPTION
## v0.1.32

### [Changed]

* Flit : utilisation de `flit_core` pour effectuer la publication (cf. [ce ticket](https://github.com/pypa/flit/issues/698)).

### [Fixed]

* upload_descriptor_file.json: plus de restriction dans upload_infos #198
* Workflows génériques : les storages n'ont plus a être tagués "IGN" #201
* UserResolver : si la clef `last_name` n'est pas définie, on renvoi `last_name`