### PR TITLE
gestion des doublons lors de la mise à jour des used_data. Close #270

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### [Changed]
 
-* Workflow : edit-entity des configurations suppression la limitation sur les used_data #269
+* Workflow : edit-entity des configurations suppression la limitation sur les used_data + amélioration du message [#269](https://github.com/Geoplateforme/sdk-entrepot/issues/269)
+* EditUsedDataConfigurationAction: ajout de la clef "resolve_conflict" permettant de gérer les possibles doublons lors de l'ajout d'une used_data [#270](https://github.com/Geoplateforme/sdk-entrepot/issues/270)
 
 ### [Fixed]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### [Changed]
 
-* Workflow : edit-entity des configurations suppression la limitation sur les used_data + amélioration du message [#269](https://github.com/Geoplateforme/sdk-entrepot/issues/269)
+* Workflow : edit-entity des configurations + suppression de la limitation sur les used_data + amélioration du message [#269](https://github.com/Geoplateforme/sdk-entrepot/issues/269)
 * EditUsedDataConfigurationAction: ajout de la clef "resolve_conflict" permettant de gérer les possibles doublons lors de l'ajout d'une used_data [#270](https://github.com/Geoplateforme/sdk-entrepot/issues/270)
 
 ### [Fixed]

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -470,6 +470,9 @@ L'action d'édition d'une configuration ne permet pas de supprimer ni ajouter un
   "delete_used_data": [{"stored_data": "id_store_data"}, {"zone": "ZONE"}],
   // Optionnel : liste des used_data à ajouter, selon le format demandé par l'API Entrepôt
   "append_used_data": [{...}],
+  // Optionnel : si les used_data qui ajouté avec "append_used_data" dont d'abord supprimer de la configuration en filtrant sur la clef "stored_data"
+  // permettant éviter les erreurs lié aux doublons. Par défaut à false.
+  "resolve_conflict": false
   // Optionnel : si on veut mettre à jour la BBox avec les données utilisées (bbox calculée après la modification des used_data). Par défaut à false.
   "reset_bbox": true
 }

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -470,8 +470,8 @@ L'action d'édition d'une configuration ne permet pas de supprimer ni ajouter un
   "delete_used_data": [{"stored_data": "id_store_data"}, {"zone": "ZONE"}],
   // Optionnel : liste des used_data à ajouter, selon le format demandé par l'API Entrepôt
   "append_used_data": [{...}],
-  // Optionnel : Si true, les used_data à ajouté avec "append_used_data" sont d'abord supprimer de la configuration d'origine en filtrant sur la clef "stored_data".
-  // permettant éviter les erreurs lié aux doublons. Par défaut à false.
+  // Optionnel : Si true, les used_data à ajouter avec "append_used_data" sont d'abord supprimées de la configuration d'origine (en filtrant sur la clef "stored_data").
+  // Permet d'éviter les erreurs liées aux doublons. Par défaut à false.
   "resolve_conflict": false
   // Optionnel : si on veut mettre à jour la BBox avec les données utilisées (bbox calculée après la modification des used_data). Par défaut à false.
   "reset_bbox": true

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -470,7 +470,7 @@ L'action d'édition d'une configuration ne permet pas de supprimer ni ajouter un
   "delete_used_data": [{"stored_data": "id_store_data"}, {"zone": "ZONE"}],
   // Optionnel : liste des used_data à ajouter, selon le format demandé par l'API Entrepôt
   "append_used_data": [{...}],
-  // Optionnel : si les used_data qui ajouté avec "append_used_data" dont d'abord supprimer de la configuration en filtrant sur la clef "stored_data"
+  // Optionnel : Si true, les used_data à ajouté avec "append_used_data" sont d'abord supprimer de la configuration d'origine en filtrant sur la clef "stored_data".
   // permettant éviter les erreurs lié aux doublons. Par défaut à false.
   "resolve_conflict": false
   // Optionnel : si on veut mettre à jour la BBox avec les données utilisées (bbox calculée après la modification des used_data). Par défaut à false.

--- a/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
+++ b/sdk_entrepot_gpf/_conf/json_schemas/workflow.json
@@ -115,6 +115,9 @@
                                                 "type": "object"
                                             }
                                         },
+                                        "resolve_conflict": {
+                                            "type": "boolean"
+                                        },
                                         "reset_bbox": {
                                             "type": "boolean"
                                         }

--- a/sdk_entrepot_gpf/workflow/action/EditUsedDataConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/EditUsedDataConfigurationAction.py
@@ -29,7 +29,7 @@ class EditUsedDataConfigurationAction(ActionAbstract):
 
         l_data_delete = self.definition_dict.get("delete_used_data", [])
         if self.definition_dict.get("resolve_conflict", False):
-            # ajoute les used_data ajouté à la liste des suppression pour évité les doublons
+            # ajoute les used_data ajouté à la liste des suppression pour éviter les doublons
             l_data_delete += [{"stored_data": d_data["stored_data"]} for d_data in self.definition_dict.get("append_used_data", [])]
         # suppression des used_data
         for d_data_delete in l_data_delete:
@@ -56,7 +56,7 @@ class EditUsedDataConfigurationAction(ActionAbstract):
                 l_stored_data = [d_data["stored_data"] for d_data in l_new_use_data]
                 l_doublons = [f"{StoredData.api_get(elem)} ({count})" for elem, count in Counter(l_stored_data).items() if count > 1]
                 s_message = (
-                    "Il y a un doublon dans les used_data. Veuillez vérifier les append_used_data. L'option 'resolve_conflict' permet de résoudre les conflits en supprimant les doublons. \n * "
+                    "Il y a au moins un doublon dans les used_data. Veuillez vérifier les append_used_data. L'option 'resolve_conflict = True' permet de résoudre les conflits en supprimant les doublons. \n * "
                     + "\n * ".join(l_doublons)
                 )
                 raise GpfSdkError(s_message) from e

--- a/sdk_entrepot_gpf/workflow/action/EditUsedDataConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/EditUsedDataConfigurationAction.py
@@ -1,4 +1,8 @@
 from typing import Any, Dict, List, Optional
+from collections import Counter
+
+from sdk_entrepot_gpf.Errors import GpfSdkError
+from sdk_entrepot_gpf.store.StoredData import StoredData
 from sdk_entrepot_gpf.store.Configuration import Configuration
 from sdk_entrepot_gpf.io.Config import Config
 from sdk_entrepot_gpf.workflow.action.ActionAbstract import ActionAbstract
@@ -22,8 +26,13 @@ class EditUsedDataConfigurationAction(ActionAbstract):
         # stockage de l'ancien body_parameters
         d_parameter = {**o_base_config.get_store_properties()}
         l_new_use_data = d_parameter["type_infos"]["used_data"]
+
+        l_data_delete = self.definition_dict.get("delete_used_data", [])
+        if self.definition_dict.get("resolve_conflict", False):
+            # ajoute les used_data ajouté à la liste des suppression pour évité les doublons
+            l_data_delete += [{"stored_data": d_data["stored_data"]} for d_data in self.definition_dict.get("append_used_data", [])]
         # suppression des used_data
-        for d_data_delete in self.definition_dict.get("delete_used_data", []):
+        for d_data_delete in l_data_delete:
             l_new_use_data = self._delete_used_data(d_data_delete, l_new_use_data)
 
         # ajout des used_data
@@ -40,7 +49,19 @@ class EditUsedDataConfigurationAction(ActionAbstract):
         # lancement de la modification
         Config().om.info(f"Modification de la configuration {o_base_config} ...", force_flush=True)
 
-        o_base_config.api_full_edit(d_parameter)
+        try:
+            o_base_config.api_full_edit(d_parameter)
+        except GpfSdkError as e:
+            if e.message == "La requête formulée par le programme est incorrecte (Une donnée stockée est référencée plusieurs fois). Contactez le support.":
+                l_stored_data = [d_data["stored_data"] for d_data in l_new_use_data]
+                l_doublons = [f"{StoredData.api_get(elem)} ({count})" for elem, count in Counter(l_stored_data).items() if count > 1]
+                s_message = (
+                    "Il y a un doublon dans les used_data. Veuillez vérifier les append_used_data. L'option 'resolve_conflict' permet de résoudre les conflits en supprimant les doublons. \n * "
+                    + "\n * ".join(l_doublons)
+                )
+                raise GpfSdkError(s_message) from e
+            raise e
+
         Config().om.info("Modification de la configuration : terminé")
 
     def _delete_used_data(self, d_data_delete: Dict[str, str], l_used_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/sdk_entrepot_gpf/workflow/action/EditUsedDataConfigurationAction.py
+++ b/sdk_entrepot_gpf/workflow/action/EditUsedDataConfigurationAction.py
@@ -56,7 +56,8 @@ class EditUsedDataConfigurationAction(ActionAbstract):
                 l_stored_data = [d_data["stored_data"] for d_data in l_new_use_data]
                 l_doublons = [f"{StoredData.api_get(elem)} ({count})" for elem, count in Counter(l_stored_data).items() if count > 1]
                 s_message = (
-                    "Il y a au moins un doublon dans les used_data. Veuillez vérifier les append_used_data. L'option 'resolve_conflict = True' permet de résoudre les conflits en supprimant les doublons. \n * "
+                    "Il y a au moins un doublon dans les used_data. Veuillez vérifier les append_used_data. L'option 'resolve_conflict = True'"
+                    + " permet de résoudre les conflits en supprimant les doublons. \n * "
                     + "\n * ".join(l_doublons)
                 )
                 raise GpfSdkError(s_message) from e

--- a/tests/workflow/action/EditUsedDataConfigurationActionTestCase.py
+++ b/tests/workflow/action/EditUsedDataConfigurationActionTestCase.py
@@ -1,7 +1,9 @@
 from typing import Any, Dict
 from unittest.mock import patch, MagicMock
 
+from sdk_entrepot_gpf.Errors import GpfSdkError
 from sdk_entrepot_gpf.store.Configuration import Configuration
+from sdk_entrepot_gpf.store.StoredData import StoredData
 from sdk_entrepot_gpf.workflow.action.EditUsedDataConfigurationAction import EditUsedDataConfigurationAction
 
 from tests.GpfTestCase import GpfTestCase
@@ -13,9 +15,7 @@ class EditUsedDataConfigurationActionTestCase(GpfTestCase):
     cmd : python3 -m unittest -b tests.workflow.action.EditUsedDataConfigurationActionTestCase
     """
 
-    i = 0
-
-    def run_run(self, s_uuid: str, d_definition: Dict[str, Any], d_base_config: Dict[str, Any], d_new_config: Dict[str, Any]) -> None:
+    def run_run(self, s_uuid: str, d_definition: Dict[str, Any], d_base_config: Dict[str, Any], d_new_config: Dict[str, Any], s_nom: str) -> None:
         """lancement des tests de EditUsedDataConfigurationAction.run
 
         Args:
@@ -24,8 +24,7 @@ class EditUsedDataConfigurationActionTestCase(GpfTestCase):
             d_base_config (Dict[str, Any]): dictionnaire de la configuration à modifiée
             d_new_config (Dict[str, Any]): dictionnaire de la configuration après modification qui sera envoyé à la GPF
         """
-        self.i += 1
-        with self.subTest(i=self.i):
+        with self.subTest(i=s_nom):
             o_action = EditUsedDataConfigurationAction("contexte", d_definition, None)
             o_mock_base_config = MagicMock()
             o_mock_base_config.get_store_properties.return_value = d_base_config
@@ -39,21 +38,21 @@ class EditUsedDataConfigurationActionTestCase(GpfTestCase):
     def test_run(self) -> None:
         """test de run"""
         s_uuid = "123"
-
+        d_add_data = {"data": "data", "stored_data": "stored_data"}
         # ajout + suppression (pas de reset de la BBox)
         d_definition: Dict[str, Any] = {
             "type": "used_data-configuration",
             "entity_id": s_uuid,
-            "append_used_data": [{"data": "data"}],
+            "append_used_data": [d_add_data],
             "delete_used_data": [{"param1": "val1"}, {"param2": "val2"}, {"param1": "val3", "param2": "val3"}],
         }
         l_used_data = [
-            {"param1": "val1", "autre": "val"},
-            {"param2": "val2", "autre": "val"},
-            {"param1": "val3", "param2": "val3", "autre": "val"},
-            {"param1": "val4", "param2": "val3", "autre": "val"},
-            {"param1": "val3", "param2": "val4", "autre": "val"},
-            {"param1": "val4", "param2": "val4", "autre": "val"},
+            {"param1": "val1", "autre": "val", "stored_data": "stored_data1"},
+            {"param2": "val2", "autre": "val", "stored_data": "stored_data2"},
+            {"param1": "val3", "param2": "val3", "autre": "val", "stored_data": "stored_data3"},
+            {"param1": "val4", "param2": "val3", "autre": "val", "stored_data": "stored_data4"},
+            {"param1": "val3", "param2": "val4", "autre": "val", "stored_data": "stored_data5"},
+            {"param1": "val4", "param2": "val4", "autre": "val", "stored_data": "stored_data6"},
         ]
         d_base_config = {
             "name": "nouveau name",
@@ -66,35 +65,82 @@ class EditUsedDataConfigurationActionTestCase(GpfTestCase):
             "name": "nouveau name",
             "type_infos": {
                 "used_data": [
-                    {"param1": "val4", "param2": "val3", "autre": "val"},
-                    {"param1": "val3", "param2": "val4", "autre": "val"},
-                    {"param1": "val4", "param2": "val4", "autre": "val"},
-                    {"data": "data"},
+                    {"param1": "val4", "param2": "val3", "autre": "val", "stored_data": "stored_data4"},
+                    {"param1": "val3", "param2": "val4", "autre": "val", "stored_data": "stored_data5"},
+                    {"param1": "val4", "param2": "val4", "autre": "val", "stored_data": "stored_data6"},
+                    d_add_data,
                 ],
                 "bbox": {},
             },
         }
 
         # ajout + suppression (pas de reset de la BBox)
-        self.run_run(s_uuid, d_definition, d_base_config, d_new_config)
+        self.run_run(s_uuid, d_definition, d_base_config, d_new_config, "ajout + suppression (pas de reset de la BBox)")
 
         # maj de BBox + modif stored_data
         d_base_config["type_infos"] = {"used_data": [*l_used_data], "bbox": {}}
-        self.run_run(s_uuid, d_definition, d_base_config, d_new_config)
+        self.run_run(s_uuid, d_definition, d_base_config, d_new_config, "maj de BBox + modif stored_data")
 
         # maj de bbox demandé mais pas de bbox dans la config
         d_definition["reset_bbox"] = True
         del d_new_config["type_infos"]["bbox"]
         d_base_config["type_infos"] = {"used_data": [*l_used_data]}
-        self.run_run(s_uuid, d_definition, d_base_config, d_new_config)
+        self.run_run(s_uuid, d_definition, d_base_config, d_new_config, "maj de bbox demandé mais pas de bbox dans la config")
 
         # pas de modif stored_data
         d_base_config["type_infos"] = {"used_data": [*l_used_data], "bbox": {}}
         d_definition_2: Dict[str, Any] = {"type": "used_data-configuration", "entity_id": s_uuid}
-        self.run_run(s_uuid, d_definition_2, d_base_config, d_base_config)
+        self.run_run(s_uuid, d_definition_2, d_base_config, d_base_config, "pas de modif stored_data")
 
         # maj de BBox + pas modif stored_data
         d_definition_2["reset_bbox"] = True
         d_base_config["type_infos"] = {"used_data": [*l_used_data], "bbox": {}}
         d_new_config_2 = {"name": "nouveau name", "type_infos": {"used_data": [*l_used_data]}}
-        self.run_run(s_uuid, d_definition_2, d_base_config, d_new_config_2)
+        self.run_run(s_uuid, d_definition_2, d_base_config, d_new_config_2, "maj de BBox + pas modif stored_data")
+
+        # ajoute de used data avec suppression de doublon
+        d_definition = {
+            "type": "used_data-configuration",
+            "entity_id": s_uuid,
+            "append_used_data": [d_add_data],
+            "resolve_conflict": True,
+        }
+        d_base_config["type_infos"] = {"used_data": [*l_used_data, d_add_data], "bbox": {}}
+        d_new_config_2 = {"name": "nouveau name", "type_infos": {"used_data": [*l_used_data, *d_definition["append_used_data"]], "bbox": {}}}
+        self.run_run(s_uuid, d_definition, d_base_config, d_new_config_2, "ajoute de used data avec suppression de doublon")
+
+        # ajoute de used data sans suppression de doublon => erreur
+        d_definition["resolve_conflict"] = False
+        with self.subTest(i="ajoute de used data sans suppression de doublon"):
+            o_action = EditUsedDataConfigurationAction("contexte", d_definition, None)
+            o_mock_base_config = MagicMock()
+            o_mock_base_config.get_store_properties.return_value = d_base_config
+            s_message = "La requête formulée par le programme est incorrecte (Une donnée stockée est référencée plusieurs fois). Contactez le support."
+            o_mock_base_config.api_full_edit.side_effect = GpfSdkError(s_message)
+
+            #  api_get raise une erreur GpfSdkError
+            with patch.object(Configuration, "api_get", return_value=o_mock_base_config):
+                with patch.object(StoredData, "api_get", return_value="stored_data"):
+                    with self.assertRaises(GpfSdkError) as o_raise:
+                        o_action.run("datastore")
+            l_doublons = ["stored_data (2)"]
+            s_new_message = s_message = (
+                "Il y a un doublon dans les used_data. Veuillez vérifier les append_used_data. L'option 'resolve_conflict' permet de résoudre les conflits en supprimant les doublons. \n * "
+                + "\n * ".join(l_doublons)
+            )
+            self.assertEqual(o_raise.exception.message, s_new_message)
+
+        # autre erreur (hors doublon)
+        with self.subTest(i="autre erreur (hors doublon)"):
+            o_action = EditUsedDataConfigurationAction("contexte", d_definition, None)
+            o_mock_base_config = MagicMock()
+            o_mock_base_config.get_store_properties.return_value = d_base_config
+            s_message = "autre problème"
+            o_mock_base_config.api_full_edit.side_effect = GpfSdkError(s_message)
+
+            #  api_get raise une erreur GpfSdkError
+            with patch.object(Configuration, "api_get", return_value=o_mock_base_config):
+                with self.assertRaises(GpfSdkError) as o_raise:
+                    o_action.run("datastore")
+            l_doublons = ["stored_data (2)"]
+            self.assertEqual(o_raise.exception.message, s_message)

--- a/tests/workflow/action/EditUsedDataConfigurationActionTestCase.py
+++ b/tests/workflow/action/EditUsedDataConfigurationActionTestCase.py
@@ -81,11 +81,11 @@ class EditUsedDataConfigurationActionTestCase(GpfTestCase):
         d_base_config["type_infos"] = {"used_data": [*l_used_data], "bbox": {}}
         self.run_run(s_uuid, d_definition, d_base_config, d_new_config, "maj de BBox + modif stored_data")
 
-        # maj de bbox demandé mais pas de bbox dans la config
+        # maj de bbox demandée mais pas de bbox dans la config
         d_definition["reset_bbox"] = True
         del d_new_config["type_infos"]["bbox"]
         d_base_config["type_infos"] = {"used_data": [*l_used_data]}
-        self.run_run(s_uuid, d_definition, d_base_config, d_new_config, "maj de bbox demandé mais pas de bbox dans la config")
+        self.run_run(s_uuid, d_definition, d_base_config, d_new_config, "maj de bbox demandée mais pas de bbox dans la config")
 
         # pas de modif stored_data
         d_base_config["type_infos"] = {"used_data": [*l_used_data], "bbox": {}}
@@ -98,7 +98,7 @@ class EditUsedDataConfigurationActionTestCase(GpfTestCase):
         d_new_config_2 = {"name": "nouveau name", "type_infos": {"used_data": [*l_used_data]}}
         self.run_run(s_uuid, d_definition_2, d_base_config, d_new_config_2, "maj de BBox + pas modif stored_data")
 
-        # ajoute de used data avec suppression de doublon
+        # ajout de used data avec suppression de doublon
         d_definition = {
             "type": "used_data-configuration",
             "entity_id": s_uuid,
@@ -107,11 +107,11 @@ class EditUsedDataConfigurationActionTestCase(GpfTestCase):
         }
         d_base_config["type_infos"] = {"used_data": [*l_used_data, d_add_data], "bbox": {}}
         d_new_config_2 = {"name": "nouveau name", "type_infos": {"used_data": [*l_used_data, *d_definition["append_used_data"]], "bbox": {}}}
-        self.run_run(s_uuid, d_definition, d_base_config, d_new_config_2, "ajoute de used data avec suppression de doublon")
+        self.run_run(s_uuid, d_definition, d_base_config, d_new_config_2, "ajout de used data avec suppression de doublon")
 
-        # ajoute de used data sans suppression de doublon => erreur
+        # ajout de used data sans suppression de doublon => erreur
         d_definition["resolve_conflict"] = False
-        with self.subTest(i="ajoute de used data sans suppression de doublon"):
+        with self.subTest(i="ajout de used data sans suppression de doublon"):
             o_action = EditUsedDataConfigurationAction("contexte", d_definition, None)
             o_mock_base_config = MagicMock()
             o_mock_base_config.get_store_properties.return_value = d_base_config

--- a/tests/workflow/action/EditUsedDataConfigurationActionTestCase.py
+++ b/tests/workflow/action/EditUsedDataConfigurationActionTestCase.py
@@ -125,7 +125,8 @@ class EditUsedDataConfigurationActionTestCase(GpfTestCase):
                         o_action.run("datastore")
             l_doublons = ["stored_data (2)"]
             s_new_message = s_message = (
-                "Il y a un doublon dans les used_data. Veuillez vérifier les append_used_data. L'option 'resolve_conflict' permet de résoudre les conflits en supprimant les doublons. \n * "
+                "Il y a au moins un doublon dans les used_data. Veuillez vérifier les append_used_data. L'option 'resolve_conflict = True'"
+                + " permet de résoudre les conflits en supprimant les doublons. \n * "
                 + "\n * ".join(l_doublons)
             )
             self.assertEqual(o_raise.exception.message, s_new_message)


### PR DESCRIPTION
Développement pour #270 

## [Changed]

* EditUsedDataConfigurationAction: ajout de la clef "resolve_conflict" permettant de gérer les possibles doublons lors de l'ajout d'une used_data [#270](https://github.com/Geoplateforme/sdk-entrepot/issues/270)