### PR TITLE
Upload : ajout du BEHAVIOR_RESUME. Close #196

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGE LOG
 
+## v0.1.33
+
+### [Added]
+
+* Upload : ajout du BEHAVIOR_RESUME pour la reprise des livraisons si les vérifications on échouer (ouverture et comportement comme BEHAVIOR_CONTINUE) [#196](https://github.com/Geoplateforme/sdk-entrepot/issues/196)
+
+### [Changed]
+
+### [Fixed]
+
 ## v0.1.32
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### [Added]
 
-* Upload : ajout du BEHAVIOR_RESUME pour la reprise des livraisons si les vérifications on échouer (ouverture et comportement comme BEHAVIOR_CONTINUE) [#196](https://github.com/Geoplateforme/sdk-entrepot/issues/196)
+* Upload : ajout du BEHAVIOR_RESUME pour la reprise des livraisons si les vérifications ont échoué (ouverture et comportement comme BEHAVIOR_CONTINUE) [#196](https://github.com/Geoplateforme/sdk-entrepot/issues/196)
 
 ### [Changed]
 

--- a/sdk_entrepot_gpf/workflow/action/UploadAction.py
+++ b/sdk_entrepot_gpf/workflow/action/UploadAction.py
@@ -26,7 +26,8 @@ class UploadAction:
     BEHAVIOR_STOP = "STOP"
     BEHAVIOR_DELETE = "DELETE"
     BEHAVIOR_CONTINUE = "CONTINUE"
-    BEHAVIORS = [BEHAVIOR_STOP, BEHAVIOR_CONTINUE, BEHAVIOR_DELETE]
+    BEHAVIOR_RESUME = "RESUME"
+    BEHAVIORS = [BEHAVIOR_STOP, BEHAVIOR_CONTINUE, BEHAVIOR_DELETE, BEHAVIOR_RESUME]
 
     def __init__(self, dataset: Dataset, behavior: Optional[str] = None, compatibility_cartes: Optional[bool] = None) -> None:
         """initialise le comportement de UploadAction
@@ -119,13 +120,17 @@ class UploadAction:
                 # on en crée une nouvelle (on utilise les champs de "upload_infos" du dataset)
                 self.__upload = Upload.api_create(self.__dataset.upload_infos, route_params={"datastore": datastore})
                 Config().om.warning(f"Livraison {self.__upload} recréée avec succès.")
-            elif self.__behavior == self.BEHAVIOR_CONTINUE:
-                # Sinon on continue avec cet upload pour le compléter (behavior == CONTINUE)
-                # cas livraison fermé : message particulier
-                if not o_upload.is_open():
-                    Config().om.warning(f"Livraison identique {o_upload} trouvée et fermée, cette livraison ne sera pas mise à jour.")
-                else:
+            elif self.__behavior in [self.BEHAVIOR_CONTINUE, self.BEHAVIOR_RESUME]:
+                # Sinon on continue avec cet upload pour le compléter (behavior == CONTINUE ou RESUME)
+                if o_upload.is_open():
                     Config().om.info(f"Livraison identique {o_upload} trouvée, le programme va la reprendre et la compléter.")
+                elif self.__behavior == self.BEHAVIOR_RESUME and len(o_upload.api_list_checks()["failed"]) != 0:
+                    # RESUME : en cas d'erreur sur les vérifications la livraison est rouverte
+                    Config().om.warning(f"Livraison identique {o_upload} trouvée et vérification en erreur, la livraison est rouverte, le programme va la reprendre et la compléter.")
+                    o_upload.api_open()
+                else:
+                    # cas livraison fermé : message particulier,
+                    Config().om.warning(f"Livraison identique {o_upload} trouvée et fermée, cette livraison ne sera pas mise à jour.")
                 self.__upload = o_upload
             else:
                 raise GpfSdkError(f"Le comportement {self.__behavior} n'est pas reconnu ({'|'.join(self.BEHAVIORS)}), l'exécution de traitement est annulée.")

--- a/tests/workflow/action/UploadActionTestCase.py
+++ b/tests/workflow/action/UploadActionTestCase.py
@@ -389,6 +389,41 @@ class UploadActionTestCase(GpfTestCase):
             o_mock_api_create.assert_called_once_with(o_dataset.upload_infos, route_params={"datastore": s_datastore})
             self.assertEqual(o_ua.upload, o_mock_upload_new)
 
+        # find_upload non vide (check OK) et BEHAVIOR_RESUME
+        s_behavior = UploadAction.BEHAVIOR_RESUME
+        o_mock_upload = MagicMock()
+        o_mock_upload.api_list_checks.return_value = {"failed": []}
+        o_mock_upload.is_open.return_value = False
+        o_dataset=MagicMock()
+        o_ua = UploadActionNoPrivate(o_dataset, behavior=s_behavior)
+        with patch.object(UploadAction, "find_upload", return_value = o_mock_upload) as o_mock_find_upload, \
+            patch.object(Upload, "api_create") as o_mock_api_create \
+        :
+            o_ua.create_upload(datastore=s_datastore)
+            o_mock_find_upload.assert_called_once_with(s_datastore)
+            o_mock_upload.is_open.assert_called_once_with()
+            o_mock_upload.api_list_checks.assert_called_once_with()
+            o_mock_upload.api_open.assert_not_called()
+            o_mock_api_create.assert_not_called()
+            self.assertEqual(o_ua.upload, o_mock_upload)
+        # find_upload non vide (check ERR) et BEHAVIOR_RESUME
+        s_behavior = UploadAction.BEHAVIOR_RESUME
+        o_mock_upload = MagicMock()
+        o_mock_upload.is_open.return_value = False
+        o_mock_upload.api_list_checks.return_value = {"failed": ['']}
+        o_dataset=MagicMock()
+        o_ua = UploadActionNoPrivate(o_dataset, behavior=s_behavior)
+        with patch.object(UploadAction, "find_upload", return_value = o_mock_upload) as o_mock_find_upload, \
+            patch.object(Upload, "api_create") as o_mock_api_create \
+        :
+            o_ua.create_upload(datastore=s_datastore)
+            o_mock_find_upload.assert_called_once_with(s_datastore)
+            o_mock_upload.is_open.assert_called_once_with()
+            o_mock_upload.api_list_checks.assert_called_once_with()
+            o_mock_upload.api_open.assert_called_once_with()
+            o_mock_api_create.assert_not_called()
+            self.assertEqual(o_ua.upload, o_mock_upload)
+
         # BEHAVIOR non valide
         s_behavior = "toto"
         o_mock_upload = MagicMock()
@@ -398,7 +433,7 @@ class UploadActionTestCase(GpfTestCase):
             patch.object(Upload, "api_create") as o_mock_api_create:
             with self.assertRaises(GpfSdkError) as e_err:
                 o_ua.create_upload(datastore=s_datastore)
-            self.assertEqual(f"Le comportement {s_behavior} n'est pas reconnu (STOP|CONTINUE|DELETE), l'exécution de traitement est annulée.", e_err.exception.message)
+            self.assertEqual(f"Le comportement {s_behavior} n'est pas reconnu (STOP|CONTINUE|DELETE|RESUME), l'exécution de traitement est annulée.", e_err.exception.message)
             o_mock_find_upload.assert_called_once_with(s_datastore)
             o_mock_api_create.assert_not_called()
             o_mock_upload.is_open.assert_not_called()


### PR DESCRIPTION
Développement pour #196

## [Added]

* Upload : ajout du BEHAVIOR_RESUME pour la reprise des livraisons si les vérifications on échouer (ouverture et comportement comme BEHAVIOR_CONTINUE) #196