### PR TITLE
CI : vérif version tag/module au moment de la publication

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -14,8 +14,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.8
-    - name: "check version same as tag (${{ github.ref_name }})"
-      run : grep -q $(echo ${{ github.ref_name }} | sed 's/t//') sdk_entrepot_gpf/__init__.py
     - name: Install dependencies
       run: |
         pip install --upgrade pip setuptools flit
@@ -41,6 +39,8 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.8
+    - name: "check version same as tag (${{ github.ref_name }})"
+      run : grep -q $(echo ${{ github.ref_name }} | sed 's/t//') sdk_entrepot_gpf/__init__.py
     - name: Install dependencies
       run: pip install --upgrade pip setuptools flit
     - name: Build and publish

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -14,8 +14,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.8
-    - name: "check version same as tag (${{ github.ref_name }})"
-      run : grep -q $(echo ${{ github.ref_name }} | sed 's/v//') sdk_entrepot_gpf/__init__.py
     - name: Install dependencies
       run: |
         pip install --upgrade pip setuptools flit
@@ -41,6 +39,8 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.8
+    - name: "check version same as tag (${{ github.ref_name }})"
+      run : grep -q $(echo ${{ github.ref_name }} | sed 's/v//') sdk_entrepot_gpf/__init__.py
     - name: Install dependencies
       run: pip install --upgrade pip setuptools flit
     - name: Build and publish

--- a/sdk_entrepot_gpf/__init__.py
+++ b/sdk_entrepot_gpf/__init__.py
@@ -1,3 +1,3 @@
 """Python API to simplify the use of the GPF Warehouse HTTPS API."""
 
-__version__ = "0.1.32"
+__version__ = "0.1.33"


### PR DESCRIPTION
Je décale la vérification de la publication au moment de la publication, car sinon c'était lancé au moment de la validation des PR que dev/prod et non à l'ajout du tag et donc le tag n'était pas bon.

J'ai aussi défini la v0.1.33 j'avais oublié.