### PR TITLE
Configuration.edit: Revert modification used_data + exception. Close #269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### [Changed]
 
+* Configuration.edit: Revert de la modification de suppression de la limitation sur les used_data pour un simple exception en cas de paramètre non donné ou vide [#269](https://github.com/Geoplateforme/sdk-entrepot/issues/269)
+
 ### [Fixed]
 
 ## v0.1.43

--- a/sdk_entrepot_gpf/store/Configuration.py
+++ b/sdk_entrepot_gpf/store/Configuration.py
@@ -78,7 +78,10 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
                 if not data_edit["type_infos"]["used_data"]:  # si la liste est vide, on ne modifie pas les used_data
                     data_edit["type_infos"]["used_data"] = d_origine_data["type_infos"]["used_data"]
                 elif len(d_origine_data["type_infos"]["used_data"]) != len(data_edit["type_infos"]["used_data"]):
-                    s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
+                    s_message = (
+                        "Edition impossible, le nombre de 'used_data' ne correspond pas. "
+                        + f"({len(d_origine_data['type_infos']['used_data'])} attendu, {len(data_edit['type_infos']['used_data'])} fourni)"
+                    )
                     raise StoreEntityError(s_message)
                 else:
                     for i in range(len(d_origine_data["type_infos"]["used_data"])):

--- a/sdk_entrepot_gpf/store/Configuration.py
+++ b/sdk_entrepot_gpf/store/Configuration.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List
 
+from sdk_entrepot_gpf.store.Errors import StoreEntityError
 from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
 from sdk_entrepot_gpf.store.interface.TagInterface import TagInterface
@@ -72,6 +73,17 @@ class Configuration(TagInterface, CommentInterface, EventInterface, FullEditInte
 
         # fusion de type_infos et de type_infos.used_data
         if "type_infos" in data_edit:  # il peut ne pas y avoir de "type_infos" dans data_edit
+            if "used_data" in data_edit["type_infos"]:  # il peut ne pas y avoir de "used_data" dans data_edit["type_infos"]
+                l_used_data = []
+                if not data_edit["type_infos"]["used_data"]:  # si la liste est vide, on ne modifie pas les used_data
+                    data_edit["type_infos"]["used_data"] = d_origine_data["type_infos"]["used_data"]
+                elif len(d_origine_data["type_infos"]["used_data"]) != len(data_edit["type_infos"]["used_data"]):
+                    s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
+                    raise StoreEntityError(s_message)
+                else:
+                    for i in range(len(d_origine_data["type_infos"]["used_data"])):
+                        l_used_data.append({**d_origine_data["type_infos"]["used_data"][i], **data_edit["type_infos"]["used_data"][i]})
+                    data_edit["type_infos"]["used_data"] = l_used_data
             data_edit["type_infos"] = {**d_origine_data["type_infos"], **data_edit["type_infos"]}
 
         # le reste est géré par la classe parente

--- a/tests/store/ConfigurationTestCase.py
+++ b/tests/store/ConfigurationTestCase.py
@@ -123,7 +123,7 @@ class ConfigurationTestCase(GpfTestCase):
         d_edit = {"_id": "1", "comm_key": "edit", "type_infos": {"used_data": [{"nom": "val_new"}]}}
         with self.assertRaises(StoreEntityError) as o_raise:
             o_entity.edit(d_edit)
-        s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
+        s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas. (3 attendu, 1 fourni)"
         self.assertEqual(s_message, o_raise.exception.message)
 
         # Ok si pas de type_infos (dans d_edit)

--- a/tests/store/ConfigurationTestCase.py
+++ b/tests/store/ConfigurationTestCase.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
 from sdk_entrepot_gpf.io.ApiRequester import ApiRequester
+from sdk_entrepot_gpf.store.Errors import StoreEntityError
 from sdk_entrepot_gpf.store.Offering import Offering
 from sdk_entrepot_gpf.store.Configuration import Configuration
 from sdk_entrepot_gpf.store.StoreEntity import StoreEntity
@@ -111,12 +112,19 @@ class ConfigurationTestCase(GpfTestCase):
         d_fusion: Dict[str, Any] = {
             **d_entity,
             **d_edit,
-            **{"type_infos": {**d_entity["type_infos"], **d_edit["type_infos"]}},
+            **{"type_infos": {"kept_key": "kept_value", "new_key": "n k", "other_key": "value_2", "used_data": [{"nom": "val_new"}, {"nom": "or-2"}, {"nom": "or-3", "new": "val"}]}},
         }
         o_entity = Configuration(d_entity)
         with patch.object(Configuration, "api_full_edit", return_value=None) as o_mock_api_edit:
             o_entity.edit(d_edit)
             o_mock_api_edit.assert_called_once_with(d_fusion)
+
+        # le nombre de used_data ne correspond pas
+        d_edit = {"_id": "1", "comm_key": "edit", "type_infos": {"used_data": [{"nom": "val_new"}]}}
+        with self.assertRaises(StoreEntityError) as o_raise:
+            o_entity.edit(d_edit)
+        s_message = "Edition impossible, le nombre de 'used_data' ne correspond pas."
+        self.assertEqual(s_message, o_raise.exception.message)
 
         # Ok si pas de type_infos (dans d_edit)
         o_entity = Configuration(d_entity)
@@ -128,6 +136,13 @@ class ConfigurationTestCase(GpfTestCase):
         # Ok si pas de type_infos.used_data (dans d_edit)
         o_entity = Configuration(d_entity)
         d_edit = {"_id": "1", "comm_key": "edit", "new_key": "new_key", "type_infos": {"new_key": "new_key", "other_key": "value_2"}}
+        with patch.object(Configuration, "api_full_edit", return_value=None) as o_mock_api_edit:
+            o_entity.edit(d_edit)
+            o_mock_api_edit.assert_called_once_with({**d_entity, **d_edit})
+
+        # Ok si type_infos.used_data vide (dans d_edit)
+        o_entity = Configuration(d_entity)
+        d_edit = {"_id": "1", "comm_key": "edit", "new_key": "new_key", "type_infos": {"new_key": "new_key", "other_key": "value_2", "used_data": []}}
         with patch.object(Configuration, "api_full_edit", return_value=None) as o_mock_api_edit:
             o_entity.edit(d_edit)
             o_mock_api_edit.assert_called_once_with({**d_entity, **d_edit})


### PR DESCRIPTION
## [Changed]

* Configuration.edit: Revert de la modification de suppression de la limitation sur les used_data pour un simple exception en cas de paramètre non donné ou vide [#269](https://github.com/Geoplateforme/sdk-entrepot/issues/269)