### PR TITLE
edit-entity: suppression de la limitation sur les used_data. Close #269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### [Changed]
 
+* Workflow : edit-entity des configurations suppression la limitation sur les used_data #269
+
 ### [Fixed]
 
 ## v0.1.42

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -439,7 +439,7 @@ Il suffit d'indiquer dans le `body_parameters` les valeurs qui sont modifiées, 
 
 !!! note "Notes"
     * Si la configuration est liée à des offres en cours de publication, la modification n'est pas possible. Si la configuration est liée à des offres publiées, les modifications sont répercutées sur les serveurs de diffusion. Le nom technique et le type ne sont pas modifiables.
-    * Cas particulier de la modification des used_data (`[type_infos][used_data]`) : la liste doit être de la même longueur que celle de la configuration et chaque dictionnaire sera fusionné avec l'ancien (cf. [#83](https://github.com/Geoplateforme/sdk-entrepot/issues/83) et [#66](https://github.com/Geoplateforme/sdk-entrepot/issues/66)). Pour supprimer/ajouter une used_data cf. action suivante [Mise à jour des used_data d'une configuration](#mettre-a-jour-les-used_data-et-la-bbox-dune-configuration).
+    * depuis v0.1.43 : Suppression de la particulier de la modification des used_data (`[type_infos][used_data]`). La liste donnée par l'utilisateur est utilisée tel quel.
 
 * offering *(partielle)*: PATCH [/datastores/{datastore}/offerings/{offering}](https://data.geopf.fr/api/swagger-ui/index.html#/Configurations%20et%20publications/update_4)
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -349,7 +349,7 @@ Pour avoir une description exhaustive du `body_parameters`, voir POST [/users//m
 
 Possibilité de supprimer des entités de type : `upload`, `stored_data`, `configuration`, `offering`, `key` et `permission`.
 
-* suppression par ID de l'entité :
+* sion par ID de l'entité :
 
 ```json
 {
@@ -358,11 +358,11 @@ Possibilité de supprimer des entités de type : `upload`, `stored_data`, `confi
     "entity_type": "configuration",
     // Id de l'entité à supprimer
     "entity_id": "{uuid}",
-    // Suppression en cascade autorisée ou pas ? par défaut à false
+    // sion en cascade autorisée ou pas ? par défaut à false
     "cascade": true,
     // Ok si non trouvée ? par défaut à true
     "not_found_ok": true,
-    // message de confirmation avant la suppression ? par défaut à true
+    // message de confirmation avant la sion ? par défaut à true
     "confirm": true
 }
 ```
@@ -370,7 +370,7 @@ Possibilité de supprimer des entités de type : `upload`, `stored_data`, `confi
 ???+ warning "Attention !!!"
     Ici la valeur **`{uuid}` doit être une uuid en dur et non une uuid récupérée par le résolveur `store_entity`** (StoreEntityResolver) pour que l'option `"not_found_ok": true,`(valeur par défaut) fonctionne.
 
-    **S'il y a besoin d'utiliser le résolveur `store_entity` il faut utiliser la "suppression par filtre sur la liste" présentée ci-dessous**.
+    **S'il y a besoin d'utiliser le résolveur `store_entity` il faut utiliser la "sion par filtre sur la liste" présentée ci-dessous**.
 
     Avec l'utilisation du résolveur `store_entity`, les résolveurs gardant en mémoire, les valeurs déjà trouvées la réutilisation du résolveur avec les mêmes filtres pointera vers l'entité supprimée.
 
@@ -439,7 +439,7 @@ Il suffit d'indiquer dans le `body_parameters` les valeurs qui sont modifiées, 
 
 !!! note "Notes"
     * Si la configuration est liée à des offres en cours de publication, la modification n'est pas possible. Si la configuration est liée à des offres publiées, les modifications sont répercutées sur les serveurs de diffusion. Le nom technique et le type ne sont pas modifiables.
-    * depuis v0.1.43 : Suppression de la particulier de la modification des used_data (`[type_infos][used_data]`). La liste donnée par l'utilisateur est utilisée tel quel.
+    * depuis v0.1.43 : Suppression de la possibilité de modification des used_data (`[type_infos][used_data]`). La liste donnée par l'utilisateur est utilisée tel quel.
 
 * offering *(partielle)*: PATCH [/datastores/{datastore}/offerings/{offering}](https://data.geopf.fr/api/swagger-ui/index.html#/Configurations%20et%20publications/update_4)
 

--- a/sdk_entrepot_gpf/store/Configuration.py
+++ b/sdk_entrepot_gpf/store/Configuration.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List
-from sdk_entrepot_gpf.store.Errors import StoreEntityError
 
 from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
@@ -73,14 +72,6 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
 
         # fusion de type_infos et de type_infos.used_data
         if "type_infos" in data_edit:  # il peut ne pas y avoir de "type_infos" dans data_edit
-            if "used_data" in data_edit["type_infos"]:  # il peut ne pas y avoir de "used_data" dans data_edit["type_infos"]
-                l_used_data = []
-                if len(d_origine_data["type_infos"]["used_data"]) != len(data_edit["type_infos"]["used_data"]):
-                    s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
-                    raise StoreEntityError(s_message)
-                for i in range(len(d_origine_data["type_infos"]["used_data"])):
-                    l_used_data.append({**d_origine_data["type_infos"]["used_data"][i], **data_edit["type_infos"]["used_data"][i]})
-                data_edit["type_infos"]["used_data"] = l_used_data
             data_edit["type_infos"] = {**d_origine_data["type_infos"], **data_edit["type_infos"]}
 
         # le reste est géré par la classe parente

--- a/tests/store/ConfigurationTestCase.py
+++ b/tests/store/ConfigurationTestCase.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
-from sdk_entrepot_gpf.store.Errors import StoreEntityError
 from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.Configuration import Configuration
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
@@ -112,19 +111,12 @@ class ConfigurationTestCase(GpfTestCase):
         d_fusion: Dict[str, Any] = {
             **d_entity,
             **d_edit,
-            **{"type_infos": {"kept_key": "kept_value", "new_key": "n k", "other_key": "value_2", "used_data": [{"nom": "val_new"}, {"nom": "or-2"}, {"nom": "or-3", "new": "val"}]}},
+            **{"type_infos": {**d_entity["type_infos"], **d_edit["type_infos"]}},
         }
         o_entity = Configuration(d_entity)
         with patch.object(Configuration, "api_full_edit", return_value=None) as o_mock_api_edit:
             o_entity.edit(d_edit)
             o_mock_api_edit.assert_called_once_with(d_fusion)
-
-        # le nombre de used_data ne correspond pas
-        d_edit = {"_id": "1", "comm_key": "edit", "type_infos": {"used_data": [{"nom": "val_new"}]}}
-        with self.assertRaises(StoreEntityError) as o_raise:
-            o_entity.edit(d_edit)
-        s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
-        self.assertEqual(s_message, o_raise.exception.message)
 
         # Ok si pas de type_infos (dans d_edit)
         o_entity = Configuration(d_entity)


### PR DESCRIPTION
Développement pour #269

## [Changed]

* Workflow : edit-entity des configurations suppression la limitation sur les used_data #269