### PR TITLE
Dataset:  debug pour les dossiers non relatif au fichier descripteur. close #260

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### [Fixed]
 
+* Dataset : debug pour les dossiers non relatif au fichier descripteur [#260](https://github.com/Geoplateforme/sdk-entrepot/issues/260)
+
 ## v0.1.42
 
 ### [Added]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### [Fixed]
 
-* Dataset : debug pour les dossiers non relatif au fichier descripteur [#260](https://github.com/Geoplateforme/sdk-entrepot/issues/260)
+* Dataset : debug pour les dossiers non relatifs au fichier descripteur [#260](https://github.com/Geoplateforme/sdk-entrepot/issues/260)
 
 ## v0.1.42
 

--- a/sdk_entrepot_gpf/io/Dataset.py
+++ b/sdk_entrepot_gpf/io/Dataset.py
@@ -125,6 +125,9 @@ class Dataset:
             # L'élément est un fichier
             elif p_elt.is_file():
                 # Création du chemin relatif pour l'API
-                p_api = p_rep_elt.relative_to(self.__root_dir)
+                try:
+                    p_api = p_rep_elt.relative_to(self.__root_dir)
+                except ValueError:
+                    p_api = p_rep_elt
                 # Remplissage du dictionnaire __data_files
                 self.__data_files[p_rep_elt] = p_api.parent.as_posix()


### PR DESCRIPTION
Développement pour # 260

## [Fixed]

* Dataset : debug pour les dossiers non relatif au fichier descripteur [#260](https://github.com/Geoplateforme/sdk-entrepot/issues/260)